### PR TITLE
Reconcile schema enums with live data; make curation action free-form

### DIFF
--- a/src/mediaingredientmech/schema/mediaingredientmech.yaml
+++ b/src/mediaingredientmech/schema/mediaingredientmech.yaml
@@ -302,9 +302,14 @@ classes:
         required: true
         description: Who performed this action (username or system)
       action:
-        range: CurationActionEnum
+        range: string
         required: true
-        description: Type of curation action
+        pattern: "^[A-Z][A-Z0-9_]*$"
+        description: >-
+          Type of curation action. Free-form SCREAMING_SNAKE_CASE label minted
+          by the curation tool that produced this event. CurationActionEnum
+          below documents well-known actions; new tools are free to introduce
+          new labels (live data has 110+ distinct values).
       changes:
         description: Description of what changed
       previous_status:
@@ -412,6 +417,30 @@ enums:
         description: Mapping suggested by LLM, human-verified
       PROVISIONAL:
         description: Tentative mapping needing verification
+      NARROW_MATCH:
+        description: >-
+          Ontology term is narrower than the ingredient (more specific). Used
+          when the ingredient name covers a class and the chosen term covers
+          one instance/subtype of that class.
+      BROAD_MATCH:
+        description: Ontology term is broader than the ingredient (less specific).
+      LEXICAL_MATCH:
+        description: >-
+          Lexical (string-level) match without semantic verification —
+          typically a token-overlap or normalized-name match.
+      CAS_RN_LOOKUP:
+        description: >-
+          Mapping resolved via CAS Registry Number lookup rather than ontology
+          label/synonym match.
+      FALLBACK_REGISTRY:
+        description: >-
+          Identity assigned via a registry-row fallback (`registry:` or
+          `kgmicrobe.compound:` / `kgmicrobe.ingredient:`) when no direct
+          ontology term is available.
+      PLACEHOLDER:
+        description: >-
+          Mapping is a placeholder pending real curation (e.g. minted
+          kg-microbe ingredient row, awaiting upgrade to CHEBI/FOODON/etc.).
 
   MatchLevelEnum:
     permissible_values:
@@ -442,8 +471,35 @@ enums:
         description: Uber Anatomy Ontology
       ENVO:
         description: Environment Ontology
+      MICRO:
+        description: Microbiology vocabulary
+      BTO:
+        description: BRENDA Tissue Ontology
+      CAS:
+        description: >-
+          CAS Registry — fallback identity when the ingredient has a CAS number
+          but no resolved ontology term (paired with `cas:` prefix CURIEs).
+      registry:
+        description: >-
+          Generic registry-row fallback used when an identity exists in a
+          non-ontology registry tracked by the SSSOM pipeline.
+      kgmicrobe.compound:
+        description: >-
+          kg-microbe compound registry row (placeholder identity awaiting
+          upgrade to a CHEBI/MESH/etc. term).
+      kgmicrobe.ingredient:
+        description: >-
+          kg-microbe ingredient registry row (placeholder identity awaiting
+          upgrade to an ontology term).
 
   CurationActionEnum:
+    description: >-
+      Documentation-only reference list of well-known curation action labels.
+      The `action` slot on CurationEvent has range `string` (not this enum) —
+      curation tools mint new labels freely (live data has 110+ distinct
+      values). New labels should follow SCREAMING_SNAKE_CASE and convey both
+      the operation and its source (e.g. AUTO_BACKFILL_CHEBI_CHEMISTRY,
+      REVIEWED_HYDRATE_AMBIGUITY).
     permissible_values:
       CREATED:
         description: Record created
@@ -470,6 +526,14 @@ enums:
         description: Exact alternative name
       RELATED_SYNONYM:
         description: Related but not identical
+      EXACT:
+        description: >-
+          Shorthand alias for EXACT_SYNONYM emitted by some import tooling;
+          retained for backward compatibility with existing records.
+      RELATED:
+        description: >-
+          Shorthand alias for RELATED_SYNONYM emitted by some import tooling;
+          retained for backward compatibility with existing records.
       RAW_TEXT:
         description: Raw text from original data
       ABBREVIATION:
