### PR TITLE
Add schema-gap-analysis skill + initial findings note

### DIFF
--- a/.claude/skills/schema-gap-analysis/SKILL.md
+++ b/.claude/skills/schema-gap-analysis/SKILL.md
@@ -50,7 +50,9 @@ runtime back to 1.9.x:
 ```
 
 (Upgrading `linkml` to a release that ships with 1.10-runtime is the
-permanent fix; until then, pinning the runtime is the simplest path.)
+permanent fix; until then, pinning the runtime is the simplest path.
+Setup is one-time: once the pin is in `.venv/`, every subsequent
+invocation of the skill works without reinstalling.)
 
 ## The three-axis perspective
 
@@ -152,20 +154,40 @@ Signs:
    above. Capture findings; don't change anything yet.
 
 6. **Cross-check the process axis.** The biggest blind spots come from
-   generator code that has slowly drifted. Two `grep`s usually catch most
-   of it:
+   generator code that has slowly drifted. Three targeted greps catch the
+   most common patterns without producing noise:
 
    ```bash
-   # Naive datetimes (no timezone) — anywhere there's a `datetime.now()`
-   # without `timezone.utc`:
+   # Naive datetimes (no timezone) — every place a `datetime.now()`
+   # appears without `timezone.utc`. High-signal: today's run finds 18+
+   # call sites and every one is real.
    grep -rn "datetime.now()" src/ scripts/ --include='*.py' \
      | grep -v "timezone"
 
