### PR TITLE
Group B: Rules B1–B4 — registry-row mandate, no double-typed pairs, asymmetric-only, canonical object_label

### DIFF
--- a/scripts/validate_sssom_invariants.py
+++ b/scripts/validate_sssom_invariants.py
@@ -6,24 +6,69 @@ Mirrors ``kg-microbe/mappings/validate_isolation_source_mappings.py``:
 stdlib only (``csv`` + ``argparse``), per-row stderr report, exit-2 on
 violation so CI blocks the merge.
 
-Initial scope = Rule A (auto-classifier token-overlap gate). Rules B1–B4
-(structural invariants on ``MIM:<slug>`` rows) land in PR2. See plan
-``culturebotai-claw/.claude/plans/now-focus-on-culturemech-piped-shell.md``.
+Rules implemented (see ``MAPPING_SEMANTICS.md`` for the full contract):
 
-Rule A — for every row whose ``source`` column is "auto-classifier-only"
-(every pipe-separated tag is ``MIM:curator=...``), accept iff at least
-one of:
+* **Rule A** — auto-classifier token-overlap gate. For every row whose
+  ``source`` column is "auto-classifier-only" (every pipe-separated tag
+  is ``MIM:curator=...``), accept iff at least one of:
 
-  * ``confidence`` >= 0.95
-  * ``subject_label`` and ``object_label`` share at least one
-    discriminating token (lowercase, length >= 2, stop-words removed —
-    pattern reused verbatim from
-    ``culturebotai-claw/scripts/foodon_pass.py:64-105``)
-  * the subject's MIM YAML at ``data/ingredients/mapped/{slug}.yaml``
-    carries an independent CAS-RN or PubChem CID xref (registry
-    corroboration). This is read lazily — only when the previous two
-    tiers have failed — and uses a minimal regex parser to avoid a
-    PyYAML dependency in CI.
+    * ``confidence`` >= 0.95
+    * ``subject_label`` and ``object_label`` share at least one
+      discriminating token (lowercase, length >= 2, stop-words removed —
+      pattern reused verbatim from
+      ``culturebotai-claw/scripts/foodon_pass.py:64-105``)
+    * the subject's MIM YAML at ``data/ingredients/mapped/{slug}.yaml``
+      carries an independent CAS-RN or PubChem CID xref (registry
+      corroboration). Read lazily — only when the previous two tiers
+      have failed — via a minimal regex parser to avoid a PyYAML
+      dependency in CI.
+
+* **Rule B1** — mandatory registry/identity row. For every distinct
+  ``MIM:<slug>`` subject with at least one ``skos:narrowMatch`` or
+  ``skos:broadMatch`` row, require that another row exists with the
+  same subject and ``predicate_id == 'skos:exactMatch'`` and
+  ``object_id`` matching ``^kgmicrobe\\.(ingredient|compound):<slug_lc>$``
+  where ``<slug_lc>`` is the lowercased subject slug (the part after
+  ``MIM:``). Reject every offending narrow/broad row. Closes the
+  Codex-#558 round-3 hardening: without the registry row, a downstream
+  consumer that walks the SSSOM by ``subject_label`` resolves the MIM
+  child to its OBO parent (identity collapse).
+
+  **Staged rollout**: B1 ships warn-only by default (the validator
+  reports per-row stderr warnings but does not exit-2 or write
+  rejects). Pass ``--strict-b1`` to convert it into a hard gate. The
+  current SSSOM has many narrowMatch subjects whose exactMatch row
+  points at a CAS-RN / mesh / NCIT id rather than a kgmicrobe.* CURIE;
+  warn-only mode lets the validator land alongside the rest of Group
+  B while the kg-microbe registry is being minted out. Flip
+  ``--strict-b1`` (and add it to ``just qc-sssom`` / the CI workflow)
+  once every narrow/broad subject carries a kgmicrobe.* registry
+  exactMatch row.
+
+* **Rule B2** — at most one row per ``(subject_id, object_id)`` pair.
+  Group all rows by tuple; any pair with > 1 row is a violation.
+  Catches double-typed rows like ``(MIM:X exactMatch Y)`` +
+  ``(MIM:X narrowMatch Y)``. Every row in a duplicated group is
+  rejected.
+
+* **Rule B3** — asymmetric child→parent only. For every
+  ``(subject_id, object_id)`` pair appearing in any
+  ``skos:narrowMatch`` (or ``skos:broadMatch``) row, verify no
+  ``skos:exactMatch`` row exists for the same pair. Cross-row variant
+  of B2 (catches the case where rows differ in trivia such as
+  whitespace but share the same subject+object tuple).
+
+* **Rule B4** — canonical ``object_label`` drift. For every row whose
+  ``object_id`` prefix is in ``{CHEBI, FOODON, UBERON, ENVO, BTO,
+  MICRO, PATO}``, look up the canonical label in the local sibling
+  kg-microbe checkout at
+  ``../kg-microbe/data/transformed/ontologies/{prefix_lc}_nodes.tsv``.
+  If the file is absent (the typical case in CI — kg-microbe's
+  ontology transforms are not checked into its repo), Rule B4 emits a
+  single warning to stderr and skips entirely; it does NOT contribute
+  to exit-2 in that case. If the file is present and ``object_label``
+  matches neither the canonical name (column 3) nor any pipe-delimited
+  exact-synonym (column 7), the row is rejected.
 
 Rejected rows are written to ``mappings/needs_curator_review.tsv`` with
 the same column shape as the source SSSOM plus a trailing