@@ -501,6 +565,23 @@ enums:
         description: Based on text similarity metrics
       CROSS_REFERENCE:
         description: Cross-reference to other database
+      LEXICAL_MATCH:
+        description: >-
+          Lexical (token-overlap / normalized-name) match against an ontology
+          label or synonym.
+      CAS_RN_CROSS_REFERENCE:
+        description: >-
+          Identity established via CAS Registry Number cross-reference rather
+          than ontology label match.
+      MANUAL_CURATION:
+        description: >-
+          Manually curated evidence supplied by a human reviewer (distinct
+          from CURATOR_JUDGMENT, which records the decision rather than the
+          source of evidence).
+      MANUAL_REVIEW:
+        description: Identity confirmed during a manual review pass.
+      CURATOR_CONFIRMED_SYNONYM:
+        description: Curator confirmed a synonym match found by tooling.
 
   EvidenceSupportEnum:
     description: How a cited reference relates to the claim it is attached to

--- a/src/mediaingredientmech/schema/mediaingredientmech.yaml
+++ b/src/mediaingredientmech/schema/mediaingredientmech.yaml
@@ -304,7 +304,7 @@ classes:
       action:
         range: string
         required: true
-        pattern: "^[A-Z][A-Z0-9_]*$"
+        pattern: "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"
         description: >-
           Type of curation action. Free-form SCREAMING_SNAKE_CASE label minted
           by the curation tool that produced this event. CurationActionEnum

--- a/src/mediaingredientmech/validation/schema_validator.py
+++ b/src/mediaingredientmech/validation/schema_validator.py
@@ -80,12 +80,26 @@ _EVIDENCE_TYPES = _enum_values("EvidenceTypeEnum") if SCHEMA_PATH.exists() else 
 _SYNONYM_TYPES = _enum_values("SynonymTypeEnum") if SCHEMA_PATH.exists() else set()
 # Curation `action` is `range: string` in the schema (curation tooling mints
 # new labels freely). The pattern that constrains it lives in the schema —
-# read it from there so the validator can't drift.
-_ACTION_PATTERN = (
-    re.compile(_slot_pattern("CurationEvent", "action") or r"^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$")
-    if SCHEMA_PATH.exists()
-    else re.compile(r"^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$")
-)
+# read it from there so the validator can't drift. Fall back to a hard-coded
+# default if the schema file is missing entirely; surface schema-level regex
+# errors with a clear message so module import fails fast.
+_DEFAULT_ACTION_PATTERN = r"^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"
+
+
+def _compile_action_pattern() -> re.Pattern[str]:
+    if not SCHEMA_PATH.exists():
+        return re.compile(_DEFAULT_ACTION_PATTERN)
+    declared = _slot_pattern("CurationEvent", "action") or _DEFAULT_ACTION_PATTERN
+    try:
+        return re.compile(declared)
+    except re.error as exc:
+        raise RuntimeError(
+            f"Invalid CurationEvent.action pattern in {SCHEMA_PATH}: "
+            f"{declared!r} ({exc})"
+        ) from exc
+
+
+_ACTION_PATTERN = _compile_action_pattern()
 
 
 def _check_required(data: dict, field_name: str, path: str, msgs: list[ValidationMessage]):

--- a/src/mediaingredientmech/validation/schema_validator.py
+++ b/src/mediaingredientmech/validation/schema_validator.py
@@ -31,6 +31,14 @@ def _enum_values(enum_name: str) -> set[str]:
     return set(enum_def.get("permissible_values", {}).keys())
 
 
+def _slot_pattern(class_name: str, slot_name: str) -> str | None:
+    """Return the `pattern:` declared on a class attribute in the schema, or None."""
+    schema = _load_schema()
+    cls = schema.get("classes", {}).get(class_name, {})
+    attr = cls.get("attributes", {}).get(slot_name, {})
+    return attr.get("pattern")
+
+
 @dataclass
 class ValidationMessage:
     level: str  # "error" or "warning"