-   # Direct YAML writes that skip IngredientCurator and may drop required
-   # collection metadata:
-   grep -rn 'yaml.dump' scripts/ --include='*.py' \
-     | grep -v "default_flow_style"
+   # Saves that drop collection metadata: yaml.dump receives a literal
+   # one-key {"ingredients": ...} dict, which throws away
+   # generation_date / total_count / mapped_count / unmapped_count.
+   # Should be empty in current code.
+   grep -rnE 'yaml\.dump\(\s*\{\s*["\047]ingredients["\047]\s*:' \
+     src/ scripts/ --include='*.py'
+
+   # Direct writes to a canonical curated collection file that skip
+   # IngredientCurator. Should also be empty in current code — every
+   # collection-touching script must round-trip through the curator so
+   # the top-level metadata is recomputed.
+   grep -rln 'mapped_ingredients\.yaml\|unmapped_ingredients\.yaml' \
+     scripts/ --include='*.py' \
+     | while read f; do
+         grep -q 'IngredientCurator' "$f" || echo "$f"
+       done
    ```
+
+   The earlier version of this step used a single noisy
+   `grep yaml.dump | grep -v default_flow_style` that surfaced six
+   call sites of which only one had ever been the real bug. The three
+   greps above are calibrated against the actual fix history: the
+   datetime grep is high-recall on a known real pattern, and the latter
+   two are precision filters that should stay empty.
 
 7. **Decide and apply fixes.** Usually a mix: rename/alias the canonical
    slot on the schema, broaden patterns, add missing slots, fix the

--- a/.claude/skills/schema-gap-analysis/SKILL.md
+++ b/.claude/skills/schema-gap-analysis/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: schema-gap-analysis
+description: Find gaps and inconsistencies between the LinkML schema, the YAML instance records, and the code that generates them — using linkml-validate as ground truth and reporting along three axes (schema, instances, process).
+category: quality
+requires_database: false
+requires_internet: false
+version: 1.0.0
+---
+
+# Schema gap analysis
+
+## When to use
+
+Run this skill when:
+
+- You suspect the schema and the live data have drifted apart (e.g. the custom
+  `scripts/validate_all.py` reports clean while curation tooling is happily
+  writing keys the schema doesn't declare).
+- A new field is being added in code and you want to know whether the schema
+  needs updating, the data needs migrating, or both.
+- A new contributor asks "is this YAML valid?" and the answer needs to be more
+  rigorous than "the project's custom validator says yes."
+
+The custom validator in `src/mediaingredientmech/validation/schema_validator.py`
+was deliberately built to be tolerant (open enums, broadened CURIE pattern,
+accepts both `identifier` and `ontology_id` as the primary key). That's good
+for CI ergonomics, but it hides real schema-vs-data divergence. This skill
+uses **`linkml-validate`** — the upstream tool — as a stricter ground truth.
+
+## Setup
+
+LinkML is normally installed in `.venv/`, but two things bite:
+
+**1. `pip` is sometimes missing from the venv.** Bootstrap it if needed:
+
+```bash
+.venv/bin/python -m ensurepip
+```
+
+**2. Version mismatch between `linkml` and `linkml-runtime` is the most
+common breakage.** As of 2026-05-16 the venv ships `linkml 1.9.3` and
+`linkml-runtime 1.10.0`; runtime 1.10 dropped `Format.JSON` which 1.9.x
+imports at module load, so `linkml-validate` aborts on import with
+`AttributeError: type object 'Format' has no attribute 'JSON'`. Pin the
+runtime back to 1.9.x:
+
+```bash
+.venv/bin/python -m pip install "linkml-runtime>=1.9,<1.10"
+.venv/bin/linkml-validate --help  # smoke test
+```
+
+(Upgrading `linkml` to a release that ships with 1.10-runtime is the
+permanent fix; until then, pinning the runtime is the simplest path.)
+
+## The three-axis perspective
+
+Every error `linkml-validate` reports fits one of these classes. Always ask
+"which axis owns the fix?" before patching anything.
+
+### Axis 1 — schema
+
+The schema (`src/mediaingredientmech/schema/mediaingredientmech.yaml`) is
+wrong: a slot is missing, a pattern is too strict, or a name has drifted
+from what tooling has standardized on. Fix is to edit the schema; data and
+generators stay the same.
+
+Signs:
+
+- Hundreds-to-thousands of records fail the same way (the data is
+  consistent, the schema is not).
+- The field name in the error is one you can see in the actual data files
+  and recognize as canonical.
+- The pattern in the error is older than recent design discussions
+  (e.g. `^[A-Z]+:[0-9]+$` predating multi-prefix CURIE support).
+
+### Axis 2 — instance records
+
+The data is wrong: a record has a typo, an unexpected key from a one-off
+script, or a malformed value. Fix is to migrate the affected records.
+
+Signs:
+
+- A small number of records fail; most don't.
+- The field name is suspicious (typo, abandoned experimental key).
+- The value is malformed in a way that suggests human entry, not tooling
+  (e.g. a single bad timestamp among thousands of well-formed ones).
+
+### Axis 3 — process
+
+The generator code is wrong: it emits structurally valid YAML that
+nonetheless violates the schema. Fix is to update the script(s) so future
+runs produce conformant output, then optionally rewrite affected data.
+
+Signs:
+
+- Errors cluster by source tool (every record imported by
+  `import_from_culturemech.py`, every event written by `accept_mapping`).
+- A field that is otherwise correct is consistently in the wrong shape
+  (naive vs. aware timestamps; lowercase vs. SCREAMING_SNAKE_CASE labels).
+- `git blame` on the offending line in the generator points at a single
+  commit that introduced the divergence.
+
+## Procedure
+
+1. **Make linkml-validate runnable** (see Setup).
+2. **Validate the canonical collection files.** These are the simplest
+   single-shot validation targets and surface the bulk of issues:
+
+   ```bash
+   .venv/bin/linkml-validate \
+     -s src/mediaingredientmech/schema/mediaingredientmech.yaml \
+     -C IngredientCollection \
+     data/curated/mapped_ingredients.yaml \
+     data/curated/unmapped_ingredients.yaml
+   ```
+
+3. **Validate one individual record** to confirm the same issues affect
+   on-disk per-ingredient files (different file shape, same schema class):
+
+   ```bash
+   SAMPLE=$(ls data/ingredients/mapped/*.yaml | head -1)
+   .venv/bin/linkml-validate \
+     -s src/mediaingredientmech/schema/mediaingredientmech.yaml \
+     -C IngredientRecord "$SAMPLE"
+   ```
+
+4. **Histogram the errors** so you see the distinct issue classes, not the
+   thousands of per-record repetitions:
+
+   ```bash
+   .venv/bin/linkml-validate -s <schema> -C IngredientCollection \
+       data/curated/mapped_ingredients.yaml 2>&1 \
+     | grep -oE "Additional properties are not allowed \('[^']+'" \
+     | sort | uniq -c | sort -rn
+
+   .venv/bin/linkml-validate -s <schema> -C IngredientCollection \
+       data/curated/mapped_ingredients.yaml 2>&1 \
+     | grep -oE "does not match '[^']+'" \
+     | sort | uniq -c | sort -rn
+
+   .venv/bin/linkml-validate -s <schema> -C IngredientCollection \
+       data/curated/mapped_ingredients.yaml 2>&1 \
+     | grep -oE "is not a '[^']+'" \
+     | sort | uniq -c | sort -rn
+
+   .venv/bin/linkml-validate -s <schema> -C IngredientCollection \
+       data/curated/mapped_ingredients.yaml 2>&1 \
+     | grep -c "is a required property"
+   ```
+
+5. **For each distinct class, decide the axis** using the heuristics
+   above. Capture findings; don't change anything yet.
+
+6. **Cross-check the process axis.** The biggest blind spots come from
+   generator code that has slowly drifted. Two `grep`s usually catch most
+   of it:
+
+   ```bash
+   # Naive datetimes (no timezone) — anywhere there's a `datetime.now()`
+   # without `timezone.utc`:
+   grep -rn "datetime.now()" src/ scripts/ --include='*.py' \
+     | grep -v "timezone"
+
+   # Direct YAML writes that skip IngredientCurator and may drop required
+   # collection metadata:
+   grep -rn 'yaml.dump' scripts/ --include='*.py' \
+     | grep -v "default_flow_style"
+   ```
+
+7. **Decide and apply fixes.** Usually a mix: rename/alias the canonical
+   slot on the schema, broaden patterns, add missing slots, fix the
+   handful of malformed records, and patch the offending generators
+   (timezone, action label, key name) so the next regeneration is clean.
+
+8. **Re-run linkml-validate.** Exit code 0 with no errors is the target.
+   Until then, document remaining divergences in a project memory file so
+   they don't get rediscovered every session.
+
+## Common gap classes seen in this repo
+
+| Error fragment | Likely class | Typical fix |
+|---|---|---|
+| `'X' is a required property` for thousands of records | Schema axis: slot is named wrong | Add `aliases:` to the canonical slot, or rename it to match data |
+| `Additional properties are not allowed ('X' was unexpected)` for thousands | Schema axis: slot missing from the schema entirely | Add the slot to the appropriate class |
+| `Additional properties are not allowed ('X' was unexpected)` for a handful | Instance axis (typo) or process axis (one tool emits a wrong key) | Migrate records / fix generator |
+| `does not match '<regex>'` | Schema axis if the regex hasn't caught up to legitimate values; instance axis if a single record is malformed | Broaden the schema pattern or correct the record |
+| `is not a 'date-time'` | Process axis: generator emits naive datetimes | Replace `datetime.now()` with `datetime.now(timezone.utc)` |
+| `Invalid value 'X' for enum Y` | Schema axis if Y is an organically growing vocabulary; process axis if a tool emits typos | Enumerate observed values OR convert the slot to `range: string` with a pattern, depending on whether the vocabulary is bounded |
+
+## Anti-patterns
+
+- **Don't patch the custom validator alone.** It's already permissive; the
+  whole point of running linkml-validate is to find what the custom
+  validator hides.
+- **Don't silently rename a slot in the schema without also updating
+  `src/mediaingredientmech/`** — `_check_required`, `_validate_*` helpers,
+  and tests still reference the old name. `git grep` the slot name before
+  renaming.
+- **Don't fix instance records with `sed`.** Round-trip through
+  `IngredientCurator.load()/save()` so the canonical YAML formatting is
+  preserved and the collection-level metadata (`generation_date`,
+  `total_count`, etc.) is correctly recomputed.
+- **Don't add fields to the schema without aliasing.** If the new field
+  partially overlaps with an existing one (e.g. `cas_rn` on both
+  `ChemicalProperties` and `MappingEvidence`), make sure both classes
+  declare it explicitly or factor a common slot.
+
+## Pointers
+
+- Custom validator (intentionally tolerant): `src/mediaingredientmech/validation/schema_validator.py`.
+- Schema: `src/mediaingredientmech/schema/mediaingredientmech.yaml`.
+- Generators that affect curated YAML shape: `src/mediaingredientmech/curation/ingredient_curator.py`, `scripts/aggregate_records.py`, every `scripts/enrich_*`, `scripts/apply_*`, `scripts/auto_correct.py`.
+- Memory of past validator alignment work: `~/.claude/projects/.../memory/validator_behavior.md`.
+- Memory of the primary-key history: `~/.claude/projects/.../memory/identifier_correction.md`.

--- a/.claude/skills/schema-gap-analysis/skill.md
+++ b/.claude/skills/schema-gap-analysis/skill.md
@@ -127,26 +127,27 @@ Signs:
    ```
 
 4. **Histogram the errors** so you see the distinct issue classes, not the
-   thousands of per-record repetitions:
+   thousands of per-record repetitions. Run against **both** canonical
+   collections — a gap that lives only in `unmapped_ingredients.yaml` is
+   silently dropped if only `mapped_ingredients.yaml` is histogrammed:
 
    ```bash
-   .venv/bin/linkml-validate -s <schema> -C IngredientCollection \
-       data/curated/mapped_ingredients.yaml 2>&1 \
+   SCHEMA=src/mediaingredientmech/schema/mediaingredientmech.yaml
+   COLS="data/curated/mapped_ingredients.yaml data/curated/unmapped_ingredients.yaml"
+
+   .venv/bin/linkml-validate -s $SCHEMA -C IngredientCollection $COLS 2>&1 \
      | grep -oE "Additional properties are not allowed \('[^']+'" \
      | sort | uniq -c | sort -rn
 
-   .venv/bin/linkml-validate -s <schema> -C IngredientCollection \
-       data/curated/mapped_ingredients.yaml 2>&1 \
+   .venv/bin/linkml-validate -s $SCHEMA -C IngredientCollection $COLS 2>&1 \
      | grep -oE "does not match '[^']+'" \
      | sort | uniq -c | sort -rn
 
-   .venv/bin/linkml-validate -s <schema> -C IngredientCollection \
-       data/curated/mapped_ingredients.yaml 2>&1 \
+   .venv/bin/linkml-validate -s $SCHEMA -C IngredientCollection $COLS 2>&1 \
      | grep -oE "is not a '[^']+'" \
      | sort | uniq -c | sort -rn
 
-   .venv/bin/linkml-validate -s <schema> -C IngredientCollection \
-       data/curated/mapped_ingredients.yaml 2>&1 \
+   .venv/bin/linkml-validate -s $SCHEMA -C IngredientCollection $COLS 2>&1 \
      | grep -c "is a required property"
    ```
 
@@ -158,10 +159,13 @@ Signs:
    most common patterns without producing noise:
 
    ```bash
-   # Naive datetimes (no timezone) — every place a `datetime.now()`
-   # appears without `timezone.utc`. High-signal: today's run finds 18+
-   # call sites and every one is real.
-   grep -rn "datetime.now()" src/ scripts/ --include='*.py' \
+   # Naive datetimes (no timezone) — every `datetime.now()` that's
+   # NOT for a `.strftime(...)` filename/display call (which doesn't
+   # end up in validated YAML). The `\.isoformat\b` filter restricts
+   # to writes that produce ISO-8601 strings (the schema's `date-time`
+   # format).
+   grep -rnE 'datetime\.now\(\)\.isoformat\b' \
+     src/ scripts/ --include='*.py' \
      | grep -v "timezone"
 
    # Saves that drop collection metadata: yaml.dump receives a literal
@@ -171,23 +175,25 @@ Signs:
    grep -rnE 'yaml\.dump\(\s*\{\s*["\047]ingredients["\047]\s*:' \
      src/ scripts/ --include='*.py'
 
-   # Direct writes to a canonical curated collection file that skip
-   # IngredientCurator. Should also be empty in current code — every
-   # collection-touching script must round-trip through the curator so
-   # the top-level metadata is recomputed.
-   grep -rln 'mapped_ingredients\.yaml\|unmapped_ingredients\.yaml' \
-     scripts/ --include='*.py' \
-     | while read f; do
-         grep -q 'IngredientCurator' "$f" || echo "$f"
-       done
+   # Direct WRITES to a canonical curated collection file that skip
+   # IngredientCurator. Match `open(..., "w"/"a")` literally so we
+   # don't false-positive on scripts that merely *mention* the
+   # filename (which the earlier "any mention" version of this grep
+   # did — analyze/categorize/prepare-style scripts that read the
+   # file or print its name kept showing up).
+   grep -rnE 'open\([^)]*(mapped|unmapped)_ingredients\.yaml[^)]*["\047][wa][bt]?["\047]' \
+     scripts/ src/ --include='*.py'
    ```
 
    The earlier version of this step used a single noisy
    `grep yaml.dump | grep -v default_flow_style` that surfaced six
    call sites of which only one had ever been the real bug. The three
-   greps above are calibrated against the actual fix history: the
-   datetime grep is high-recall on a known real pattern, and the latter
-   two are precision filters that should stay empty.
+   greps above are calibrated against the actual fix history of this
+   repo. Even so, the first one (naive `datetime.now()`) can
+   occasionally surface a filename/display call site that doesn't go
+   to validated YAML (e.g. `report_generator.py` writing
+   `"generated_at"` into a top-level JSON report) — read the line
+   before classifying it as a process-axis bug.
 
 7. **Decide and apply fixes.** Usually a mix: rename/alias the canonical
    slot on the schema, broaden patterns, add missing slots, fix the
@@ -202,7 +208,7 @@ Signs:
 
 | Error fragment | Likely class | Typical fix |
 |---|---|---|
-| `'X' is a required property` for thousands of records | Schema axis: slot is named wrong | Add `aliases:` to the canonical slot, or rename it to match data |
+| `'X' is a required property` for thousands of records | Schema axis: slot is named wrong | Rename the slot in the schema to match what the data carries (note: LinkML `aliases:` is descriptive metadata only — it does NOT make `linkml-validate` accept an alternate YAML key; rename is the actual fix). See PR #19 for an example. |
 | `Additional properties are not allowed ('X' was unexpected)` for thousands | Schema axis: slot missing from the schema entirely | Add the slot to the appropriate class |
 | `Additional properties are not allowed ('X' was unexpected)` for a handful | Instance axis (typo) or process axis (one tool emits a wrong key) | Migrate records / fix generator |
 | `does not match '<regex>'` | Schema axis if the regex hasn't caught up to legitimate values; instance axis if a single record is malformed | Broaden the schema pattern or correct the record |
@@ -232,5 +238,5 @@ Signs:
 - Custom validator (intentionally tolerant): `src/mediaingredientmech/validation/schema_validator.py`.
 - Schema: `src/mediaingredientmech/schema/mediaingredientmech.yaml`.
 - Generators that affect curated YAML shape: `src/mediaingredientmech/curation/ingredient_curator.py`, `scripts/aggregate_records.py`, every `scripts/enrich_*`, `scripts/apply_*`, `scripts/auto_correct.py`.
-- Memory of past validator alignment work: `~/.claude/projects/.../memory/validator_behavior.md`.
-- Memory of the primary-key history: `~/.claude/projects/.../memory/identifier_correction.md`.
+- Most recent end-to-end remediation pass: `notes/schema_gap_analysis_2026-05-16.md` (the six gap classes the skill turned up, plus the PR that closed each).
+- Primary-key history is described inline in the schema (`IngredientRecord.identifier`'s `description:` block) — the `ontology_id` → `identifier` rename happened in PR #19.

--- a/notes/schema_gap_analysis_2026-05-16.md
+++ b/notes/schema_gap_analysis_2026-05-16.md
@@ -1,0 +1,61 @@
+# Schema / instance / process gap analysis
+
+**Date**: 2026-05-16
+**Tool**: `linkml-validate` (linkml 1.9.3, linkml-runtime pinned to 1.9.x)
+**Schema**: `src/mediaingredientmech/schema/mediaingredientmech.yaml`
+**Data**: 1870 mapped + 398 unmapped + 2268 individual records (`data/curated/` + `data/ingredients/`)
+
+This is a snapshot of the divergences `linkml-validate` finds when run against
+the current schema and curated data. The methodology lives in
+`.claude/skills/schema-gap-analysis/SKILL.md`; this file records what it
+turned up this session so we don't rediscover the same gaps next time.
+
+## Findings ranked by blast radius
+
+| # | Error | Axis | Records affected | Fix sketch |
+|---|---|---|---:|---|
+| 1 | `'ontology_id' is a required property` and `Additional properties are not allowed ('identifier')` | Schema | 2268 (all) | Alias or rename: data uses `identifier`; schema slot is `ontology_id`. Either add `aliases: [identifier]` on the schema slot OR rename it. See [[identifier_system_dual]] memory for context. |
+| 2 | `does not match '^[A-Z]+:[0-9]+$'` on `ontology_mapping.ontology_id` | Schema | 311 | The custom validator was broadened to `^[A-Za-z][A-Za-z0-9.]*:[A-Za-z0-9][A-Za-z0-9._-]*$`. Apply the same broadening to the schema `pattern:` on `OntologyMapping.ontology_id`. |
+| 3 | `is not a 'date-time'` (naive timestamps without offset) | Process | 1537 | `accept_mapping()`, `ingredient_reviewer.py`, several `scripts/*` use `datetime.now()` instead of `datetime.now(timezone.utc)`. Fix the generators; one-shot rewrite of affected records is optional. |
+| 4 | `Additional properties are not allowed ('pubchem_cid')` on `chemical_properties` | Schema | 185 | Add `pubchem_cid` to `ChemicalProperties` (range: string, pattern `^[0-9]+$`). |
+| 5 | `does not match '^CHEBI:[0-9]+$'` on `kg_microbe_node_id` | Schema | 31 | Pattern too narrow; current data has non-CHEBI prefixes here too. Broaden similarly to (2). |
+| 6 | `Additional properties are not allowed ('cas_rn')` on `ontology_mapping.evidence[]` | Schema | 44 | Add `cas_rn` to `MappingEvidence` (range: string, pattern `^\d+-\d+-\d+$`) — already defined on `ChemicalProperties`; promote to a reusable slot. |
+
+Total error count: ~5848 across 2275 files (every issue above is systematic — none are isolated record bugs).
+
+## Process-axis hot spots
+
+`grep -rn 'datetime.now()' src/ scripts/ --include='*.py' | grep -v timezone`
+turns up these generators writing naive timestamps:
+
+- `src/mediaingredientmech/validation/ingredient_reviewer.py` (3 sites)
+- `src/mediaingredientmech/export/report_generator.py`
+- `scripts/download_ontologies.py`
+- `scripts/batch_curate.py` (2 sites)
+- `scripts/batch_curate_unmapped.py` (2 sites)
+- and ~10 more under `scripts/`
+
+The collection-level `generation_date` written by `scripts/aggregate_records.py`
+is already timezone-aware; only record-level / event-level timestamps are
+affected.
+
+## Suggested remediation order
+
+1. **Schema first (no migration risk)**: items 2, 4, 5, 6 — broaden patterns
+   and add missing slots. After this, the only remaining errors are #1 and #3.
+2. **Identifier slot alias (item 1)**: add `aliases: [identifier]` to the
+   `IngredientRecord.ontology_id` slot rather than renaming, so old callers
+   keep working. Re-run validation: residual errors should be zero except
+   the timestamps.
+3. **Generator fixes (item 3)**: switch `datetime.now()` → `datetime.now(timezone.utc)`
+   in every site grep finds. Optional follow-up: a one-shot pass over
+   `data/curated/` + `data/ingredients/` to retrofit the existing naive
+   timestamps with `+00:00` so historical records also validate.
+
+## Not addressed yet
+
+- The `OntologyMapping.ontology_label` field is required by the schema but
+  several records have `ontology_label: null` in the source YAML. Run a
+  separate `grep "ontology_label: null"` pass before fixing #1, because
+  those will become visible once the slot-name issue stops dominating the
+  error output.

--- a/notes/schema_gap_analysis_2026-05-16.md
+++ b/notes/schema_gap_analysis_2026-05-16.md
@@ -59,3 +59,23 @@ affected.
   separate `grep "ontology_label: null"` pass before fixing #1, because
   those will become visible once the slot-name issue stops dominating the
   error output.
+
+## Resolution (2026-05-16, same day)
+
+Every numbered class above was remediated immediately, one PR per gap:
+
+| # | PR  | Class                                            | Errors |
+|---|-----|--------------------------------------------------|-------:|
+|   | —   | *baseline*                                       |  6653  |
+| 4,6 | #17 | Add `pubchem_cid` + `cas_rn` slots             |  6424  |
+| 2,5 | #18 | Broaden CURIE patterns (`OntologyMapping.ontology_id` + `kg_microbe_node_id`) | 6077 |
+| 1   | #19 | Rename `IngredientRecord.ontology_id` → `identifier` + 17 broken readers | 1541 |
+| 3a  | #20 | Generators emit timezone-aware timestamps (code) |  1541  |
+| 3b  | #21 | Retrofit 3082 existing naive timestamps (data)   | **0**  |
+
+`linkml-validate` against both curated collections is now clean. The
+`ontology_label: null` follow-up flagged in "Not addressed yet" above did
+not surface in the post-#19 histogram — either the count is zero or those
+errors fall under a different class than this analysis split out. Worth
+re-running the `/schema-gap-analysis` skill periodically (e.g. before
+SSSOM republishes) to catch new drift.

--- a/notes/schema_gap_analysis_2026-05-16.md
+++ b/notes/schema_gap_analysis_2026-05-16.md
@@ -14,14 +14,14 @@ turned up this session so we don't rediscover the same gaps next time.
 
 | # | Error | Axis | Records affected | Fix sketch |
 |---|---|---|---:|---|
-| 1 | `'ontology_id' is a required property` and `Additional properties are not allowed ('identifier')` | Schema | 2268 (all) | Alias or rename: data uses `identifier`; schema slot is `ontology_id`. Either add `aliases: [identifier]` on the schema slot OR rename it. See [[identifier_system_dual]] memory for context. |
-| 2 | `does not match '^[A-Z]+:[0-9]+$'` on `ontology_mapping.ontology_id` | Schema | 311 | The custom validator was broadened to `^[A-Za-z][A-Za-z0-9.]*:[A-Za-z0-9][A-Za-z0-9._-]*$`. Apply the same broadening to the schema `pattern:` on `OntologyMapping.ontology_id`. |
-| 3 | `is not a 'date-time'` (naive timestamps without offset) | Process | 1537 | `accept_mapping()`, `ingredient_reviewer.py`, several `scripts/*` use `datetime.now()` instead of `datetime.now(timezone.utc)`. Fix the generators; one-shot rewrite of affected records is optional. |
-| 4 | `Additional properties are not allowed ('pubchem_cid')` on `chemical_properties` | Schema | 185 | Add `pubchem_cid` to `ChemicalProperties` (range: string, pattern `^[0-9]+$`). |
+| 1 | `'ontology_id' is a required property` and `Additional properties are not allowed ('identifier')` | Schema | 4536 (2268 of each) | Rename the schema slot: data uses `identifier`; schema slot is `ontology_id`. (Note: LinkML `aliases:` is descriptive metadata only — it does NOT make `linkml-validate` accept an alternate YAML key. Slot rename is the actual fix.) |
+| 2 | `does not match '^[A-Z]+:[0-9]+$'` on `ontology_mapping.ontology_id` | Schema | 316 | The custom validator was broadened to `^[A-Za-z][A-Za-z0-9.]*:[A-Za-z0-9][A-Za-z0-9._~-]*$` (note the `~` — kg-microbe locals like `disodium_phosphate_heptahydrate_~28002_m_stock~29` use it). Apply the same broadening to the schema `pattern:` on `OntologyMapping.ontology_id`. |
+| 3 | `is not a 'date-time'` (naive timestamps without offset) | Process | 1541 | `accept_mapping()`, `ingredient_reviewer.py`, several `scripts/*` use `datetime.now()` instead of `datetime.now(timezone.utc)`. Fix the generators; one-shot rewrite of affected records is optional. |
+| 4 | `Additional properties are not allowed ('pubchem_cid')` on `chemical_properties` | Schema | 185 | Add `pubchem_cid` to `ChemicalProperties` as `range: integer` + `minimum_value: 1` — PubChem CIDs are positive ints in the data; a string + pattern would fail every value because LinkML patterns apply only to strings. |
 | 5 | `does not match '^CHEBI:[0-9]+$'` on `kg_microbe_node_id` | Schema | 31 | Pattern too narrow; current data has non-CHEBI prefixes here too. Broaden similarly to (2). |
-| 6 | `Additional properties are not allowed ('cas_rn')` on `ontology_mapping.evidence[]` | Schema | 44 | Add `cas_rn` to `MappingEvidence` (range: string, pattern `^\d+-\d+-\d+$`) — already defined on `ChemicalProperties`; promote to a reusable slot. |
+| 6 | `Additional properties are not allowed ('cas_rn')` on `ontology_mapping.evidence[]` | Schema | 44 | Add `cas_rn` to `MappingEvidence` (range: string, pattern `^\d+-\d+-\d+$`) — already defined on `ChemicalProperties`. |
 
-Total error count: ~5848 across 2275 files (every issue above is systematic — none are isolated record bugs).
+Total error count: 6653 across 2275 files (every issue above is systematic — none are isolated record bugs). Item 1 contributes two errors per record (missing required slot + unexpected key) which is why its row total is 4536, and the grand total is the sum of all six rows.
 
 ## Process-axis hot spots
 
@@ -39,14 +39,21 @@ The collection-level `generation_date` written by `scripts/aggregate_records.py`
 is already timezone-aware; only record-level / event-level timestamps are
 affected.
 
-## Suggested remediation order
+## Suggested remediation order (historical — superseded by Resolution below)
+
+> **Note (2026-05-16):** an earlier version of step 2 below recommended
+> `aliases: [identifier]` on the slot rather than a rename. That is wrong:
+> LinkML aliases are descriptive metadata and do not change which YAML
+> keys validate. The Resolution section that follows used a slot rename
+> instead. The original text is left in place for traceability.
 
 1. **Schema first (no migration risk)**: items 2, 4, 5, 6 — broaden patterns
    and add missing slots. After this, the only remaining errors are #1 and #3.
-2. **Identifier slot alias (item 1)**: add `aliases: [identifier]` to the
-   `IngredientRecord.ontology_id` slot rather than renaming, so old callers
-   keep working. Re-run validation: residual errors should be zero except
-   the timestamps.
+2. **Identifier slot alias (item 1)**: ~~add `aliases: [identifier]` to the
+   `IngredientRecord.ontology_id` slot rather than renaming~~ — superseded.
+   The actual fix is to rename the schema slot from `ontology_id` to
+   `identifier` (and update every reader / writer in the codebase). See
+   PR #19.
 3. **Generator fixes (item 3)**: switch `datetime.now()` → `datetime.now(timezone.utc)`
    in every site grep finds. Optional follow-up: a one-shot pass over
    `data/curated/` + `data/ingredients/` to retrofit the existing naive


### PR DESCRIPTION
## Summary

The methodology + initial-state record for the schema-gap-analysis remediation series (PRs #17 / #18 / #19 / #20 / #21, all already merged). Lands the originating two artifacts:

- **`.claude/skills/schema-gap-analysis/SKILL.md`** — reusable methodology that uses upstream \`linkml-validate\` as ground truth and reports findings along three axes (schema / instances / process), including the \`linkml-runtime\` 1.9.x pin needed to make linkml-validate import on Python 3.14, the three targeted process-axis greps that replace the noisy \`yaml.dump\` heuristic from an earlier draft, and an error-fragment → axis mapping table.

- **`notes/schema_gap_analysis_2026-05-16.md`** — point-in-time inventory of the six gap classes discovered the first time the skill was run (4536 / 1541 / 347 / 229 / 31 / 44 errors), updated post-merge with a Resolution section linking each class to the PR that closed it.

The skill is invocable via \`/schema-gap-analysis\`.

## Test plan

This PR is documentation + tooling only. No code or schema changes.

- [x] \`PYTHONPATH=src pytest -o addopts='' tests/\` → 226/226 (unchanged from main)
- [x] \`scripts/validate_all.py --mode both --no-oak\` → 0 errors / 0 warnings / 2275 files
- [x] \`linkml-validate -s … -C IngredientCollection data/curated/{mapped,unmapped}_ingredients.yaml\` → 0 errors (already clean on main as of #21)
- [x] Skill loads and runs end-to-end (verified by re-running it after this branch was authored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)