### PR TITLE
Expand CurationActionEnum to a useful reference set

### DIFF
--- a/src/mediaingredientmech/schema/mediaingredientmech.yaml
+++ b/src/mediaingredientmech/schema/mediaingredientmech.yaml
@@ -498,10 +498,11 @@ enums:
       The `action` slot on CurationEvent has range `string` constrained by a
       SCREAMING_SNAKE_CASE pattern, not membership in this enum — curation
       tools mint new labels freely (live data has 117 distinct values as of
-      2026-05-12). The labels below cover the top ~20 most frequent actions
-      (>93% of all curation events) and the original baseline operations;
-      new tools should reuse one of these names when applicable rather than
-      inventing a near-duplicate.
+      2026-05-12). The 25 labels below cover the 9 baseline operation verbs
+      plus the most frequent automated/classification/merge labels observed
+      in live data (together >93% of all curation events). New tools should
+      reuse one of these names when applicable rather than inventing a
+      near-duplicate.
     permissible_values:
       # --- Baseline curation operations (semantic verbs) ---
       CREATED:

--- a/src/mediaingredientmech/schema/mediaingredientmech.yaml
+++ b/src/mediaingredientmech/schema/mediaingredientmech.yaml
@@ -495,30 +495,70 @@ enums:
   CurationActionEnum:
     description: >-
       Documentation-only reference list of well-known curation action labels.
-      The `action` slot on CurationEvent has range `string` (not this enum) —
-      curation tools mint new labels freely (live data has 110+ distinct
-      values). New labels should follow SCREAMING_SNAKE_CASE and convey both
-      the operation and its source (e.g. AUTO_BACKFILL_CHEBI_CHEMISTRY,
-      REVIEWED_HYDRATE_AMBIGUITY).
+      The `action` slot on CurationEvent has range `string` constrained by a
+      SCREAMING_SNAKE_CASE pattern, not membership in this enum — curation
+      tools mint new labels freely (live data has 117 distinct values as of
+      2026-05-12). The labels below cover the top ~20 most frequent actions
+      (>93% of all curation events) and the original baseline operations;
+      new tools should reuse one of these names when applicable rather than
+      inventing a near-duplicate.
     permissible_values:
+      # --- Baseline curation operations (semantic verbs) ---
       CREATED:
-        description: Record created
+        description: Record minted by a curator or import tool.
       IMPORTED:
-        description: Imported from external source
+        description: Record imported from an external source.
       MAPPED:
-        description: Ontology mapping added
-      SYNONYM_ADDED:
-        description: Synonym added
-      VALIDATED:
-        description: Mapping validated
-      CORRECTED:
-        description: Mapping or data corrected
-      MERGED:
-        description: Merged with another record
-      STATUS_CHANGED:
-        description: Mapping status changed
+        description: Ontology mapping added or replaced.
       ANNOTATED:
-        description: Notes or metadata added
+        description: Notes or freeform metadata added.
+      CORRECTED:
+        description: Mapping or data corrected (in response to a review finding).
+      MERGED:
+        description: Record merged with another record.
+      STATUS_CHANGED:
+        description: "`mapping_status` field changed."
+      VALIDATED:
+        description: Mapping validated against ontology or reference data.
+      SYNONYM_ADDED:
+        description: Single synonym added (cf. plural ADDED_SYNONYMS for batch).
+      # --- Most frequent automated actions (live data) ---
+      AUTO_CLASSIFY_INGREDIENT_TYPE:
+        description: "Automated `ingredient_type` classification (single chemical, defined medium, mixture, stock)."
+      AUTO_BACKFILL_CHEBI_CHEMISTRY:
+        description: Automated backfill of molecular formula / SMILES / InChI from ChEBI.
+      AUTO_BACKFILL_PUBCHEM_CHEMISTRY:
+        description: Automated backfill of chemical properties from PubChem.
+      ADDED_SYNONYMS:
+        description: Batch synonym add (multiple synonyms in one event).
+      ADDED_CAS_RN:
+        description: CAS Registry Number added to a record.
+      CAS_RN_ADDED:
+        description: >-
+          Legacy alias for ADDED_CAS_RN emitted by older tooling. Prefer
+          ADDED_CAS_RN in new code.
+      # --- Provenance of unmapped/placeholder records ---
+      CREATED_AS_UNMAPPED:
+        description: Record minted in the UNMAPPED state, awaiting ontology lookup.
+      CREATED_FROM_CULTUREBOTHT:
+        description: Record imported from the CultureBot HT pipeline.
+      CREATED_FROM_CAS_LOOKUP:
+        description: Record created after resolving an unmapped name via CAS lookup.
+      CREATED_FROM_CAS_FALLBACK:
+        description: Record created with a `cas:` fallback identity when no ontology term was found.
+      CREATED_FROM_KGM_PLACEHOLDER:
+        description: Record created from a kg-microbe placeholder ingredient row.
+      # --- Classification & merge ---
+      CLASSIFIED_UNDEFINED_MIXTURE:
+        description: Classified as an undefined mixture (yeast extract, peptone, ...).
+      CLASSIFIED_STOCK_SOLUTION:
+        description: Classified as a stock solution / premix.
+      CLASSIFIED_DEFINED_MEDIUM:
+        description: Classified as a complete defined-medium recipe.
+      MERGED_FROM_DUPLICATES:
+        description: Duplicate records consolidated into this representative.
+      BACKFILL_PARENT_CHEBI:
+        description: "`parent_ingredient` populated by lookup against CHEBI hierarchy."
 
   SynonymTypeEnum:
     permissible_values:

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -233,19 +233,34 @@ class TestSchemaEnums:
         # is string + pattern). The enum should still document the original
         # baseline verbs and the most frequent labels observed in live data
         # — assert a subset rather than equality so new reference values can
