### PR TITLE
schema: add pubchem_cid + cas_rn to match live data

### DIFF
--- a/src/mediaingredientmech/schema/mediaingredientmech.yaml
+++ b/src/mediaingredientmech/schema/mediaingredientmech.yaml
@@ -218,6 +218,13 @@ classes:
       molecular_weight:
         range: float
         description: Molecular weight in g/mol
+      pubchem_cid:
+        range: integer
+        description: >-
+          PubChem Compound IDentifier (CID), stored as a positive integer.
+          Populated by the PubChem enrichment path in
+          `enrich_chemical_properties.py` when chemical properties are
+          sourced from PubChem rather than ChEBI.
       data_source:
         description: Source of chemical properties (e.g., ChEBI, PubChem, CultureBotHT/MicroMediaParam)
       retrieval_date:
@@ -238,6 +245,13 @@ classes:
         description: Confidence score (0.0-1.0)
       notes:
         description: Additional context
+      cas_rn:
+        description: >-
+          CAS Registry Number that supports this evidence row. Set by the
+          CAS-RN cross-reference resolver (`evidence_type: CAS_RN_CROSS_REFERENCE`)
+          when an ontology term was matched via its CAS-RN rather than label
+          or synonym. Same format as `ChemicalProperties.cas_rn`.
+        pattern: "^\\d+-\\d+-\\d+$"
       pmid:
         description: PubMed ID for MEDLINE citations (e.g., 12345678)
         pattern: "^[0-9]+$"

--- a/src/mediaingredientmech/schema/mediaingredientmech.yaml
+++ b/src/mediaingredientmech/schema/mediaingredientmech.yaml
@@ -220,11 +220,12 @@ classes:
         description: Molecular weight in g/mol
       pubchem_cid:
         range: integer
+        minimum_value: 1
         description: >-
-          PubChem Compound IDentifier (CID), stored as a positive integer.
+          PubChem Compound Identifier (CID), stored as a positive integer.
           Populated by the PubChem enrichment path in
-          `enrich_chemical_properties.py` when chemical properties are
-          sourced from PubChem rather than ChEBI.
+          `scripts/enrich_chemical_properties.py` when chemical properties
+          are sourced from PubChem rather than ChEBI.
       data_source:
         description: Source of chemical properties (e.g., ChEBI, PubChem, CultureBotHT/MicroMediaParam)
       retrieval_date:


### PR DESCRIPTION
## Summary

First in a series of small schema-gap remediations identified by `/schema-gap-analysis` (PR #17). This one closes two systematic 'Additional properties are not allowed' classes from linkml-validate:

- **`pubchem_cid`** (185 records): added to `ChemicalProperties` as `range: integer`. PubChem CIDs are stored as positive ints in the data, so an integer range is the correct shape — a string pattern would fail every value because LinkML pattern checks only apply to strings.
- **`cas_rn`** (44 records): added to `MappingEvidence` with the same `^\d+-\d+-\d+$` pattern that's already on `ChemicalProperties.cas_rn`. Curation tooling that resolves an ontology term via CAS-RN cross-reference attaches the resolved CAS-RN to its evidence row.

## Verification

`linkml-validate -s … -C IngredientCollection data/curated/{mapped,unmapped}_ingredients.yaml`:

| metric | before | after |
|---|---:|---:|
| total `[ERROR]` lines | 6653 | 6424 |
| `'pubchem_cid' was unexpected` | 185 | **0** |
| `'cas_rn' was unexpected` | 44 | **0** |

Custom validator (`scripts/validate_all.py`) and tests still green: 2275 files 0/0, pytest 209/209.

The remaining 6424 errors fall into three known classes (`identifier`/`ontology_id` slot naming, CURIE-pattern strictness, naive datetimes) — those are the next PRs in this series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)