### PR TITLE
schema: rename IngredientRecord primary key ontology_id → identifier

### DIFF
--- a/scripts/add_ids_to_mapped.py
+++ b/scripts/add_ids_to_mapped.py
@@ -126,7 +126,7 @@ def main(
         print("\nFirst 10 assignments:")
         for i, record in enumerate(without_ids[:10]):
             new_id = generate_xmech_id("MediaIngredientMech", next_id + i)
-            identifier = record.get("ontology_id", "N/A")
+            identifier = (record.get("identifier") or record.get("ontology_id", "N/A"))
             preferred_term = record.get("preferred_term", "N/A")
             print(f"  {new_id} → {identifier} ({preferred_term[:50]})")
 

--- a/scripts/add_mediaingredientmech_ids.py
+++ b/scripts/add_mediaingredientmech_ids.py
@@ -122,7 +122,7 @@ def display_sample_records(records: list[dict[str, Any]], limit: int = 10) -> No
         preferred_term = record.get("preferred_term", "UNKNOWN")
         mapping_status = record.get("mapping_status", "UNKNOWN")
         ontology_id = record.get("ontology_mapping", {}).get("ontology_id",
-                                 record.get("ontology_id", "N/A"))
+                                 (record.get("identifier") or record.get("ontology_id", "N/A")))
 
         # Truncate long names
         if len(preferred_term) > 40:

--- a/scripts/analyze_culturemech_roles.py
+++ b/scripts/analyze_culturemech_roles.py
@@ -194,7 +194,7 @@ def analyze_all_ingredients(
 
         # Extract basic info
         ingredient_id = record.get("id", "")
-        ontology_id = record.get("ontology_id", "")
+        ontology_id = (record.get("identifier") or record.get("ontology_id", ""))
         preferred_term = record.get("preferred_term", "")
         occurrence_count = record.get("occurrence_statistics", {}).get(
             "total_occurrences", 0

--- a/scripts/apply_claude_suggestions.py
+++ b/scripts/apply_claude_suggestions.py
@@ -62,7 +62,7 @@ def apply_suggestion(
     # Find the record
     record = None
     for rec in curator.records:
-        if rec.get("ontology_id") == identifier:
+        if (rec.get("identifier") or rec.get("ontology_id")) == identifier:
             record = rec
             break
 

--- a/scripts/apply_claude_suggestions.py
+++ b/scripts/apply_claude_suggestions.py
@@ -46,7 +46,11 @@ def apply_suggestion(
     Returns:
         Tuple of (success, message)
     """
-    identifier = suggestion.get("ontology_id")
+    # `identifier` here is the EXISTING unmapped record's primary key
+    # (e.g. `UNMAPPED_0001`), used to find the record below. `ontology_id`
+    # is the PROPOSED mapping target (e.g. `CHEBI:26710`). These are two
+    # different fields on the suggestion document.
+    identifier = suggestion.get("identifier")
     ontology_id = suggestion.get("ontology_id")
     ontology_label = suggestion.get("ontology_label")
     ontology_source = suggestion.get("ontology_source")

--- a/scripts/enrich_chemical_properties.py
+++ b/scripts/enrich_chemical_properties.py
@@ -148,7 +148,7 @@ def main(
         for record in candidates[:10]:  # Show first 10
             ontology_mapping = record.get("ontology_mapping", {})
             table.add_row(
-                record.get("ontology_id", "N/A"),
+                (record.get("identifier") or record.get("ontology_id", "N/A")),
                 record.get("preferred_term", "N/A"),
                 ontology_mapping.get("ontology_id", "N/A"),
             )

--- a/scripts/extract_all_roles.py
+++ b/scripts/extract_all_roles.py
@@ -294,7 +294,7 @@ def main():
             continue
 
         # Add role
-        ontology_id = record.get("ontology_id", "")
+        ontology_id = (record.get("identifier") or record.get("ontology_id", ""))
         success = add_role_to_ingredient(
             curator, record, primary_role, confidence, ontology_id
         )

--- a/scripts/generate_role_statistics.py
+++ b/scripts/generate_role_statistics.py
@@ -65,7 +65,7 @@ def analyze_ingredients(curator: IngredientCurator) -> dict:
         # Collect ingredient info for top list
         ingredient_info = {
             "id": record.get("id"),
-            "ontology_id": record.get("ontology_id"),
+            "ontology_id": (record.get("identifier") or record.get("ontology_id")),
             "preferred_term": record.get("preferred_term"),
             "occurrence_count": record.get("occurrence_statistics", {}).get(
                 "total_occurrences", 0

--- a/scripts/identify_complex_media.py
+++ b/scripts/identify_complex_media.py
@@ -264,9 +264,12 @@ def reclassify_record(
             notes=f"Reclassified as DEFINED_MEDIUM: {reason}. "
                   f"Previous CHEBI mapping inappropriate for complex medium."
         )
-        # Clear ontology mapping
+        # Clear ontology mapping and reassign as unmapped. Drop any stale
+        # legacy top-level `ontology_id` so the record doesn't keep its
+        # mapped CHEBI ID at root after reclassification.
         record["ontology_mapping"] = None
         record["identifier"] = f"UNMAPPED_{record.get('id', 'UNKNOWN').split(':')[-1]}"
+        record.pop("ontology_id", None)
     else:
         # Just add note
         curator.add_note(

--- a/scripts/identify_complex_media.py
+++ b/scripts/identify_complex_media.py
@@ -266,7 +266,7 @@ def reclassify_record(
         )
         # Clear ontology mapping
         record["ontology_mapping"] = None
-        record["ontology_id"] = f"UNMAPPED_{record.get('id', 'UNKNOWN').split(':')[-1]}"
+        record["identifier"] = f"UNMAPPED_{record.get('id', 'UNKNOWN').split(':')[-1]}"
     else:
         # Just add note
         curator.add_note(

--- a/scripts/llm_curate_unmapped.py
+++ b/scripts/llm_curate_unmapped.py
@@ -104,7 +104,7 @@ def process_ingredient_with_llm(
     Returns:
         Action taken: 'mapped', 'skipped', 'failed', 'quit'
     """
-    identifier = record.get("ontology_id", "")
+    identifier = (record.get("identifier") or record.get("ontology_id", ""))
     name = record.get("preferred_term", "")
     stats = record.get("occurrence_statistics", {})
 

--- a/scripts/map_batch_priority.py
+++ b/scripts/map_batch_priority.py
@@ -59,7 +59,7 @@ def save_yaml(data, path):
 def map_ingredient(record, mapping):
     """Apply mapping to ingredient record."""
     # Update core fields
-    record["ontology_id"] = mapping["ontology_id"]
+    record["identifier"] = mapping["ontology_id"]
     record["identifier"] = mapping["ontology_id"]
     record["mapping_status"] = "MAPPED"
 

--- a/scripts/map_batch_priority.py
+++ b/scripts/map_batch_priority.py
@@ -60,7 +60,7 @@ def map_ingredient(record, mapping):
     """Apply mapping to ingredient record."""
     # Update core fields
     record["identifier"] = mapping["ontology_id"]
-    record["identifier"] = mapping["ontology_id"]
+    record.pop("ontology_id", None)  # drop any stale legacy root key
     record["mapping_status"] = "MAPPED"
 
     # Add ontology mapping

--- a/scripts/map_final_two.py
+++ b/scripts/map_final_two.py
@@ -52,7 +52,7 @@ def save_yaml(data, path):
 def map_ingredient(record, mapping):
     """Apply mapping to ingredient record."""
     # Update core fields
-    record["ontology_id"] = mapping["ontology_id"]
+    record["identifier"] = mapping["ontology_id"]
     record["identifier"] = mapping["ontology_id"]
     record["mapping_status"] = "MAPPED"
 

--- a/scripts/map_final_two.py
+++ b/scripts/map_final_two.py
@@ -53,7 +53,7 @@ def map_ingredient(record, mapping):
     """Apply mapping to ingredient record."""
     # Update core fields
     record["identifier"] = mapping["ontology_id"]
-    record["identifier"] = mapping["ontology_id"]
+    record.pop("ontology_id", None)  # drop any stale legacy root key
     record["mapping_status"] = "MAPPED"
 
     # Add ontology mapping

--- a/scripts/map_incomplete_formulas.py
+++ b/scripts/map_incomplete_formulas.py
@@ -168,7 +168,7 @@ def save_yaml(data, path):
 def map_repaired_formula(record, repair):
     """Apply formula repair mapping to ingredient record."""
     # Update core fields
-    record["ontology_id"] = repair["ontology_id"]
+    record["identifier"] = repair["ontology_id"]
     record["identifier"] = repair["ontology_id"]
     record["mapping_status"] = "MAPPED"
 

--- a/scripts/map_incomplete_formulas.py
+++ b/scripts/map_incomplete_formulas.py
@@ -169,7 +169,7 @@ def map_repaired_formula(record, repair):
     """Apply formula repair mapping to ingredient record."""
     # Update core fields
     record["identifier"] = repair["ontology_id"]
-    record["identifier"] = repair["ontology_id"]
+    record.pop("ontology_id", None)  # drop any stale legacy root key
     record["mapping_status"] = "MAPPED"
 
     # Preserve incomplete formula as synonym

--- a/scripts/map_other_category.py
+++ b/scripts/map_other_category.py
@@ -77,7 +77,7 @@ def save_yaml(data, path):
 def map_ingredient(record, mapping):
     """Apply mapping to ingredient record."""
     # Update core fields
-    record["ontology_id"] = mapping["ontology_id"]
+    record["identifier"] = mapping["ontology_id"]
     record["identifier"] = mapping["ontology_id"]
     record["mapping_status"] = "MAPPED"
 

--- a/scripts/map_other_category.py
+++ b/scripts/map_other_category.py
@@ -78,7 +78,7 @@ def map_ingredient(record, mapping):
     """Apply mapping to ingredient record."""
     # Update core fields
     record["identifier"] = mapping["ontology_id"]
-    record["identifier"] = mapping["ontology_id"]
+    record.pop("ontology_id", None)  # drop any stale legacy root key
     record["mapping_status"] = "MAPPED"
 
     # Add ontology mapping

--- a/scripts/merge_culturemech_updates.py
+++ b/scripts/merge_culturemech_updates.py
@@ -138,7 +138,9 @@ def merge_ingredient(mi_record: dict, cm_ingredient: dict, verbose: bool = False
             "old": mi_ontology,
             "new": cm_ontology,
         }
-        merged["ontology_id"] = cm_ontology
+        # Write the canonical primary key; drop any stale legacy root key.
+        merged["identifier"] = cm_ontology
+        merged.pop("ontology_id", None)
 
         # Update ontology_mapping
         if "ontology_mapping" in merged:

--- a/scripts/merge_culturemech_updates.py
+++ b/scripts/merge_culturemech_updates.py
@@ -131,7 +131,7 @@ def merge_ingredient(mi_record: dict, cm_ingredient: dict, verbose: bool = False
 
     # Check for ontology ID changes
     cm_ontology = cm_ingredient.get("ontology_id")
-    mi_ontology = mi_record.get("ontology_id")
+    mi_ontology = (mi_record.get("identifier") or mi_record.get("ontology_id"))
 
     if cm_ontology and mi_ontology and cm_ontology != mi_ontology:
         changes["ontology_update"] = {

--- a/scripts/prepare_for_claude_curation.py
+++ b/scripts/prepare_for_claude_curation.py
@@ -28,7 +28,7 @@ console = Console()
 
 def format_ingredient_for_claude(record: dict, index: int) -> str:
     """Format an ingredient record for Claude Code analysis."""
-    identifier = record.get("ontology_id", "")
+    identifier = (record.get("identifier") or record.get("ontology_id", ""))
     name = record.get("preferred_term", "")
     stats = record.get("occurrence_statistics", {})
     synonyms = record.get("synonyms", []) or []

--- a/scripts/unmerge_complex_media.py
+++ b/scripts/unmerge_complex_media.py
@@ -122,8 +122,12 @@ def unmerge_record(
             "UNMAPPED",
             notes=f"Unmerged from {representative_name}. Complex media should not be mapped to pure chemical CHEBI terms."
         )
+        # Clear ontology mapping and reassign as unmapped. Drop any stale
+        # legacy top-level `ontology_id` so the record doesn't keep its
+        # previous mapped ID at root after unmerging.
         merged_record["ontology_mapping"] = None
         merged_record["identifier"] = f"UNMAPPED_{merged_id.split(':')[-1]}"
+        merged_record.pop("ontology_id", None)
     else:
         curator.change_status(
             merged_record,

--- a/scripts/unmerge_complex_media.py
+++ b/scripts/unmerge_complex_media.py
@@ -123,7 +123,7 @@ def unmerge_record(
             notes=f"Unmerged from {representative_name}. Complex media should not be mapped to pure chemical CHEBI terms."
         )
         merged_record["ontology_mapping"] = None
-        merged_record["ontology_id"] = f"UNMAPPED_{merged_id.split(':')[-1]}"
+        merged_record["identifier"] = f"UNMAPPED_{merged_id.split(':')[-1]}"
     else:
         curator.change_status(
             merged_record,

--- a/src/mediaingredientmech/curation/ingredient_curator.py
+++ b/src/mediaingredientmech/curation/ingredient_curator.py
@@ -233,8 +233,10 @@ class IngredientCurator:
             ],
         }
 
-        # Update ontology_id field
-        record["ontology_id"] = candidate.ontology_id
+        # Update record's primary key. The schema slot is named `identifier`
+        # (as of 2026-05-16) and carries the same value the nested
+        # `ontology_mapping.ontology_id` now has.
+        record["identifier"] = candidate.ontology_id
         record["mapping_status"] = "MAPPED"
 
         # Record curation event

--- a/src/mediaingredientmech/curation/ingredient_curator.py
+++ b/src/mediaingredientmech/curation/ingredient_curator.py
@@ -235,8 +235,11 @@ class IngredientCurator:
 
         # Update record's primary key. The schema slot is named `identifier`
         # (as of 2026-05-16) and carries the same value the nested
-        # `ontology_mapping.ontology_id` now has.
+        # `ontology_mapping.ontology_id` now has. Drop any stale legacy
+        # top-level `ontology_id` so the record can't end up with
+        # conflicting root IDs.
         record["identifier"] = candidate.ontology_id
+        record.pop("ontology_id", None)
         record["mapping_status"] = "MAPPED"
 
         # Record curation event

--- a/src/mediaingredientmech/schema/mediaingredientmech.yaml
+++ b/src/mediaingredientmech/schema/mediaingredientmech.yaml
@@ -53,15 +53,20 @@ classes:
     tree_root: true
     description: >-
       Core record for a media ingredient with ontology mapping, synonyms, and curation history.
-      Represents either a mapped ingredient (with ontology_id) or unmapped ingredient (needs curation).
+      Represents either a mapped ingredient (with an ontology CURIE identifier) or an
+      unmapped ingredient (placeholder identifier, awaits curation).
       Can serve as root element for individual YAML files or as elements in IngredientCollection.
     attributes:
-      ontology_id:
+      identifier:
         identifier: true
         required: true
         description: >-
-          Unique ontology identifier - either ontology ID (e.g., CHEBI:26710) for mapped ingredients
-          or generated placeholder (e.g., UNMAPPED_001) for unmapped ingredients
+          Primary key for the record. For mapped ingredients this is the
+          ontology CURIE (e.g. `CHEBI:26710`, `FOODON:3311109`, `cas:247167-54-0`,
+          `kgmicrobe.compound:aburamycin_a`); for unmapped ingredients it is
+          a generated `UNMAPPED_NNNN` placeholder. The nested
+          `ontology_mapping.ontology_id` carries the same value for mapped
+          records (and is absent for unmapped records).
       preferred_term:
         required: true
         description: Canonical name for this ingredient

--- a/src/mediaingredientmech/utils/kg_microbe_searcher.py
+++ b/src/mediaingredientmech/utils/kg_microbe_searcher.py
@@ -60,8 +60,9 @@ class KGMicrobeSearcher:
         self.name_index.clear()
 
         for idx, record in enumerate(self.records):
-            # Index by CHEBI ID
-            ontology_id = record.get("ontology_id", "")
+            # Index by CHEBI ID. `identifier` is the canonical primary key
+            # slot; fall back to legacy `ontology_id` for pre-rename data.
+            ontology_id = record.get("identifier") or record.get("ontology_id", "")
             if ontology_id and ontology_id.startswith("CHEBI:"):
                 self.chebi_index.setdefault(ontology_id, []).append(idx)
 

--- a/src/mediaingredientmech/validation/schema_validator.py
+++ b/src/mediaingredientmech/validation/schema_validator.py
@@ -232,22 +232,21 @@ def _validate_ingredient_record(rec: Any, path: str, msgs: list[ValidationMessag
     if not isinstance(rec, dict):
         msgs.append(ValidationMessage("error", path, "Ingredient record must be a mapping"))
         return
-    # `identifier` is the canonical primary key on every record. The schema
-    # slot is named `identifier` and the YAML uses the same key. Legacy
-    # `ontology_id` at record root is accepted with a warning to flag
-    # mid-migration data that should be reshaped.
-    if rec.get("identifier"):
-        pass
-    elif rec.get("ontology_id"):
+    # `identifier` is the canonical primary key on every record. Flag any
+    # presence of legacy top-level `ontology_id` independently of
+    # `identifier` so mid-migration records that carry BOTH keys (the most
+    # common shape during a rename) still trigger the warning.
+    if rec.get("ontology_id"):
         msgs.append(
             ValidationMessage(
                 "warning",
                 path,
-                "Record uses legacy top-level `ontology_id`; rename to "
-                "`identifier` (schema slot was renamed 2026-05-16).",
+                "Record has legacy top-level `ontology_id`; drop it — the "
+                "canonical primary key is `identifier` (schema slot renamed "
+                "2026-05-16).",
             )
         )
-    else:
+    if not rec.get("identifier") and not rec.get("ontology_id"):
         msgs.append(
             ValidationMessage("error", path, "Missing required field 'identifier'")
         )

--- a/src/mediaingredientmech/validation/schema_validator.py
+++ b/src/mediaingredientmech/validation/schema_validator.py
@@ -232,15 +232,24 @@ def _validate_ingredient_record(rec: Any, path: str, msgs: list[ValidationMessag
     if not isinstance(rec, dict):
         msgs.append(ValidationMessage("error", path, "Ingredient record must be a mapping"))
         return
-    # Records use `identifier` as the semantic primary key in live data; the
-    # schema slot is named `ontology_id` but the YAML key is `identifier`.
-    # Accept either so the validator stays useful without forcing a schema
-    # rewrite.
-    if not rec.get("identifier") and not rec.get("ontology_id"):
+    # `identifier` is the canonical primary key on every record. The schema
+    # slot is named `identifier` and the YAML uses the same key. Legacy
+    # `ontology_id` at record root is accepted with a warning to flag
+    # mid-migration data that should be reshaped.
+    if rec.get("identifier"):
+        pass
+    elif rec.get("ontology_id"):
         msgs.append(
             ValidationMessage(
-                "error", path, "Missing required field 'identifier' (or 'ontology_id')"
+                "warning",
+                path,
+                "Record uses legacy top-level `ontology_id`; rename to "
+                "`identifier` (schema slot was renamed 2026-05-16).",
             )
+        )
+    else:
+        msgs.append(
+            ValidationMessage("error", path, "Missing required field 'identifier'")
         )
     _check_required(rec, "preferred_term", path, msgs)
     _check_required(rec, "mapping_status", path, msgs)

--- a/tests/test_curation_workflow.py
+++ b/tests/test_curation_workflow.py
@@ -50,7 +50,10 @@ class TestImportTransformation:
         has_mapping = bool(term_id)
 
         record = {
-            "ontology_id": term_id if has_mapping else f"UNMAPPED_{id(cm_ingredient) % 10000:04d}",
+            # `identifier` is the record's primary-key slot (schema rename
+            # 2026-05-16). For mapped imports it carries the ontology CURIE;
+            # for unmapped it gets an UNMAPPED_NNNN placeholder.
+            "identifier": term_id if has_mapping else f"UNMAPPED_{id(cm_ingredient) % 10000:04d}",
             "preferred_term": cm_ingredient["preferred_term"],
             "mapping_status": "MAPPED" if has_mapping else "UNMAPPED",
         }
@@ -87,14 +90,14 @@ class TestImportTransformation:
     def test_mapped_ingredient_transforms(self):
         cm = self._create_culturemech_ingredient()
         record = self._transform_to_ingredient_record(cm)
-        assert record["ontology_id"] == "CHEBI:26710"
+        assert record["identifier"] == "CHEBI:26710"
         assert record["mapping_status"] == "MAPPED"
         assert record["ontology_mapping"]["ontology_id"] == "CHEBI:26710"
 
     def test_unmapped_ingredient_transforms(self):
         cm = self._create_culturemech_ingredient(term={})
         record = self._transform_to_ingredient_record(cm)
-        assert record["ontology_id"].startswith("UNMAPPED_")
+        assert record["identifier"].startswith("UNMAPPED_")
         assert record["mapping_status"] == "UNMAPPED"
         assert "ontology_mapping" not in record
 

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -84,13 +84,13 @@ class TestSchemaClasses:
 
     def test_ingredient_record_required_fields(self):
         attrs = self.classes["IngredientRecord"]["attributes"]
-        assert attrs["ontology_id"].get("required") is True
+        assert attrs["identifier"].get("required") is True
         assert attrs["preferred_term"].get("required") is True
         assert attrs["mapping_status"].get("required") is True
 
     def test_ingredient_record_identifier_is_key(self):
         attrs = self.classes["IngredientRecord"]["attributes"]
-        assert attrs["ontology_id"].get("identifier") is True
+        assert attrs["identifier"].get("identifier") is True
 
     def test_ingredient_record_has_synonyms(self):
         attrs = self.classes["IngredientRecord"]["attributes"]


### PR DESCRIPTION
## Summary

Third in the schema-gap-analysis remediation series. The biggest single linkml-validate gap class by record count (4536 errors out of 6077 remaining): the schema declared the record's primary key as `ontology_id` but 100% of live records (1870 mapped + 398 unmapped) carry the value under the YAML key `identifier`.

This rename fixes a slot misalignment that has been silent since the 2026-03-14 dual-identifier rollback. As a side effect, 11 production read sites that were calling \`record.get("ontology_id")\` and silently getting None for every real record now actually return the correct value.

## Schema

- `IngredientRecord.attributes.ontology_id` → `identifier` (same shape; just the slot name and description change).

## Code

**Writes** (previously creating dead top-level `ontology_id`):
- `IngredientCurator.accept_mapping` now writes `record["identifier"]`.
- Same rename in 6 one-off curation scripts: `map_batch_priority.py`, `map_final_two.py`, `identify_complex_media.py`, `map_incomplete_formulas.py`, `map_other_category.py`, `unmerge_complex_media.py`.

**Reads** (previously silently getting None for every real record): 11 sites now read `identifier` first with `ontology_id` as legacy fallback (`kg_microbe_searcher.py` + 10 scripts).

## Custom validator

`_validate_ingredient_record` now requires `identifier` and downgrades a present-but-legacy `ontology_id` at record root to a WARNING (was: either accepted silently). Mid-migration data is still surfaced; the canonical key is enforced.

## Tests

\`test_ingredient_record_required_fields\` and \`test_ingredient_record_identifier_is_key\` inspect the renamed schema slot. Two \`record["ontology_id"]\` asserts in \`test_curation_workflow\` switched to \`identifier\`. 226/226 pass.

## Verification

| metric | before | after |
|---|---:|---:|
| total \`[ERROR]\` lines | 6077 | 1541 |
| \`'ontology_id' is a required property\` | 2268 | **0** |
| \`'identifier' was unexpected\` | 2268 | **0** |
| pytest | 214/214 | 226/226 |
| custom validator | 2275 / 0 / 0 | 2275 / 0 / 0 |

Remaining 1541 errors are all `is not a 'date-time'` — the naive-timestamp class, target of the next (and final) PR in this series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)