### PR TITLE
CI: authenticate qc-evidence claw checkout with CLAW_READ_TOKEN

### DIFF
--- a/.github/workflows/qc-evidence.yaml
+++ b/.github/workflows/qc-evidence.yaml
@@ -31,6 +31,11 @@ jobs:
         with:
           repository: CultureBotAI/culturebotai-claw
           path: culturebotai-claw
+          # CLAW_READ_TOKEN is a fine-grained PAT with Contents:Read on
+          # CultureBotAI/culturebotai-claw, set as an Actions secret on
+          # this repo. The default GITHUB_TOKEN can't read the private
+          # sibling.
+          token: ${{ secrets.CLAW_READ_TOKEN }}
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary

The `qc-evidence` GitHub Actions workflow has been failing on every push/PR since it was introduced because its default `GITHUB_TOKEN` can't read the sibling private repo `CultureBotAI/culturebotai-claw` (where `scripts/validate_evidence_references.py` lives). This PR points the `actions/checkout@v4` step at a dedicated repo secret, `CLAW_READ_TOKEN`, that has `Contents: Read` on claw.

## Provisioning (already done for this repo)

The secret has been added as a repo-level Actions secret on `CultureBotAI/MediaIngredientMech`. The PAT itself is a fine-grained token, scoped to **`CultureBotAI/culturebotai-claw`** only, with **Contents: Read-only**. Future maintainers re-provisioning the secret should follow the same scope.

## Verified

- Manual `workflow_dispatch` against this branch: run `25957509903` → **success** (claw checkout, validator run, artifact upload all complete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)