-        # be added without breaking the test.
+        # be added without breaking the test. The required `frequent` set
+        # mirrors every non-baseline label introduced by the reference-set
+        # expansion so the test guards what the PR is actually documenting.
         values = set(self.enums["CurationActionEnum"]["permissible_values"].keys())
         baseline = {
             "CREATED", "IMPORTED", "MAPPED", "SYNONYM_ADDED",
             "VALIDATED", "CORRECTED", "MERGED", "STATUS_CHANGED", "ANNOTATED",
         }
         frequent = {
+            # Most frequent automated actions
             "AUTO_CLASSIFY_INGREDIENT_TYPE",
             "AUTO_BACKFILL_CHEBI_CHEMISTRY",
+            "AUTO_BACKFILL_PUBCHEM_CHEMISTRY",
             "ADDED_SYNONYMS",
             "ADDED_CAS_RN",
+            "CAS_RN_ADDED",
+            # Provenance of unmapped / placeholder records
             "CREATED_AS_UNMAPPED",
+            "CREATED_FROM_CULTUREBOTHT",
+            "CREATED_FROM_CAS_LOOKUP",
+            "CREATED_FROM_CAS_FALLBACK",
+            "CREATED_FROM_KGM_PLACEHOLDER",
+            # Classification & merge
+            "CLASSIFIED_UNDEFINED_MIXTURE",
+            "CLASSIFIED_STOCK_SOLUTION",
+            "CLASSIFIED_DEFINED_MEDIUM",
             "MERGED_FROM_DUPLICATES",
+            "BACKFILL_PARENT_CHEBI",
         }
         missing = (baseline | frequent) - values
         assert not missing, (

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -228,13 +228,29 @@ class TestSchemaEnums:
     def test_curation_action_enum_exists(self):
         assert "CurationActionEnum" in self.enums
 
-    def test_curation_action_values(self):
+    def test_curation_action_values_include_baseline_and_frequent(self):
+        # CurationActionEnum is documentation-only (range of CurationEvent.action
+        # is string + pattern). The enum should still document the original
+        # baseline verbs and the most frequent labels observed in live data
+        # — assert a subset rather than equality so new reference values can
+        # be added without breaking the test.
         values = set(self.enums["CurationActionEnum"]["permissible_values"].keys())
-        expected = {
+        baseline = {
             "CREATED", "IMPORTED", "MAPPED", "SYNONYM_ADDED",
             "VALIDATED", "CORRECTED", "MERGED", "STATUS_CHANGED", "ANNOTATED",
         }
-        assert values == expected
+        frequent = {
+            "AUTO_CLASSIFY_INGREDIENT_TYPE",
+            "AUTO_BACKFILL_CHEBI_CHEMISTRY",
+            "ADDED_SYNONYMS",
+            "ADDED_CAS_RN",
+            "CREATED_AS_UNMAPPED",
+            "MERGED_FROM_DUPLICATES",
+        }
+        missing = (baseline | frequent) - values
+        assert not missing, (
+            f"CurationActionEnum is missing reference labels: {sorted(missing)}"
+        )
 
     def test_synonym_type_enum_exists(self):
         assert "SynonymTypeEnum" in self.enums


### PR DESCRIPTION
## Summary

`CurationActionEnum` became documentation-only in #8 (range of `CurationEvent.action` is now `string` + pattern). Its 9 baseline verbs covered only a small fraction of the 117 distinct labels actually emitted by curation tooling. This PR expands the enum to a useful subset and updates the test to assert that the subset is present rather than pinning an exact equality.

**Schema** — `CurationActionEnum.permissible_values` now has 22 entries grouped by purpose:

- 9 baseline operations (CREATED, IMPORTED, MAPPED, ANNOTATED, CORRECTED, MERGED, STATUS_CHANGED, VALIDATED, SYNONYM_ADDED).
- The top frequent automated actions: AUTO_CLASSIFY_INGREDIENT_TYPE, AUTO_BACKFILL_CHEBI_CHEMISTRY, AUTO_BACKFILL_PUBCHEM_CHEMISTRY, ADDED_SYNONYMS, ADDED_CAS_RN, CAS_RN_ADDED.
- Provenance of unmapped / placeholder records: CREATED_AS_UNMAPPED, CREATED_FROM_CULTUREBOTHT, CREATED_FROM_CAS_LOOKUP, CREATED_FROM_CAS_FALLBACK, CREATED_FROM_KGM_PLACEHOLDER.
- Classification & merge: CLASSIFIED_UNDEFINED_MIXTURE, CLASSIFIED_STOCK_SOLUTION, CLASSIFIED_DEFINED_MEDIUM, MERGED_FROM_DUPLICATES, BACKFILL_PARENT_CHEBI.

These cover >93% of all curation events observed in live data as of 2026-05-12. The enum description spells out documentation-only intent and that the slot's real constraint is the SCREAMING_SNAKE_CASE pattern.

**Tests** — `test_curation_action_values` (renamed to `test_curation_action_values_include_baseline_and_frequent`) now asserts a required subset rather than exact equality, so the reference set can grow without test churn.

## Test plan

- [x] `python scripts/validate_all.py --mode both --no-oak` → 0 errors / 0 warnings / 2276 files
- [x] `PYTHONPATH=src pytest -o addopts='' tests/` → 209/209 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)