@@ -71,8 +79,13 @@ _MAPPING_QUALITIES = _enum_values("MappingQualityEnum") if SCHEMA_PATH.exists() 
 _EVIDENCE_TYPES = _enum_values("EvidenceTypeEnum") if SCHEMA_PATH.exists() else set()
 _SYNONYM_TYPES = _enum_values("SynonymTypeEnum") if SCHEMA_PATH.exists() else set()
 # Curation `action` is `range: string` in the schema (curation tooling mints
-# new labels freely). The action label must still follow SCREAMING_SNAKE_CASE.
-_ACTION_PATTERN = re.compile(r"^[A-Z][A-Z0-9_]*$")
+# new labels freely). The pattern that constrains it lives in the schema —
+# read it from there so the validator can't drift.
+_ACTION_PATTERN = (
+    re.compile(_slot_pattern("CurationEvent", "action") or r"^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$")
+    if SCHEMA_PATH.exists()
+    else re.compile(r"^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$")
+)
 
 
 def _check_required(data: dict, field_name: str, path: str, msgs: list[ValidationMessage]):

--- a/src/mediaingredientmech/validation/schema_validator.py
+++ b/src/mediaingredientmech/validation/schema_validator.py
@@ -70,32 +70,9 @@ _MAPPING_STATUSES = _enum_values("MappingStatusEnum") if SCHEMA_PATH.exists() el
 _MAPPING_QUALITIES = _enum_values("MappingQualityEnum") if SCHEMA_PATH.exists() else set()
 _EVIDENCE_TYPES = _enum_values("EvidenceTypeEnum") if SCHEMA_PATH.exists() else set()
 _SYNONYM_TYPES = _enum_values("SynonymTypeEnum") if SCHEMA_PATH.exists() else set()
-_CURATION_ACTIONS = _enum_values("CurationActionEnum") if SCHEMA_PATH.exists() else set()
-
-
-def _check_open_enum(
-    data: dict,
-    field_name: str,
-    allowed: set[str],
-    path: str,
-    msgs: list[ValidationMessage],
-):
-    """Warn (not error) on values outside an enum that grows organically.
-
-    Several enums in the schema (ontology_source, mapping_quality, evidence_type,
-    synonym_type, action) lag the live data: tooling mints new permissible
-    values without schema bumps. Errors here just produce noise — warnings still
-    surface typos without flooding the report.
-    """
-    val = data.get(field_name)
-    if val is not None and val not in allowed:
-        msgs.append(
-            ValidationMessage(
-                "warning",
-                path,
-                f"Unknown value '{val}' for '{field_name}' (not in schema enum)",
-            )
-        )
+# Curation `action` is `range: string` in the schema (curation tooling mints
+# new labels freely). The action label must still follow SCREAMING_SNAKE_CASE.
+_ACTION_PATTERN = re.compile(r"^[A-Z][A-Z0-9_]*$")
 
 
 def _check_required(data: dict, field_name: str, path: str, msgs: list[ValidationMessage]):
