### PR TITLE
generators: emit timezone-aware timestamps in YAML-bound writes

### DIFF
--- a/scripts/apply_corrections.py
+++ b/scripts/apply_corrections.py
@@ -12,7 +12,7 @@ import argparse
 import json
 import sys
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 
 from rich.console import Console
 
@@ -109,7 +109,7 @@ def apply_correction(correction: dict, ingredient: dict) -> dict:
         corrected["curation_history"] = []
 
     corrected["curation_history"].append({
-        "timestamp": datetime.now().isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
         "event": "correction_applied",
         "details": {
             "action": action,

--- a/scripts/auto_correct.py
+++ b/scripts/auto_correct.py
@@ -12,7 +12,7 @@ Usage:
 import argparse
 import sys
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 
 from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TimeElapsedColumn
@@ -136,7 +136,7 @@ def main():
                         corrected["curation_history"] = []
 
                     corrected["curation_history"].append({
-                        "timestamp": datetime.now().isoformat(),
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
                         "curator": "auto_correct.py",
                         "action": "AUTO_CORRECTION_APPLIED",
                         "changes": (

--- a/scripts/batch_curate.py
+++ b/scripts/batch_curate.py
@@ -14,7 +14,7 @@ import os
 from pathlib import Path
 import click
 import yaml
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Dict, Any, Optional
 
 # Add src to path
@@ -309,7 +309,7 @@ def batch_curate(
     report_file = report_dir / f"batch_curation_{datetime.now().strftime('%Y%m%d_%H%M%S')}.yaml"
 
     report = {
-        "timestamp": datetime.now().isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
         "parameters": {
             "batch_size": batch_size,
             "auto_accept_threshold": auto_accept_threshold,

--- a/scripts/batch_curate_unmapped.py
+++ b/scripts/batch_curate_unmapped.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import csv
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -86,7 +86,7 @@ class BatchCurationSession:
             data = {
                 'processed_ids': list(self.processed_ids),
                 'decisions': self.decisions,
-                'last_updated': datetime.now().isoformat(),
+                'last_updated': datetime.now(timezone.utc).isoformat(),
             }
             self.resume_file.parent.mkdir(parents=True, exist_ok=True)
             with open(self.resume_file, 'w') as f:
@@ -422,7 +422,7 @@ class BatchCurationSession:
             'ontology_label': ontology_label,
             'quality': quality,
             'normalization_rules': ', '.join(norm_result.get('applied_rules', [])),
-            'timestamp': datetime.now().isoformat(),
+            'timestamp': datetime.now(timezone.utc).isoformat(),
         })
         self.processed_ids.add(identifier)
 

--- a/scripts/batch_review.py
+++ b/scripts/batch_review.py
@@ -13,7 +13,7 @@ import argparse
 import json
 import sys
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, List
 
 import yaml
@@ -130,7 +130,7 @@ def generate_json_report(result, output_path: Path):
     """Generate JSON validation report."""
     report_data = {
         "metadata": {
-            "generated": datetime.now().isoformat(),
+            "generated": datetime.now(timezone.utc).isoformat(),
             "total_reviewed": sum(result.summary.values()),
             "summary": result.summary,
         },

--- a/scripts/download_ontologies.py
+++ b/scripts/download_ontologies.py
@@ -15,7 +15,7 @@ import hashlib
 import json
 import sys
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 
 import requests
 from rich.console import Console
@@ -112,7 +112,7 @@ def download_ontology(source: str, url: str, force: bool = False) -> bool:
         manifest = load_manifest()
         manifest[source.lower()] = {
             "url": url,
-            "downloaded": datetime.now().isoformat(),
+            "downloaded": datetime.now(timezone.utc).isoformat(),
             "md5": md5,
             "size_mb": round(size_mb, 1),
             "status": "valid",

--- a/scripts/enrich_from_ols.py
+++ b/scripts/enrich_from_ols.py
@@ -14,7 +14,7 @@ import json
 import sys
 import time
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 
 import yaml
 from rich.console import Console
@@ -177,7 +177,7 @@ def main():
                             ingredient["curation_history"] = []
 
                         ingredient["curation_history"].append({
-                            "timestamp": datetime.now().isoformat(),
+                            "timestamp": datetime.now(timezone.utc).isoformat(),
                             "curator": "enrich_from_ols.py",
                             "action": "AUTO_BACKFILL_CHEBI_CHEMISTRY",
                             "changes": (

--- a/scripts/generate_complex_media_report.py
+++ b/scripts/generate_complex_media_report.py
@@ -14,7 +14,7 @@ Usage:
 import argparse
 import sys
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -194,7 +194,7 @@ def generate_yaml_report(
         output_path: Path to output file.
     """
     report = {
-        "generation_date": datetime.now().isoformat(),
+        "generation_date": datetime.now(timezone.utc).isoformat(),
         "data_source": str(curator.data_path),
         "total_records": len(curator.records),
         "summary": {

--- a/scripts/generate_role_statistics.py
+++ b/scripts/generate_role_statistics.py
@@ -14,7 +14,7 @@ Output: data/analysis/role_statistics_report.yaml
 import sys
 from pathlib import Path
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timezone
 
 import yaml
 
@@ -137,7 +137,7 @@ def generate_report(stats: dict, output_path: Path):
 
     # Build report structure
     report = {
-        "generation_date": datetime.now().isoformat(),
+        "generation_date": datetime.now(timezone.utc).isoformat(),
         "summary": {
             "total_ingredients": total_ingredients,
             "with_roles": with_roles,

--- a/scripts/validate_synonyms.py
+++ b/scripts/validate_synonyms.py
@@ -12,7 +12,7 @@ Usage:
 import argparse
 import sys
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 
 from rich.console import Console
 from rich.table import Table
@@ -164,7 +164,7 @@ def add_missing_synonyms(
         ingredient["curation_history"] = []
 
     ingredient["curation_history"].append({
-        "timestamp": datetime.now().isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
         "curator": "validate_synonyms.py",
         "action": "ADDED_SYNONYMS",
         "changes": (

--- a/src/mediaingredientmech/export/report_generator.py
+++ b/src/mediaingredientmech/export/report_generator.py
@@ -2,7 +2,7 @@
 
 import json
 from collections import Counter
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -145,7 +145,7 @@ def generate_report(data_dir: Path | None = None) -> dict[str, Any]:
     curator_progress = compute_curator_progress(mapped_data)
 
     return {
-        "generated_at": datetime.now().isoformat(),
+        "generated_at": datetime.now(timezone.utc).isoformat(),
         "statistics": stats,
         "curation_history": curation_history,
         "curator_progress": curator_progress,

--- a/src/mediaingredientmech/validation/ingredient_reviewer.py
+++ b/src/mediaingredientmech/validation/ingredient_reviewer.py
@@ -14,7 +14,7 @@ import time
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Any, Tuple
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from datetime import datetime
+from datetime import datetime, timezone
 
 import requests
 
@@ -191,7 +191,7 @@ class IngredientReviewer:
             return ReviewResult(
                 status="PASS",
                 metadata={
-                    "timestamp": datetime.now().isoformat(),
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
                     "duration_ms": int((time.time() - start_time) * 1000),
                     "skipped": "Not mapped",
                 },
@@ -212,7 +212,7 @@ class IngredientReviewer:
                 issues=issues,
                 suggestions=suggestions,
                 metadata={
-                    "timestamp": datetime.now().isoformat(),
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
                     "duration_ms": int((time.time() - start_time) * 1000),
                     "rules_checked": ["P1"],
                 },
@@ -254,7 +254,7 @@ class IngredientReviewer:
             issues=issues,
             suggestions=suggestions,
             metadata={
-                "timestamp": datetime.now().isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
                 "duration_ms": duration_ms,
                 "rules_checked": ["P1", "P2", "P3", "P4"],
             },


### PR DESCRIPTION
## Summary

Process-axis fix for the last gap class linkml-validate was flagging — `is not a 'date-time'` on every naive `datetime.now().isoformat()` call site that wrote into curated YAML (1541 errors against the canonical collections alone). RFC 3339 / JSON Schema's \`date-time\` format requires a \`Z\` or \`±HH:MM\` suffix.

## Code change

15 call sites across 12 files: \`datetime.now().isoformat()\` → \`datetime.now(timezone.utc).isoformat()\`. \`timezone\` added to the \`from datetime import …\` line where needed.

\`strftime("%Y%m%d_%H%M%S")\` filename and display sites are left alone — they don't end up in validated YAML.

## What this PR doesn't do

It doesn't migrate the ~3082 existing naive timestamps in \`data/\` (566 files). Those records would keep failing the schema until naturally regenerated. The data migration is in a follow-up PR (\`process-timezone-aware-timestamps-data\`) which is purely mechanical and is split off because the diff is well over Copilot's 300-file review limit.

## Verification

\`linkml-validate\` against both collections is still 1541 errors after this PR alone (existing data unchanged); after the follow-up data PR it drops to 0.

\`pytest\` 226/226 and \`scripts/validate_all.py\` 2275 / 0 / 0 stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)