@@ -32,8 +77,10 @@ claw builder) or leave it in the triage TSV; CI fails as long as a
 violating row sits in ``ingredient_mappings.sssom.tsv``.
 
 Exit codes:
-  0 — every row passes Rule A.
-  2 — at least one row failed Rule A (CI-blocking).
+  0 — every row passes Rules A, B2, B3, and (when its label source is
+      present) B4. B1 contributes to exit-2 only when ``--strict-b1``
+      is passed; without that flag B1 is warn-only.
+  2 — at least one row failed Rule A, B2, B3, B4, or B1-with-strict.
 """
 from __future__ import annotations
 
@@ -49,12 +96,26 @@ DEFAULT_SSSOM = REPO_ROOT / "mappings" / "ingredient_mappings.sssom.tsv"
 DEFAULT_REJECT_TSV = REPO_ROOT / "mappings" / "needs_curator_review.tsv"
 INGREDIENTS_DIR = REPO_ROOT / "data" / "ingredients" / "mapped"
 
+# Local sibling kg-microbe checkout — Rule B4 reads canonical labels
+# from <prefix>_nodes.tsv files here. Absent in CI; warn-and-skip then.
+KGM_TRANSFORMS_DIR = REPO_ROOT.parent / "kg-microbe" / "data" / "transformed" / "ontologies"
+
 AUTO_PIPELINE_TAGS = frozenset({
     "MIM:curator=auto_classify_ingredient_type",
     "MIM:curator=backfill_parent_terms",
 })
 CURATOR_TAG_PREFIX = "MIM:curator="
 CONFIDENCE_TIER = 0.95
+
+# Rule B1: predicates that trigger the registry-row requirement. The
+# registry CURIE must match this regex (slug_lc filled in per-subject).
+ASYMMETRIC_PREDICATES = frozenset({"skos:narrowMatch", "skos:broadMatch"})
+_REGISTRY_OBJECT_RE = re.compile(r"^kgmicrobe\.(ingredient|compound):(.+)$")
+
+# Rule B4: only these object_id prefixes are looked up against
+# kg-microbe ontology transforms. Other prefixes (cas:, mesh:, NCIT,
+# kgmicrobe.*) have no canonical label source local to this repo.
+B4_PREFIXES = frozenset({"CHEBI", "FOODON", "UBERON", "ENVO", "BTO", "MICRO", "PATO"})
 
 
 # ---------------------------------------------------------------------------
@@ -228,10 +289,254 @@ def evaluate_rule_a(rows: Iterable[dict[str, str]]) -> Iterator[tuple[int, dict[
         yield idx, row, reason
 
 
-# TODO PR2: extend with Rules B1-B4 (registry/identity row mandate,
-# at-most-one row per (subject_id, object_id), narrowMatch-vs-exactMatch
-# disjointness, canonical object_label drift). See plan section "PR2 —
-# Group B".
+# ---------------------------------------------------------------------------
+# Rule B1 — mandatory registry/identity row
+# ---------------------------------------------------------------------------
+def _registry_slug_for(subject_id: str) -> str | None:
+    """``MIM:Vermont_Soil`` -> ``vermont_soil``. None if not a MIM CURIE."""
+    if not subject_id.startswith("MIM:"):
+        return None
+    return subject_id[4:].lower()
+
+
+def _has_registry_row(rows: list[dict[str, str]], subject_id: str) -> bool:
+    """True iff some row has ``subject_id == subject_id``,
+    ``predicate_id == 'skos:exactMatch'``, and ``object_id`` matching
+    ``^kgmicrobe\\.(ingredient|compound):<slug_lc>$`` for the subject's
+    lowercased slug."""
+    slug = _registry_slug_for(subject_id)
+    if slug is None:
+        return False
+    for r in rows:
+        if (r.get("subject_id") or "").strip() != subject_id:
+            continue
+        if (r.get("predicate_id") or "").strip() != "skos:exactMatch":
+            continue
+        m = _REGISTRY_OBJECT_RE.match((r.get("object_id") or "").strip())
+        if m and m.group(2) == slug:
+            return True
+    return False
+
+
+def _other_exact_match_targets(
+    rows: list[dict[str, str]], subject_id: str
+) -> list[str]:
+    """Return every ``object_id`` that the subject is exactMatch'd to,
+    excluding the kgmicrobe.* registry shape. Used by Rule B1's reject
+    message so curators see at a glance whether the subject already has
+    a CAS-RN / mesh / NCIT exactMatch and only the kg-microbe registry
+    row is missing (vs. having no exactMatch row at all)."""
+    out: list[str] = []
+    for r in rows:
+        if (r.get("subject_id") or "").strip() != subject_id:
+            continue
+        if (r.get("predicate_id") or "").strip() != "skos:exactMatch":
+            continue
+        oid = (r.get("object_id") or "").strip()
+        if not oid:
+            continue
+        if _REGISTRY_OBJECT_RE.match(oid):
+            continue
+        out.append(oid)
+    return out
+
+
+def evaluate_rule_b1(
+    rows: list[dict[str, str]],
+) -> Iterator[tuple[int, dict[str, str], str]]:
+    """Yield ``(row_number, row, reason)`` for every narrowMatch /
+    broadMatch row whose subject lacks a matching registry row.
+
+    A subject with N narrow/broad rows but no registry row produces N
+    rejects (one per offending row), so curators see every row that
+    needs to move out of the main TSV until the registry row is added.
+    """
+    # subject_id -> True if registry row exists; cached because we may
+    # ask many times per subject.
+    cache: dict[str, bool] = {}
+    for idx, row in enumerate(rows, start=1):
+        predicate = (row.get("predicate_id") or "").strip()
+        if predicate not in ASYMMETRIC_PREDICATES:
+            continue
+        subject_id = (row.get("subject_id") or "").strip()
+        if not subject_id.startswith("MIM:"):
+            continue
+        if subject_id not in cache:
+            cache[subject_id] = _has_registry_row(rows, subject_id)
+        if cache[subject_id]:
+            continue
+        slug = _registry_slug_for(subject_id) or "?"
+        other_targets = _other_exact_match_targets(rows, subject_id)
+        if other_targets:
+            other_hint = (
+                f" (subject has non-registry exactMatch row(s) to "
+                f"{', '.join(other_targets)} — those are not the "
+                f"kg-microbe registry CURIE Rule B1 requires)"
+            )
+        else:
+            other_hint = " (subject has no exactMatch row at all)"
+        reason = (
+            f"Rule B1: missing registry row for {subject_id}. A "
+            f"{predicate} row requires a sibling 'skos:exactMatch' row "
+            f"with object_id matching kgmicrobe.(ingredient|compound):"
+            f"{slug}.{other_hint} Mint the registry CURIE and re-emit "
+            f"the SSSOM."
+        )
+        yield idx, row, reason
+
+
+# ---------------------------------------------------------------------------
+# Rule B2 — at most one row per (subject_id, object_id)
+# ---------------------------------------------------------------------------
+def evaluate_rule_b2(
+    rows: list[dict[str, str]],
+) -> Iterator[tuple[int, dict[str, str], str]]:
+    """Yield every row that participates in a duplicated
+    ``(subject_id, object_id)`` group. All rows in a group of size > 1
+    are rejected — fixing one without checking the other lets the
+    contradiction live on, so curators must look at every row."""
+    groups: dict[tuple[str, str], list[tuple[int, dict[str, str]]]] = {}
+    for idx, row in enumerate(rows, start=1):
+        key = (
+            (row.get("subject_id") or "").strip(),
+            (row.get("object_id") or "").strip(),
+        )
+        groups.setdefault(key, []).append((idx, row))
+    for (subj, obj), members in groups.items():
+        if len(members) <= 1:
+            continue
+        predicates = sorted({
+            (r.get("predicate_id") or "").strip() for _, r in members
+        })
+        for idx, row in members:
+            reason = (
+                f"Rule B2: duplicate (subject_id, object_id) pair "
+                f"({subj}, {obj}) appears in {len(members)} rows under "
+                f"predicate(s) {predicates}. At most one row per pair "
+                f"is allowed; pick the correct predicate and remove the "
+                f"others."
+            )
+            yield idx, row, reason
+
+
+# ---------------------------------------------------------------------------
+# Rule B3 — asymmetric child→parent disjoint from exactMatch
+# ---------------------------------------------------------------------------
+def evaluate_rule_b3(
+    rows: list[dict[str, str]],
+) -> Iterator[tuple[int, dict[str, str], str]]:
+    """Yield every narrow/broad row whose ``(subject_id, object_id)``
+    pair also appears under ``skos:exactMatch`` in some other row.
+    B2 catches this when both rows live in the file with identical
+    tuples; B3 is the cross-row variant where the rows might differ in
+    columns other than subject_id/object_id."""
+    exact_pairs: set[tuple[str, str]] = set()
+    for row in rows:
+        if (row.get("predicate_id") or "").strip() != "skos:exactMatch":
+            continue
+        exact_pairs.add((
+            (row.get("subject_id") or "").strip(),
+            (row.get("object_id") or "").strip(),
+        ))
+    for idx, row in enumerate(rows, start=1):
+        predicate = (row.get("predicate_id") or "").strip()
+        if predicate not in ASYMMETRIC_PREDICATES:
+            continue
+        key = (
+            (row.get("subject_id") or "").strip(),
+            (row.get("object_id") or "").strip(),
+        )
+        if key not in exact_pairs:
+            continue
+        reason = (
+            f"Rule B3: ({key[0]}, {key[1]}) is asserted under both "
+            f"{predicate} and skos:exactMatch — incompatible. The two "
+            f"predicates are mutually exclusive for the same pair: "
+            f"narrowMatch is parent/child, exactMatch is identity. "
+            f"Pick one."
+        )
+        yield idx, row, reason
+
+
+# ---------------------------------------------------------------------------
+# Rule B4 — canonical object_label drift
+# ---------------------------------------------------------------------------
+def _load_ontology_labels(prefix: str) -> dict[str, tuple[str, set[str]]] | None:
+    """Load ``../kg-microbe/data/transformed/ontologies/<prefix_lc>_nodes.tsv``
+    into a dict ``{id: (canonical_name, {synonyms})}``. Return None if
+    the file is absent. Raises on a parse error (the file is expected
+    to have a header row with ``id``, ``name``, ``synonym`` columns)."""
+    path = KGM_TRANSFORMS_DIR / f"{prefix.lower()}_nodes.tsv"
+    if not path.is_file():
+        return None
+    out: dict[str, tuple[str, set[str]]] = {}
+    with path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f, delimiter="\t")
+        if reader.fieldnames is None:
+            return out
+        for row in reader:
+            term_id = (row.get("id") or "").strip()
+            if not term_id:
+                continue
+            name = (row.get("name") or "").strip()
+            syn_raw = (row.get("synonym") or "").strip()
+            synonyms = {
+                s.strip() for s in syn_raw.split("|") if s.strip()
+            } if syn_raw else set()
+            out[term_id] = (name, synonyms)
+    return out
+
+
+def evaluate_rule_b4(
+    rows: list[dict[str, str]],
+    *,
+    transforms_present: dict[str, bool] | None = None,
+) -> Iterator[tuple[int, dict[str, str], str]]:
+    """Yield rows whose ``object_label`` doesn't match the canonical
+    name or any exact synonym in the local kg-microbe ontology
+    transform. Skips rows whose object_id prefix isn't in
+    ``B4_PREFIXES`` and skips entirely (yields nothing) for any
+    prefix whose transform file is absent — caller has already emitted
+    the warn-and-skip stderr line.
+
+    ``transforms_present`` is an optional caller-supplied dict
+    populated by load attempts so the caller can decide which prefixes
+    to warn about. When None, this function loads transforms lazily
+    and silently skips absent ones."""
+    cache: dict[str, dict[str, tuple[str, set[str]]] | None] = {}
+    for idx, row in enumerate(rows, start=1):
+        object_id = (row.get("object_id") or "").strip()
+        if ":" not in object_id:
+            continue
+        prefix = object_id.split(":", 1)[0]
+        if prefix not in B4_PREFIXES:
+            continue
+        if prefix not in cache:
+            cache[prefix] = _load_ontology_labels(prefix)
+        labels = cache[prefix]
+        if labels is None:
+            continue  # warn-and-skip handled by caller
+        if object_id not in labels:
+            continue  # term not in transform — out of B4 scope
+        canonical_name, synonyms = labels[object_id]
+        if not canonical_name and not synonyms:
+            # Term is in the transform but has no name and no synonyms
+            # (e.g. an upper-level CHEBI placeholder). We have no
+            # canonical label to compare against — skip to avoid false
+            # positives.
+            continue
+        object_label = (row.get("object_label") or "").strip()
+        if canonical_name and object_label == canonical_name:
+            continue
+        if object_label in synonyms:
+            continue
+        reason = (
+            f"Rule B4: object_label '{object_label}' does not match "
+            f"the canonical name '{canonical_name}' for {object_id} "
+            f"and is not in the term's exact-synonym set. Use the "
+            f"OBO-published label or a registered synonym."
+        )
+        yield idx, row, reason
 
 
 def main(argv: list[str]) -> int:
@@ -252,6 +557,26 @@ def main(argv: list[str]) -> int:
             f"(default: {DEFAULT_REJECT_TSV.relative_to(REPO_ROOT)})"
         ),
     )
+    p.add_argument(
+        "--strict-b1",
+        action="store_true",
+        help=(
+            "Treat Rule B1 (mandatory kgmicrobe.{ingredient,compound}: "
+            "registry row) as a hard reject. Default is warn-only: B1 "
+            "violations are reported to stderr but do not contribute to "
+            "exit-2 or the reject TSV. Flip this flag once the SSSOM "
+            "carries kgmicrobe.* registry rows for every narrowMatch / "
+            "broadMatch subject (see MAPPING_SEMANTICS.md Section 2). "
+            "The current SSSOM has many narrowMatch subjects whose "
+            "exactMatch row points at a CAS-RN / mesh / NCIT id rather "
+            "than a kgmicrobe.* registry CURIE — those subjects are B1 "
+            "violations under the strict reading even though the "
+            "non-kg-microbe exactMatch row prevents some forms of "
+            "identity collapse. Strict B1 is the correct long-term "
+            "gate; warn-only is the temporary stage until the "
+            "kg-microbe registry is fully minted."
+        ),
+    )
     args = p.parse_args(argv[1:])
 
     if not args.sssom_path.is_file():
@@ -259,14 +584,85 @@ def main(argv: list[str]) -> int:
         return 1
 
     prelude, fieldnames, rows = _read_sssom(args.sssom_path)
-    rejects = list(evaluate_rule_a(rows))
+
+    # Aggregate rejects across rules. A row may fail multiple rules; we
+    # keep one entry per (row_number, rule) so the curator sees every
+    # contributing reason. Insertion order = rule order = stable output.
+    all_rejects: list[tuple[int, dict[str, str], str]] = []
+    rule_counts: dict[str, int] = {}
+
+    def _collect(label: str, gen: Iterable[tuple[int, dict[str, str], str]]) -> None:
+        new = list(gen)
+        if new:
+            rule_counts[label] = len(new)
+            all_rejects.extend(new)
+
+    _collect("Rule A", evaluate_rule_a(rows))
+    if args.strict_b1:
+        _collect("Rule B1", evaluate_rule_b1(rows))
+    else:
+        # Warn-only B1: emit per-row warnings to stderr but do not
+        # contribute to exit-2 or the reject TSV. Once the SSSOM carries
+        # kgmicrobe.* registry rows for every narrowMatch subject, run
+        # the validator with --strict-b1 (and add the flag to CI) to
+        # flip B1 into a hard gate.
+        b1_findings = list(evaluate_rule_b1(rows))
+        if b1_findings:
+            print(
+                f"WARNING: Rule B1 (warn-only without --strict-b1): "
+                f"{len(b1_findings)} narrowMatch/broadMatch row(s) "
+                f"belong to a MIM subject that lacks a "
+                f"kgmicrobe.{{ingredient,compound}}:<slug_lc> registry "
+                f"exactMatch row. Pass --strict-b1 to convert these to "
+                f"hard rejects. First five:",
+                file=sys.stderr,
+            )
+            for row_num, row, _reason in b1_findings[:5]:
+                print(
+                    f"  row {row_num}: {row.get('subject_id','?')} "
+                    f"-> {row.get('object_id','?')}",
+                    file=sys.stderr,
+                )
+    _collect("Rule B2", evaluate_rule_b2(rows))
+    _collect("Rule B3", evaluate_rule_b3(rows))
+
+    # Rule B4: warn-and-skip if any in-use prefix's transform is absent.
+    # We probe each B4 prefix that actually appears in the SSSOM so the
+    # warning lists exactly the prefixes that would have been checked.
+    in_use_prefixes: set[str] = set()
+    for r in rows:
+        oid = (r.get("object_id") or "").strip()
+        if ":" in oid:
+            p = oid.split(":", 1)[0]
+            if p in B4_PREFIXES:
+                in_use_prefixes.add(p)
+    missing_prefixes = sorted(
+        p for p in in_use_prefixes
+        if not (KGM_TRANSFORMS_DIR / f"{p.lower()}_nodes.tsv").is_file()
+    )
+    if missing_prefixes:
+        print(
+            f"WARNING: Rule B4 skipped — kg-microbe ontology transforms "
+            f"not found at {KGM_TRANSFORMS_DIR} for prefix(es): "
+            f"{', '.join(missing_prefixes)}. To enable Rule B4 locally, "
+            f"check out kg-microbe at the sibling path and run its "
+            f"`just transform` recipe. (CI typically lacks these "
+            f"transforms; the validator does not exit-2 on B4 alone in "
+            f"that case.)",
+            file=sys.stderr,
+        )
+    if missing_prefixes != sorted(in_use_prefixes):
+        # At least one prefix has its transform — run B4 over the rows;
+        # _load_ontology_labels returns None for the missing prefixes
+        # and evaluate_rule_b4 silently skips them.
+        _collect("Rule B4", evaluate_rule_b4(rows))
 
     args.reject_tsv.parent.mkdir(parents=True, exist_ok=True)
     _write_reject_tsv(
         args.reject_tsv,
         prelude,
         fieldnames,
-        [(row, reason) for _, row, reason in rejects],
+        [(row, reason) for _, row, reason in all_rejects],
     )
 
     try:
@@ -274,25 +670,26 @@ def main(argv: list[str]) -> int:
     except ValueError:
         reject_display = args.reject_tsv
 
-    if not rejects:
-        print(f"OK: {args.sssom_path.name} passed Rule A (auto-classifier "
-              f"token-overlap gate). {reject_display} "
-              f"written with header only.")
+    if not all_rejects:
+        b1_label = "B1" if args.strict_b1 else "B1(warn-only)"
+        rule_summary = f"Rules A, {b1_label}, B2, B3"
+        if "Rule B4" in rule_counts or not missing_prefixes:
+            rule_summary += ", B4"
+        print(
+            f"OK: {args.sssom_path.name} passed {rule_summary}. "
+            f"{reject_display} written with header only."
+        )
         return 0
 
-    print(
-        f"FAIL: {len(rejects)} row(s) in {args.sssom_path.name} fail Rule A "
-        f"(auto-classifier token-overlap gate).",
-        file=sys.stderr,
+    rule_summary = ", ".join(
+        f"{rule}: {count}" for rule, count in rule_counts.items()
     )
     print(
-        "Each row below is stamped only with MIM:curator=... automation "
-        "tags, has confidence < 0.95, has zero discriminating-token overlap "
-        "between subject_label and object_label, and lacks an independent "
-        "CAS-RN / PubChem corroboration in its MIM YAML.",
+        f"FAIL: {len(all_rejects)} reject(s) in {args.sssom_path.name} "
+        f"({rule_summary}).",
         file=sys.stderr,
     )
-    for row_num, row, reason in rejects:
+    for row_num, row, reason in all_rejects:
         subject = row.get("subject_label", "?")
         subject_id = row.get("subject_id", "?")
         object_id = row.get("object_id", "?")
@@ -304,10 +701,11 @@ def main(argv: list[str]) -> int:
         )
     print(
         f"\nRejects written to {reject_display}. "
-        "Fix the offending row in MIM (re-emit via the claw builder, or "
-        "add a non-curator tag to the source column once a human has "
-        "vetted it), or remove the row from the SSSOM. CI fails while a "
-        "violating row remains in ingredient_mappings.sssom.tsv.",
+        "Fix the offending row(s) in MIM (re-emit via the claw builder, "
+        "mint the missing registry CURIE for B1, dedupe pairs for B2/B3, "
+        "or update object_label for B4), or remove the row from the SSSOM. "
+        "CI fails while a violating row remains in "
+        "ingredient_mappings.sssom.tsv.",
         file=sys.stderr,
     )
     return 2


### PR DESCRIPTION
## Summary

Extends `scripts/validate_sssom_invariants.py` with the four B-series structural invariants documented in [`MAPPING_SEMANTICS.md`](https://github.com/CultureBotAI/MediaIngredientMech/blob/main/MAPPING_SEMANTICS.md) (merged via #3) and specified by the Codex-#558 round-3 hardening. Closes the Group B lane that complements PR #2 (Group A: Rule A) and PR #3 (Group C: docs).

The validator stays stdlib-only (`csv` + `argparse`), preserves Rule A verbatim, and continues to write rejects to `mappings/needs_curator_review.tsv` with a `reject_reason` column that names the rule.

## Rules added

- **Rule B1 — mandatory registry/identity row** (MAPPING_SEMANTICS.md §2). Every `MIM:<slug>` subject with at least one `skos:narrowMatch` or `skos:broadMatch` row must have a sibling `skos:exactMatch` row whose `object_id` matches `^kgmicrobe\.(ingredient|compound):<slug_lc>$`. Without this row a downstream consumer that walks the SSSOM by `subject_label` resolves the MIM child to its OBO parent — the identity-collapse bug Codex review #558 round 3 flagged.

  **Staged rollout**: B1 ships **warn-only by default**. Pass `--strict-b1` to convert to a hard reject. Rationale: the current SSSOM has 162 narrowMatch subjects whose exactMatch row points at `cas:` / `mesh:` / `NCIT:` registries instead of `kgmicrobe.*`. Those rows partially solve the identity-collapse problem (consumer lookups by CAS-RN don't collapse to the OBO parent) but they don't satisfy the strict contract. Warn-only mode lets the validator implementation ship now; flip `--strict-b1` (and add it to `just qc-sssom` / the CI workflow) once every narrow/broad subject carries a `kgmicrobe.*` registry exactMatch row.

- **Rule B2 — at most one row per `(subject_id, object_id)` pair** (MAPPING_SEMANTICS.md §3 Mistake 2). Group every row by `(subject_id, object_id)`; reject every row participating in a group of size > 1. Catches double-typed rows like `(MIM:X exactMatch Y) + (MIM:X narrowMatch Y)` directly.

- **Rule B3 — asymmetric child→parent only** (MAPPING_SEMANTICS.md §1 narrowMatch / §3 Mistake 2). Cross-row variant of B2: any `(subject, object)` pair appearing in a `skos:narrowMatch` (or `skos:broadMatch`) row must NOT also appear in a `skos:exactMatch` row, even if the rows differ in trivia (whitespace, source tag, comment).

- **Rule B4 — canonical `object_label` drift** (MAPPING_SEMANTICS.md §3 Mistake 4). For every row whose `object_id` prefix is in `{CHEBI, FOODON, UBERON, ENVO, BTO, MICRO, PATO}`, look up the canonical label in the local sibling kg-microbe checkout at `../kg-microbe/data/transformed/ontologies/<prefix_lc>_nodes.tsv` and reject rows whose `object_label` matches neither the canonical name (column 3) nor any pipe-delimited exact synonym (column 7). When a transform file is absent (typical CI configuration) the validator emits one stderr WARNING and skips B4 entirely — B4 does NOT contribute to exit-2 in that case. Terms with empty canonical name AND empty synonym set are skipped (a few CHEBI placeholder/upper-level nodes have no name in the transform).

## Validator behavior matrix

| Rule | Default exit | `--strict-b1` exit | Reject TSV | Notes |
|------|--------------|--------------------|------------|-------|
| A    | exit 2 on violation | (same) | yes | unchanged from PR #2 |
| B1   | warn-only (no exit-2) | exit 2 on violation | yes (only with strict) | per-row stderr `WARNING:` summary lines |
| B2   | exit 2 on violation | (same) | yes | every row in a duplicated group rejected |
| B3   | exit 2 on violation | (same) | yes | catches cross-row variants |
| B4   | exit 2 on violation when transform present, warn-and-skip when absent | (same) | yes (when transform present) | warns once per missing prefix |

Single PR, one file changed: `scripts/validate_sssom_invariants.py` (317 → 715 LOC, +441 / -43).

## Test plan

- [x] **Live SSSOM, default mode**: `python3 scripts/validate_sssom_invariants.py` → exit 0, with one B4 warning (BTO transform absent locally) and 162 B1 warn-only entries (the kg-microbe-registry-mint backlog). `mappings/needs_curator_review.tsv` contains only the header.
- [x] **Live SSSOM, strict mode**: `python3 scripts/validate_sssom_invariants.py --strict-b1` → exit 2, 162 B1 rejects, 0 B2/B3/B4. The 162 violations break down into ~143 subjects whose only registry exactMatch is a CAS-RN / mesh / NCIT id, plus ~19 subjects with no exactMatch row at all. Each reject_reason names the subject's other exactMatch targets so curators see at a glance whether they need to mint a `kgmicrobe.*` row alongside an existing CAS row, or mint the registry row from scratch.
- [x] **`just qc-sssom`**: exit 0 (uses default warn-only B1).
- [x] **Synthetic test cases**: hand-crafted SSSOM exercising each rule (in scratch files outside the repo) — every rule fires with the correct `reject_reason`. Vermont_Soil with both narrowMatch ENVO row + kgmicrobe.ingredient: registry row → all rules pass.
- [x] **B4 empty-canonical handling**: rows whose `object_id` resolves to a transform entry with no name AND no synonyms (e.g. `CHEBI:1`, `CHEBI:8150` placeholder upper-level nodes) are skipped to avoid false positives.

## Next steps after merge

1. **Strict B1 rollout (the actual Codex-#558 fix)**: mint `kgmicrobe.{ingredient,compound}:<slug_lc>` registry rows for the 162 subjects currently in B1 warn-only. The reject_reason output of `--strict-b1` mode is the worklist — it lists each subject and its existing non-registry exactMatch target so curators know whether to add or to upgrade an existing row. Once minting is complete, flip CI to use `--strict-b1` (one-line change in `.github/workflows/qc-sssom.yaml` and `justfile`).

2. **Remove kg-microbe's compensating filters**: once strict B1 is enabled in CI, kg-microbe's `purge_asymmetric_pollution()` and `KNOWN_BAD_NARROWMATCH` filter become redundant — the SSSOM consumer no longer has to defensively scrub for identity-collapsed rows because the producer guarantees they don't exist. Open a downstream kg-microbe PR to delete those guards.

3. **Optional B4 enrichment in CI**: at the moment Rule B4 warn-and-skips on every CI run because kg-microbe's ontology transforms aren't checked into its repo. A future iteration could publish the canonical-label tables (or a small subset) as a CI artifact, letting B4 run as a hard gate everywhere.

## References

- MAPPING_SEMANTICS.md §1 Predicate semantics (skos:exactMatch / closeMatch / narrowMatch / broadMatch)
- MAPPING_SEMANTICS.md §2 Registry/identity row pattern (Vermont_Soil worked example)
- MAPPING_SEMANTICS.md §3 Common mistakes (each B-rule indexed)
- PR #2 — Rule A (auto-classifier token-overlap gate)
- PR #3 — MAPPING_SEMANTICS.md docs (the contract this validator enforces)
- Codex review #558 round 3 — original asymmetric-pollution finding

🤖 Generated with [Claude Code](https://claude.com/claude-code)