### PR TITLE
Validators: accept individual-record YAMLs and broaden CURIE/enum tolerance

### DIFF
--- a/scripts/validate_all.py
+++ b/scripts/validate_all.py
@@ -83,12 +83,26 @@ def main(
     else:
         ingredients_dir_path = Path(ingredients_dir)
 
+    def _is_excluded(p: Path) -> bool:
+        # Skip backup snapshots that intentionally lag the current schema.
+        parts = set(p.parts)
+        if "backups" in parts:
+            return True
+        name = p.name
+        if ".backup" in name or name.endswith(".bak"):
+            return True
+        return False
+
     # Collect files to validate based on mode
     yaml_files = []
 
     if mode in ("collection", "both"):
         if data_dir_path.exists():
-            collection_files = sorted(data_dir_path.glob("**/*.yaml")) + sorted(data_dir_path.glob("**/*.yml"))
+            collection_files = [
+                p
+                for p in sorted(data_dir_path.glob("**/*.yaml")) + sorted(data_dir_path.glob("**/*.yml"))
+                if not _is_excluded(p)
+            ]
             yaml_files.extend(collection_files)
             if collection_files:
                 console.print(f"[bold]Collection files:[/bold] {len(collection_files)} from {data_dir_path}")
@@ -98,7 +112,11 @@ def main(
 
     if mode in ("individual", "both"):
         if ingredients_dir_path.exists():
-            individual_files = sorted(ingredients_dir_path.glob("**/*.yaml")) + sorted(ingredients_dir_path.glob("**/*.yml"))
+            individual_files = [
+                p
+                for p in sorted(ingredients_dir_path.glob("**/*.yaml")) + sorted(ingredients_dir_path.glob("**/*.yml"))
+                if not _is_excluded(p)
+            ]
             yaml_files.extend(individual_files)
             if individual_files:
                 console.print(f"[bold]Individual files:[/bold] {len(individual_files)} from {ingredients_dir_path}")

--- a/src/mediaingredientmech/validation/ontology_validator.py
+++ b/src/mediaingredientmech/validation/ontology_validator.py
@@ -7,12 +7,15 @@ from dataclasses import dataclass, field
 from typing import Any
 
 # CURIE pattern broadened to match prefixes actually present in mapped
-# records: case-insensitive prefix with optional dot, and local IDs that may be
-# alphanumeric (`NCIT:C80654`) or contain hyphens (`cas:247167-54-0`).
+# records: prefix may include letters of either case and an optional dot, and
+# local IDs may be alphanumeric (`NCIT:C80654`) or contain hyphens
+# (`cas:247167-54-0`). Prefix case is preserved (not normalised) — KNOWN_PREFIXES
+# is checked case-sensitively against the SSSOM curie_map below.
 _CURIE_RE = re.compile(r"^([A-Za-z][A-Za-z0-9.]*):([A-Za-z0-9][A-Za-z0-9._-]*)$")
 
-# Recognised ontology prefixes. Case-sensitive; keep in sync with the
-# SSSOM curie_map that the claw builder emits for ingredient mappings.
+# Recognised ontology prefixes. Case-sensitive (e.g. `mesh:` and `MESH:` are
+# both accepted, but only the exact spellings listed here); keep in sync with
+# the SSSOM curie_map that the claw builder emits for ingredient mappings.
 KNOWN_PREFIXES = {
     "CHEBI",
     "FOODON",
@@ -152,9 +155,16 @@ def validate_records(
 
     # Accept both the collection shape (`ingredients: [...]`) and the
     # individual-record shape (the document itself is an IngredientRecord).
+    # Match schema_validator: a record has either `identifier` (canonical) or
+    # `ontology_id` (legacy) as its primary key. Also accept any document with
+    # an `ontology_mapping` block.
     ingredients = data.get("ingredients")
     if not isinstance(ingredients, list):
-        if isinstance(data.get("ontology_mapping"), dict) or "identifier" in data:
+        if (
+            isinstance(data.get("ontology_mapping"), dict)
+            or "identifier" in data
+            or "ontology_id" in data
+        ):
             ingredients = [data]
             path_prefix = "$"
         else:

--- a/src/mediaingredientmech/validation/ontology_validator.py
+++ b/src/mediaingredientmech/validation/ontology_validator.py
@@ -6,10 +6,28 @@ import re
 from dataclasses import dataclass, field
 from typing import Any
 
-_CURIE_RE = re.compile(r"^([A-Z]+):([0-9]+)$")
+# CURIE pattern broadened to match prefixes actually present in mapped
+# records: case-insensitive prefix with optional dot, and local IDs that may be
+# alphanumeric (`NCIT:C80654`) or contain hyphens (`cas:247167-54-0`).
+_CURIE_RE = re.compile(r"^([A-Za-z][A-Za-z0-9.]*):([A-Za-z0-9][A-Za-z0-9._-]*)$")
 
-# Recognised ontology prefixes from the schema
-KNOWN_PREFIXES = {"CHEBI", "FOODON", "NCIT", "MESH", "UBERON", "ENVO"}
+# Recognised ontology prefixes. Case-sensitive; keep in sync with the
+# SSSOM curie_map that the claw builder emits for ingredient mappings.
+KNOWN_PREFIXES = {
+    "CHEBI",
+    "FOODON",
+    "NCIT",
+    "MESH",
+    "mesh",
+    "UBERON",
+    "ENVO",
+    "MICRO",
+    "BTO",
+    "cas",
+    "kgmicrobe.compound",
+    "kgmicrobe.ingredient",
+    "registry",
+}
 
 
 @dataclass
@@ -132,9 +150,17 @@ def validate_records(
     """
     result = OntologyValidationResult(file_path=source)
 
+    # Accept both the collection shape (`ingredients: [...]`) and the
+    # individual-record shape (the document itself is an IngredientRecord).
     ingredients = data.get("ingredients")
     if not isinstance(ingredients, list):
-        return result
+        if isinstance(data.get("ontology_mapping"), dict) or "identifier" in data:
+            ingredients = [data]
+            path_prefix = "$"
+        else:
+            return result
+    else:
+        path_prefix = None
 
     oak_was_used = False
 
@@ -150,7 +176,11 @@ def validate_records(
             continue
 
         result.terms_checked += 1
-        path = f"$.ingredients[{i}].ontology_mapping"
+        path = (
+            f"{path_prefix}.ontology_mapping"
+            if path_prefix is not None
+            else f"$.ingredients[{i}].ontology_mapping"
+        )
 
         # Format check
         fmt_err = validate_curie_format(str(oid))

--- a/src/mediaingredientmech/validation/schema_validator.py
+++ b/src/mediaingredientmech/validation/schema_validator.py
@@ -60,13 +60,42 @@ class SchemaValidationResult:
 # Validators for individual classes
 # ---------------------------------------------------------------------------
 
-_CURIE_PATTERN = re.compile(r"^[A-Z]+:[0-9]+$")
+# CURIE pattern broadened to match the prefixes actually present in mapped
+# records: case-insensitive prefix with optional dot (e.g. `cas:`, `mesh:`,
+# `kgmicrobe.compound:`), and local IDs that may be alphanumeric or contain
+# hyphens (e.g. `NCIT:C80654`, `cas:247167-54-0`).
+_CURIE_PATTERN = re.compile(r"^[A-Za-z][A-Za-z0-9.]*:[A-Za-z0-9][A-Za-z0-9._-]*$")
 _ONTOLOGY_SOURCES = _enum_values("OntologySourceEnum") if SCHEMA_PATH.exists() else set()
 _MAPPING_STATUSES = _enum_values("MappingStatusEnum") if SCHEMA_PATH.exists() else set()
 _MAPPING_QUALITIES = _enum_values("MappingQualityEnum") if SCHEMA_PATH.exists() else set()
 _EVIDENCE_TYPES = _enum_values("EvidenceTypeEnum") if SCHEMA_PATH.exists() else set()
 _SYNONYM_TYPES = _enum_values("SynonymTypeEnum") if SCHEMA_PATH.exists() else set()
 _CURATION_ACTIONS = _enum_values("CurationActionEnum") if SCHEMA_PATH.exists() else set()
+
+
+def _check_open_enum(
+    data: dict,
+    field_name: str,
+    allowed: set[str],
+    path: str,
+    msgs: list[ValidationMessage],
+):
+    """Warn (not error) on values outside an enum that grows organically.
+
+    Several enums in the schema (ontology_source, mapping_quality, evidence_type,
+    synonym_type, action) lag the live data: tooling mints new permissible
+    values without schema bumps. Errors here just produce noise — warnings still
+    surface typos without flooding the report.
+    """
+    val = data.get(field_name)
+    if val is not None and val not in allowed:
+        msgs.append(
+            ValidationMessage(
+                "warning",
+                path,
+                f"Unknown value '{val}' for '{field_name}' (not in schema enum)",
+            )
+        )
 
 
 def _check_required(data: dict, field_name: str, path: str, msgs: list[ValidationMessage]):
@@ -114,7 +143,7 @@ def _validate_mapping_evidence(ev: Any, path: str, msgs: list[ValidationMessage]
         msgs.append(ValidationMessage("error", path, "Evidence entry must be a mapping"))
         return
     _check_required(ev, "evidence_type", path, msgs)
-    _check_enum(ev, "evidence_type", _EVIDENCE_TYPES, path, msgs)
+    _check_open_enum(ev, "evidence_type", _EVIDENCE_TYPES, path, msgs)
     score = ev.get("confidence_score")
     if score is not None:
         try:
@@ -144,8 +173,8 @@ def _validate_ontology_mapping(mapping: Any, path: str, msgs: list[ValidationMes
             ValidationMessage("error", path, f"ontology_id '{oid}' does not match CURIE pattern ^[A-Z]+:[0-9]+$")
         )
 
-    _check_enum(mapping, "ontology_source", _ONTOLOGY_SOURCES, path, msgs)
-    _check_enum(mapping, "mapping_quality", _MAPPING_QUALITIES, path, msgs)
+    _check_open_enum(mapping, "ontology_source", _ONTOLOGY_SOURCES, path, msgs)
+    _check_open_enum(mapping, "mapping_quality", _MAPPING_QUALITIES, path, msgs)
 
     for i, ev in enumerate(mapping.get("evidence") or []):
         _validate_mapping_evidence(ev, f"{path}.evidence[{i}]", msgs)
@@ -156,7 +185,7 @@ def _validate_synonym(syn: Any, path: str, msgs: list[ValidationMessage]):
         msgs.append(ValidationMessage("error", path, "Synonym entry must be a mapping"))
         return
     _check_required(syn, "synonym_text", path, msgs)
-    _check_enum(syn, "synonym_type", _SYNONYM_TYPES, path, msgs)
+    _check_open_enum(syn, "synonym_type", _SYNONYM_TYPES, path, msgs)
     _check_type(syn, "occurrence_count", int, "integer", path, msgs)
 
 
@@ -177,7 +206,7 @@ def _validate_curation_event(evt: Any, path: str, msgs: list[ValidationMessage])
     _check_required(evt, "timestamp", path, msgs)
     _check_required(evt, "curator", path, msgs)
     _check_required(evt, "action", path, msgs)
-    _check_enum(evt, "action", _CURATION_ACTIONS, path, msgs)
+    _check_open_enum(evt, "action", _CURATION_ACTIONS, path, msgs)
     _check_enum(evt, "previous_status", _MAPPING_STATUSES, path, msgs)
     _check_enum(evt, "new_status", _MAPPING_STATUSES, path, msgs)
     _check_type(evt, "llm_assisted", bool, "boolean", path, msgs)
@@ -187,7 +216,16 @@ def _validate_ingredient_record(rec: Any, path: str, msgs: list[ValidationMessag
     if not isinstance(rec, dict):
         msgs.append(ValidationMessage("error", path, "Ingredient record must be a mapping"))
         return
-    _check_required(rec, "ontology_id", path, msgs)
+    # Records use `identifier` as the semantic primary key in live data; the
+    # schema slot is named `ontology_id` but the YAML key is `identifier`.
+    # Accept either so the validator stays useful without forcing a schema
+    # rewrite.
+    if not rec.get("identifier") and not rec.get("ontology_id"):
+        msgs.append(
+            ValidationMessage(
+                "error", path, "Missing required field 'identifier' (or 'ontology_id')"
+            )
+        )
     _check_required(rec, "preferred_term", path, msgs)
     _check_required(rec, "mapping_status", path, msgs)
     _check_enum(rec, "mapping_status", _MAPPING_STATUSES, path, msgs)
@@ -211,11 +249,30 @@ def _validate_ingredient_record(rec: Any, path: str, msgs: list[ValidationMessag
 
 
 def validate_data(data: dict[str, Any], source: str = "<inline>") -> SchemaValidationResult:
-    """Validate a parsed YAML dict against the schema."""
+    """Validate a parsed YAML dict against the schema.
+
+    Accepts two shapes:
+      - Collection: top-level dict with an `ingredients` list.
+      - Individual record: top-level dict that *is* an IngredientRecord (has
+        `identifier`/`ontology_id` and `preferred_term`).
+    """
     result = SchemaValidationResult(file_path=source)
 
     if not isinstance(data, dict):
         result.messages.append(ValidationMessage("error", "$", "Top-level document must be a mapping"))
+        return result
+
+    # Detect individual-record shape: no `ingredients` list, but the document
+    # itself looks like a record (has the canonical identifier/preferred_term).
+    has_ingredients_field = "ingredients" in data
+    looks_like_record = (
+        not has_ingredients_field
+        and ("identifier" in data or "ontology_id" in data)
+        and "preferred_term" in data
+    )
+
+    if looks_like_record:
+        _validate_ingredient_record(data, "$", result.messages)
         return result
 
     _check_type(data, "total_count", int, "integer", "$", result.messages)

--- a/src/mediaingredientmech/validation/schema_validator.py
+++ b/src/mediaingredientmech/validation/schema_validator.py
@@ -170,7 +170,11 @@ def _validate_ontology_mapping(mapping: Any, path: str, msgs: list[ValidationMes
     oid = mapping.get("ontology_id")
     if oid and not _CURIE_PATTERN.match(str(oid)):
         msgs.append(
-            ValidationMessage("error", path, f"ontology_id '{oid}' does not match CURIE pattern ^[A-Z]+:[0-9]+$")
+            ValidationMessage(
+                "error",
+                path,
+                f"ontology_id '{oid}' does not match CURIE pattern {_CURIE_PATTERN.pattern}",
+            )
         )
 
     _check_open_enum(mapping, "ontology_source", _ONTOLOGY_SOURCES, path, msgs)

--- a/tests/test_curation_workflow.py
+++ b/tests/test_curation_workflow.py
@@ -394,7 +394,10 @@ class TestHistoryTracking:
         """Verify curation history in the unmapped fixture has proper structure."""
         data = load_fixture("sample_unmapped.yaml")
         # Find record with rich history (casamino acids)
-        casamino = next(r for r in data["ingredients"] if r["ontology_id"] == "UNMAPPED_005")
+        casamino = next(
+            r for r in data["ingredients"]
+            if r.get("identifier", r.get("ontology_id")) == "UNMAPPED_005"
+        )
         assert len(casamino["curation_history"]) == 2
         assert casamino["curation_history"][0]["action"] == "IMPORTED"
         assert casamino["curation_history"][1]["action"] == "MAPPED"
@@ -403,7 +406,10 @@ class TestHistoryTracking:
     def test_mapped_fixture_beef_extract_history(self):
         """Beef extract in mapped fixture should show full workflow."""
         data = load_fixture("sample_mapped.yaml")
-        beef = next(r for r in data["ingredients"] if r["ontology_id"] == "FOODON:3311109")
+        beef = next(
+            r for r in data["ingredients"]
+            if r.get("identifier", r.get("ontology_id")) == "FOODON:3311109"
+        )
         assert len(beef["curation_history"]) == 3
         actions = [e["action"] for e in beef["curation_history"]]
         assert actions == ["IMPORTED", "MAPPED", "VALIDATED"]
@@ -452,6 +458,8 @@ class TestCollectionAggregation:
         """All identifiers in fixtures should be unique."""
         mapped_data = load_fixture("sample_mapped.yaml")
         unmapped_data = load_fixture("sample_unmapped.yaml")
-        all_ids = [r["ontology_id"] for r in mapped_data["ingredients"]] + \
-                  [r["ontology_id"] for r in unmapped_data["ingredients"]]
+        all_ids = [
+            r.get("identifier", r.get("ontology_id"))
+            for r in mapped_data["ingredients"] + unmapped_data["ingredients"]
+        ]
         assert len(all_ids) == len(set(all_ids)), "Duplicate identifiers found"

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -90,7 +90,7 @@ class TestSchemaClasses:
 
     def test_ingredient_record_identifier_is_key(self):
         attrs = self.classes["IngredientRecord"]["attributes"]
-        assert attrs["ontology_id"].get("ontology_id") is True
+        assert attrs["ontology_id"].get("identifier") is True
 
     def test_ingredient_record_has_synonyms(self):
         attrs = self.classes["IngredientRecord"]["attributes"]
@@ -215,7 +215,18 @@ class TestSchemaEnums:
 
     def test_synonym_type_values(self):
         values = set(self.enums["SynonymTypeEnum"]["permissible_values"].keys())
-        expected = {"EXACT_SYNONYM", "RELATED_SYNONYM", "RAW_TEXT", "ABBREVIATION", "COMMON_NAME", "SYSTEMATIC_NAME"}
+        expected = {
+            "EXACT_SYNONYM",
+            "RELATED_SYNONYM",
+            "RAW_TEXT",
+            "ABBREVIATION",
+            "COMMON_NAME",
+            "SYSTEMATIC_NAME",
+            "ALTERNATE_FORM",
+            "CATALOG_VARIANT",
+            "HYDRATE_FORM",
+            "INCOMPLETE_FORMULA",
+        }
         assert values == expected
 
     def test_evidence_type_enum_exists(self):
@@ -303,7 +314,9 @@ class TestFixtureDataValidation:
     def test_mapped_records_have_required_fields(self):
         data = self._load_fixture("sample_mapped.yaml")
         for rec in data["ingredients"]:
-            assert "ontology_id" in rec, f"Record missing identifier: {rec}"
+            assert "identifier" in rec or "ontology_id" in rec, (
+                f"Record missing identifier: {rec}"
+            )
             assert "preferred_term" in rec, f"Record missing preferred_term: {rec}"
             assert "mapping_status" in rec, f"Record missing mapping_status: {rec}"
 


### PR DESCRIPTION
## Summary

Brings `scripts/validate_all.py`, `src/mediaingredientmech/validation/schema_validator.py`, and `.../ontology_validator.py` into alignment with the data shape that has been in `data/ingredients/` and `data/curated/` for some time, plus the matching test updates. Carved out of the bigger curation branch (#6) so Copilot can actually review it — that PR is over the 300-file limit.

- `validate-all` skips `data/curated/backups/` and `*.backup*` / `*.bak` snapshots that intentionally lag the live schema.
- Schema validator accepts both shapes: the collection wrapper (`ingredients: [...]`) and individual-record YAMLs (top-level is the record).
- Records use `identifier` as the canonical primary key; `ontology_id` is still accepted for backward compatibility.
- CURIE pattern broadened to `^[A-Za-z][A-Za-z0-9.]*:[A-Za-z0-9][A-Za-z0-9._-]*$` and known prefixes expanded to cover `cas:`, `mesh:`, `MICRO`, `BTO`, `kgmicrobe.compound:`, `kgmicrobe.ingredient:`, `registry:`.
- Enums that grow organically (`ontology_source`, `mapping_quality`, `evidence_type`, `synonym_type`, curation `action`) now emit warnings on unknown values, not errors. The curation `action` enum alone has 110+ distinct values in live data.

## Test plan

- [x] `PYTHONPATH=src pytest -o addopts='' tests/test_curation_workflow.py tests/test_schema_validation.py` → 111 passed
- [x] `python scripts/validate_all.py --mode both --no-oak` (on the parent branch where the regenerated data lives) → 0 errors over 2276 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)