@@ -143,7 +120,7 @@ def _validate_mapping_evidence(ev: Any, path: str, msgs: list[ValidationMessage]
         msgs.append(ValidationMessage("error", path, "Evidence entry must be a mapping"))
         return
     _check_required(ev, "evidence_type", path, msgs)
-    _check_open_enum(ev, "evidence_type", _EVIDENCE_TYPES, path, msgs)
+    _check_enum(ev, "evidence_type", _EVIDENCE_TYPES, path, msgs)
     score = ev.get("confidence_score")
     if score is not None:
         try:
@@ -177,8 +154,8 @@ def _validate_ontology_mapping(mapping: Any, path: str, msgs: list[ValidationMes
             )
         )
 
-    _check_open_enum(mapping, "ontology_source", _ONTOLOGY_SOURCES, path, msgs)
-    _check_open_enum(mapping, "mapping_quality", _MAPPING_QUALITIES, path, msgs)
+    _check_enum(mapping, "ontology_source", _ONTOLOGY_SOURCES, path, msgs)
+    _check_enum(mapping, "mapping_quality", _MAPPING_QUALITIES, path, msgs)
 
     for i, ev in enumerate(mapping.get("evidence") or []):
         _validate_mapping_evidence(ev, f"{path}.evidence[{i}]", msgs)
@@ -189,7 +166,7 @@ def _validate_synonym(syn: Any, path: str, msgs: list[ValidationMessage]):
         msgs.append(ValidationMessage("error", path, "Synonym entry must be a mapping"))
         return
     _check_required(syn, "synonym_text", path, msgs)
-    _check_open_enum(syn, "synonym_type", _SYNONYM_TYPES, path, msgs)
+    _check_enum(syn, "synonym_type", _SYNONYM_TYPES, path, msgs)
     _check_type(syn, "occurrence_count", int, "integer", path, msgs)
 
 
@@ -210,7 +187,15 @@ def _validate_curation_event(evt: Any, path: str, msgs: list[ValidationMessage])
     _check_required(evt, "timestamp", path, msgs)
     _check_required(evt, "curator", path, msgs)
     _check_required(evt, "action", path, msgs)
-    _check_open_enum(evt, "action", _CURATION_ACTIONS, path, msgs)
+    action = evt.get("action")
+    if action is not None and not _ACTION_PATTERN.match(str(action)):
+        msgs.append(
+            ValidationMessage(
+                "error",
+                path,
+                f"action '{action}' does not match pattern {_ACTION_PATTERN.pattern}",
+            )
+        )
     _check_enum(evt, "previous_status", _MAPPING_STATUSES, path, msgs)
     _check_enum(evt, "new_status", _MAPPING_STATUSES, path, msgs)
     _check_type(evt, "llm_assisted", bool, "boolean", path, msgs)

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -188,7 +188,20 @@ class TestSchemaEnums:
 
     def test_mapping_quality_values(self):
         values = set(self.enums["MappingQualityEnum"]["permissible_values"].keys())
-        expected = {"EXACT_MATCH", "SYNONYM_MATCH", "CLOSE_MATCH", "MANUAL_CURATION", "LLM_ASSISTED", "PROVISIONAL"}
+        expected = {
+            "EXACT_MATCH",
+            "SYNONYM_MATCH",
+            "CLOSE_MATCH",
+            "MANUAL_CURATION",
+            "LLM_ASSISTED",
+            "PROVISIONAL",
+            "NARROW_MATCH",
+            "BROAD_MATCH",
+            "LEXICAL_MATCH",
+            "CAS_RN_LOOKUP",
+            "FALLBACK_REGISTRY",
+            "PLACEHOLDER",
+        }
         assert values == expected
 
     def test_ontology_source_enum_exists(self):
@@ -196,7 +209,20 @@ class TestSchemaEnums:
 
     def test_ontology_source_values(self):
         values = set(self.enums["OntologySourceEnum"]["permissible_values"].keys())
-        expected = {"CHEBI", "FOODON", "NCIT", "MESH", "UBERON", "ENVO"}
+        expected = {
+            "CHEBI",
+            "FOODON",
+            "NCIT",
+            "MESH",
+            "UBERON",
+            "ENVO",
+            "MICRO",
+            "BTO",
+            "CAS",
+            "registry",
+            "kgmicrobe.compound",
+            "kgmicrobe.ingredient",
+        }
         assert values == expected
 
     def test_curation_action_enum_exists(self):
@@ -218,6 +244,8 @@ class TestSchemaEnums:
         expected = {
             "EXACT_SYNONYM",
             "RELATED_SYNONYM",
+            "EXACT",
+            "RELATED",
             "RAW_TEXT",
             "ABBREVIATION",
             "COMMON_NAME",
@@ -234,7 +262,19 @@ class TestSchemaEnums:
 
     def test_evidence_type_values(self):
         values = set(self.enums["EvidenceTypeEnum"]["permissible_values"].keys())
-        expected = {"DATABASE_MATCH", "CURATOR_JUDGMENT", "LLM_SUGGESTION", "LITERATURE", "TEXT_SIMILARITY", "CROSS_REFERENCE"}
+        expected = {
+            "DATABASE_MATCH",
+            "CURATOR_JUDGMENT",
+            "LLM_SUGGESTION",
+            "LITERATURE",
+            "TEXT_SIMILARITY",
+            "CROSS_REFERENCE",
+            "LEXICAL_MATCH",
+            "CAS_RN_CROSS_REFERENCE",
+            "MANUAL_CURATION",
+            "MANUAL_REVIEW",
+            "CURATOR_CONFIRMED_SYNONYM",
+        }
         assert values == expected
 
     def test_all_enum_values_have_descriptions(self):

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -423,10 +423,18 @@ class TestFixtureDataValidation:
                     )
 
     def test_all_curation_actions_valid(self):
+        # CurationEvent.action is range: string with a SCREAMING_SNAKE_CASE
+        # pattern (CurationActionEnum is documentation-only). Validate against
+        # the schema's declared pattern, not enum membership.
+        action_pattern_str = (
+            self.schema["classes"]["CurationEvent"]["attributes"]["action"]["pattern"]
+        )
+        action_pattern = re.compile(action_pattern_str)
         for fixture_file in ["sample_mapped.yaml", "sample_unmapped.yaml"]:
             data = self._load_fixture(fixture_file)
             for rec in data["ingredients"]:
                 for event in rec.get("curation_history", []):
-                    assert event["action"] in self.enum_values["CurationActionEnum"], (
-                        f"Invalid action: {event['action']} in {rec['identifier']}"
+                    assert action_pattern.match(event["action"]), (
+                        f"Invalid action: {event['action']} in {rec['identifier']} "
+                        f"(does not match {action_pattern_str})"
                     )


### PR DESCRIPTION
## Summary

Resolves the enum-drift workaround introduced in #6. The validator briefly downgraded five enum slots to warn-only because their schema values lagged what live curation tooling was producing. This PR brings the schema into line and puts the validator back to strict-by-default.

**Four bounded enums** now enumerate every value present in `data/curated/` and `data/ingredients/`:

- `OntologySourceEnum` (12 values) — added `MICRO`, `BTO`, `CAS`, `registry`, `kgmicrobe.compound`, `kgmicrobe.ingredient`.
- `MappingQualityEnum` (12 values) — added `NARROW_MATCH`, `BROAD_MATCH`, `LEXICAL_MATCH`, `CAS_RN_LOOKUP`, `FALLBACK_REGISTRY`, `PLACEHOLDER`.
- `EvidenceTypeEnum` (11 values) — added `LEXICAL_MATCH`, `CAS_RN_CROSS_REFERENCE`, `MANUAL_CURATION`, `MANUAL_REVIEW`, `CURATOR_CONFIRMED_SYNONYM`.
- `SynonymTypeEnum` (12 values) — added `EXACT` / `RELATED` as backward-compat aliases for `EXACT_SYNONYM` / `RELATED_SYNONYM` produced by some import tooling.

**`CurationEvent.action`** is converted from `range: CurationActionEnum` to `range: string` with `pattern: ^[A-Z][A-Z0-9_]*$`. Live data has 117 distinct action labels and continues to grow; enumerating them was not the right shape. The `CurationActionEnum` definition is kept as a documentation-only reference list of well-known labels.

The validator's earlier `_check_open_enum` helper is removed; the four bounded slots use `_check_enum` again. The `action` field now gets a pattern check.

## Test plan

- [x] `python scripts/validate_all.py --mode both --no-oak` → 0 errors, 0 warnings across 2276 files
- [x] `PYTHONPATH=src pytest -o addopts='' tests/ --ignore=tests/test_merge_tracking.py --ignore=tests/test_merge_integration.py --ignore=tests/test_purity_detection.py` → 209/209 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)