### PR TITLE
schema-gap-analysis: bake MIM paths in for copy-paste runnability

### DIFF
--- a/.claude/skills/schema-gap-analysis/skill.md
+++ b/.claude/skills/schema-gap-analysis/skill.md
@@ -1,35 +1,144 @@
 ---
 name: schema-gap-analysis
-description: Find gaps between MIM's LinkML schema, its YAML instances, and the code that generates them. Canonical version now lives in the claw repo and applies cross-Mech; this MIM-side stub records the MIM-specific config row + history.
+description: Find gaps between MIM's LinkML schema, its YAML instances, and the code that generates them. Uses linkml-validate as ground truth and reports along three axes (schema / instances / process). Copy-paste runnable.
 category: quality
 requires_database: false
 requires_internet: false
-version: 2.0.0
+version: 2.1.0
 ---
 
-# schema-gap-analysis — MIM
+# Schema gap analysis (MIM)
 
-The canonical, cross-Mech version of this skill now lives in the claw repo:
+The conceptual framework — why three axes (schema / instances / process), what each error class signals, common anti-patterns — lives once at the cross-Mech version in claw:
+https://github.com/CultureBotAI/culturebotai-claw/blob/main/.claude/skills/schema-gap-analysis/skill.md
 
-- **GitHub**: https://github.com/CultureBotAI/culturebotai-claw/blob/main/.claude/skills/schema-gap-analysis/skill.md
-- **Local path** (when the Mech repos are checked out as siblings):
-  `../culturebotai-claw/.claude/skills/schema-gap-analysis/skill.md`
+This file is the MIM-specific operational version: every command below is ready to run as-is, with MIM paths baked in.
 
-It generalises the methodology (linkml-validate as ground truth, three-axis classification, error histograms, process-drift greps) so it can run against any Mech repo. Use that version when invoking the skill — the Claude Code skill registry resolves to it automatically.
+## Setup
 
-## MIM-specific config (substitute into the cross-Mech procedure)
+LinkML lives in `.venv/`. Two known bumps:
 
-| Field | Value |
-|---|---|
-| `SCHEMA` | `src/mediaingredientmech/schema/mediaingredientmech.yaml` |
-| Tree-root class | `IngredientCollection` (curated/ files) / `IngredientRecord` (per-file) |
-| Canonical collections | `data/curated/mapped_ingredients.yaml`, `data/curated/unmapped_ingredients.yaml` |
-| Per-record YAMLs | `data/ingredients/mapped/*.yaml`, `data/ingredients/unmapped/*.yaml` |
-| Custom (tolerant) validator | `src/mediaingredientmech/validation/schema_validator.py` |
-| Curator/save module | `src/mediaingredientmech/curation/ingredient_curator.py` |
+```bash
+# (1) pip missing in .venv — bootstrap if needed
+.venv/bin/python -m ensurepip
 
-## MIM-specific reference
+# (2) linkml-validate aborts with `AttributeError: Format has no attribute 'JSON'`
+# — pin linkml-runtime to a 1.9.x release (linkml 1.9.x imports Format.JSON
+# at module load and runtime 1.10 dropped it).
+.venv/bin/python -m pip install "linkml-runtime>=1.9,<1.10"
+.venv/bin/linkml-validate --help  # smoke test
+```
 
-- **Last end-to-end pass**: `notes/schema_gap_analysis_2026-05-16.md` — six gap classes the skill surfaced on its first MIM run, plus the PR that closed each.
-- **Primary-key history**: described inline in the schema (`IngredientRecord.identifier`'s `description:` block). The `ontology_id` → `identifier` rename happened in PR #19.
-- **Process-drift sites worth grepping for changes**: `src/mediaingredientmech/curation/ingredient_curator.py`, `scripts/aggregate_records.py`, every `scripts/enrich_*`, `scripts/apply_*`, `scripts/auto_correct.py`.
+## Procedure
+
+### 1. Validate canonical collection files
+
+```bash
+.venv/bin/linkml-validate \
+  -s src/mediaingredientmech/schema/mediaingredientmech.yaml \
+  -C IngredientCollection \
+  data/curated/mapped_ingredients.yaml \
+  data/curated/unmapped_ingredients.yaml
+```
+
+### 2. Validate one individual per-record YAML
+
+```bash
+SAMPLE=$(ls data/ingredients/mapped/*.yaml | head -1)
+.venv/bin/linkml-validate \
+  -s src/mediaingredientmech/schema/mediaingredientmech.yaml \
+  -C IngredientRecord "$SAMPLE"
+```
+
+### 3. Validate the per-record corpus
+
+```bash
+find data/ingredients -name "*.yaml" -print0 \
+  | xargs -0 .venv/bin/linkml-validate \
+      -s src/mediaingredientmech/schema/mediaingredientmech.yaml \
+      -C IngredientRecord 2>&1 | tee /tmp/mim_validate.out > /dev/null
+grep -c "^\[ERROR\]" /tmp/mim_validate.out  # target: 0
+```
+
+### 4. Histogram the errors
+
+Run against both collections **and** per-record output combined — a gap that lives only in `unmapped_ingredients.yaml` is silently dropped if only mapped is histogrammed.
+
+```bash
+SCHEMA=src/mediaingredientmech/schema/mediaingredientmech.yaml
+COLS="data/curated/mapped_ingredients.yaml data/curated/unmapped_ingredients.yaml"
+
+.venv/bin/linkml-validate -s $SCHEMA -C IngredientCollection $COLS 2>&1 \
+  | grep -oE "Additional properties are not allowed \('[^']+'" \
+  | sort | uniq -c | sort -rn
+
+.venv/bin/linkml-validate -s $SCHEMA -C IngredientCollection $COLS 2>&1 \
+  | grep -oE "'[^']+' is a required property" \
+  | sort | uniq -c | sort -rn
+
+.venv/bin/linkml-validate -s $SCHEMA -C IngredientCollection $COLS 2>&1 \
+  | grep -oE "does not match '[^']+'" \
+  | sort | uniq -c | sort -rn
+
+.venv/bin/linkml-validate -s $SCHEMA -C IngredientCollection $COLS 2>&1 \
+  | grep -oE "is not a '[^']+'" \
+  | sort | uniq -c | sort -rn
+```
+
+### 5. Cross-check generator drift (Axis 3)
+
+Three calibrated greps for MIM:
+
+```bash
+# Naive datetimes — every `datetime.now()` that produces ISO-8601 output.
+grep -rnE 'datetime\.now\(\)\.isoformat\b' \
+  src/ scripts/ --include='*.py' \
+  | grep -v "timezone"
+
+# Saves that drop collection metadata: yaml.dump receives a literal
+# one-key {"ingredients": ...} dict, which throws away
+# generation_date / total_count / mapped_count / unmapped_count.
+# Should be empty in current code.
+grep -rnE 'yaml\.dump\(\s*\{\s*["\047]ingredients["\047]\s*:' \
+  src/ scripts/ --include='*.py'
+
+# Direct WRITES to a canonical curated collection file that skip
+# IngredientCurator. Match `open(..., "w"/"a")` literally so we
+# don't false-positive on scripts that merely *mention* the filename.
+grep -rnE 'open\([^)]*(mapped|unmapped)_ingredients\.yaml[^)]*["\047][wa][bt]?["\047]' \
+  scripts/ src/ --include='*.py'
+```
+
+### 6. Decide and apply fixes
+
+For each distinct error class, pick the axis and fix accordingly:
+
+- **Schema axis** (hundreds-to-thousands of records fail same way): edit `src/mediaingredientmech/schema/mediaingredientmech.yaml`.
+- **Instance axis** (small number, looks like typos): round-trip through `src/mediaingredientmech/curation/ingredient_curator.py` (`load → save`) so canonical YAML formatting + `generation_date`/`total_count` metadata are recomputed correctly. **Don't `sed`-fix.**
+- **Process axis** (clustered by source tool, same wrong shape): patch the offender in `src/mediaingredientmech/` or `scripts/aggregate_*.py`, `scripts/enrich_*.py`, `scripts/apply_*.py`, `scripts/auto_correct.py`. Then optionally rewrite affected records.
+
+### 7. Re-validate
+
+```bash
+.venv/bin/linkml-validate \
+  -s src/mediaingredientmech/schema/mediaingredientmech.yaml \
+  -C IngredientCollection \
+  data/curated/mapped_ingredients.yaml \
+  data/curated/unmapped_ingredients.yaml
+# target: "No issues found"
+```
+
+## MIM-specific gap classes (history)
+
+| Error | Class | Resolution | Reference |
+|---|---|---|---|
+| `'ontology_id' is a required property` (×thousands) | Schema axis: slot renamed | Renamed `ontology_id` → `identifier`; LinkML `aliases:` is descriptive only, doesn't actually accept alternate YAML keys | PR #19 |
+| Six other classes from the first end-to-end pass | mixed | See `notes/schema_gap_analysis_2026-05-16.md` for the per-class breakdown + closing PRs | 2026-05-16 audit |
+
+## Pointers
+
+- Custom (tolerant) validator the skill is calibrated against: `src/mediaingredientmech/validation/schema_validator.py`
+- Schema: `src/mediaingredientmech/schema/mediaingredientmech.yaml`
+- Curator (use for instance-axis fixes): `src/mediaingredientmech/curation/ingredient_curator.py`
+- Last full audit notes: `notes/schema_gap_analysis_2026-05-16.md`
+- Cross-Mech framework + new-Mech bootstrap template: [claw/.claude/skills/schema-gap-analysis](https://github.com/CultureBotAI/culturebotai-claw/blob/main/.claude/skills/schema-gap-analysis/skill.md)

--- a/.claude/skills/schema-gap-analysis/skill.md
+++ b/.claude/skills/schema-gap-analysis/skill.md
@@ -16,25 +16,20 @@ This file is the MIM-specific operational version: every command below is ready 
 
 ## Setup
 
-LinkML lives in `.venv/`. Two known bumps:
+MIM's `justfile` (`just validate-schema` / `just validate-all`) calls `linkml-validate` directly from `PATH`, so the commands below use the same bare invocation. If your local install is in `.venv/`, substitute `.venv/bin/linkml-validate` everywhere (or run `uv run linkml-validate ...`).
 
 ```bash
-# (1) pip missing in .venv — bootstrap if needed
-.venv/bin/python -m ensurepip
-
-# (2) linkml-validate aborts with `AttributeError: Format has no attribute 'JSON'`
-# — pin linkml-runtime to a 1.9.x release (linkml 1.9.x imports Format.JSON
-# at module load and runtime 1.10 dropped it).
-.venv/bin/python -m pip install "linkml-runtime>=1.9,<1.10"
-.venv/bin/linkml-validate --help  # smoke test
+linkml-validate --help    # smoke test
 ```
+
+If this fails with `command not found`, run `uv sync` (or activate the venv) — MIM's `pyproject.toml` pins `linkml-runtime>=1.7.0,<1.10` so a fresh `uv sync` produces a working `linkml-validate` (the `<1.10` cap exists because linkml-runtime 1.10 removed `Format.JSON`, which linkml 1.9.x imports at module load; bump the cap when bumping `linkml` past 1.9.x).
 
 ## Procedure
 
 ### 1. Validate canonical collection files
 
 ```bash
-.venv/bin/linkml-validate \
+linkml-validate \
   -s src/mediaingredientmech/schema/mediaingredientmech.yaml \
   -C IngredientCollection \
   data/curated/mapped_ingredients.yaml \
@@ -45,7 +40,7 @@ LinkML lives in `.venv/`. Two known bumps:
 
 ```bash
 SAMPLE=$(ls data/ingredients/mapped/*.yaml | head -1)
-.venv/bin/linkml-validate \
+linkml-validate \
   -s src/mediaingredientmech/schema/mediaingredientmech.yaml \
   -C IngredientRecord "$SAMPLE"
 ```
@@ -54,7 +49,7 @@ SAMPLE=$(ls data/ingredients/mapped/*.yaml | head -1)
 
 ```bash
 find data/ingredients -name "*.yaml" -print0 \
-  | xargs -0 .venv/bin/linkml-validate \
+  | xargs -0 linkml-validate \
       -s src/mediaingredientmech/schema/mediaingredientmech.yaml \
       -C IngredientRecord 2>&1 | tee /tmp/mim_validate.out > /dev/null
 grep -c "^\[ERROR\]" /tmp/mim_validate.out  # target: 0
@@ -62,26 +57,30 @@ grep -c "^\[ERROR\]" /tmp/mim_validate.out  # target: 0
 
 ### 4. Histogram the errors
 
-Run against both collections **and** per-record output combined — a gap that lives only in `unmapped_ingredients.yaml` is silently dropped if only mapped is histogrammed.
+Histogram both the collection run **and** the per-record run from step 3 (`/tmp/mim_validate.out`). A gap that lives only in `unmapped_ingredients.yaml`, or only in the per-record corpus, is silently dropped if only one of the two is histogrammed.
 
 ```bash
 SCHEMA=src/mediaingredientmech/schema/mediaingredientmech.yaml
 COLS="data/curated/mapped_ingredients.yaml data/curated/unmapped_ingredients.yaml"
 
-.venv/bin/linkml-validate -s $SCHEMA -C IngredientCollection $COLS 2>&1 \
-  | grep -oE "Additional properties are not allowed \('[^']+'" \
+# Re-run the collection validation, capturing to /tmp/mim_collections.out
+linkml-validate -s $SCHEMA -C IngredientCollection $COLS \
+  > /tmp/mim_collections.out 2>&1
+
+# Combine collection + per-record output (per-record already captured in step 3
+# at /tmp/mim_validate.out; re-run step 3 first if it's missing/stale).
+cat /tmp/mim_collections.out /tmp/mim_validate.out > /tmp/mim_all.out
+
+grep -oE "Additional properties are not allowed \('[^']+'" /tmp/mim_all.out \
   | sort | uniq -c | sort -rn
 
-.venv/bin/linkml-validate -s $SCHEMA -C IngredientCollection $COLS 2>&1 \
-  | grep -oE "'[^']+' is a required property" \
+grep -oE "'[^']+' is a required property" /tmp/mim_all.out \
   | sort | uniq -c | sort -rn
 
-.venv/bin/linkml-validate -s $SCHEMA -C IngredientCollection $COLS 2>&1 \
-  | grep -oE "does not match '[^']+'" \
+grep -oE "does not match '[^']+'" /tmp/mim_all.out \
   | sort | uniq -c | sort -rn
 
-.venv/bin/linkml-validate -s $SCHEMA -C IngredientCollection $COLS 2>&1 \
-  | grep -oE "is not a '[^']+'" \
+grep -oE "is not a '[^']+'" /tmp/mim_all.out \
   | sort | uniq -c | sort -rn
 ```
 
@@ -120,7 +119,7 @@ For each distinct error class, pick the axis and fix accordingly:
 ### 7. Re-validate
 
 ```bash
-.venv/bin/linkml-validate \
+linkml-validate \
   -s src/mediaingredientmech/schema/mediaingredientmech.yaml \
   -C IngredientCollection \
   data/curated/mapped_ingredients.yaml \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,12 @@ classifiers = [
 ]
 
 dependencies = [
-    "linkml>=1.7.0",
-    "linkml-runtime>=1.7.0",
+    "linkml>=1.7.0,<1.10",
+    # Pinned <1.10: linkml 1.9.x imports `Format.JSON` at module load,
+    # and linkml-runtime 1.10 dropped that enum value, breaking
+    # `linkml-validate` startup with `AttributeError: Format has no attribute 'JSON'`.
+    # Lift this cap when bumping linkml past 1.9.x.
+    "linkml-runtime>=1.7.0,<1.10",
     "oaklib>=0.5.0",
     "pyyaml>=6.0",
     "click>=8.1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1989,7 +1989,7 @@ wheels = [
 
 [[package]]
 name = "linkml-runtime"
-version = "1.10.0"
+version = "1.9.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -2007,9 +2007,9 @@ dependencies = [
     { name = "rdflib" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/3d/031e2e8ef7ca872340fb7b7102cfd1fe4a0b329dc04ff694ad9ec6ccaddc/linkml_runtime-1.10.0.tar.gz", hash = "sha256:899889d584ce8056c5c44512b2d247bdc84a8484c3aa228aeb2db283e3a9d2ec", size = 589957 }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/38/38ac19a5b81982f03709cda0a008327dc775d11f008d0cbdc0f2a5389e24/linkml_runtime-1.9.5.tar.gz", hash = "sha256:78dc1383adf11ad5f20bb11b6adde56ed566fbd2429a292d57699ad4596c738a", size = 480288 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/2d/6ab4127bb9aa6e3b54ad5d81fd0c0c12e4d1a80300f2bfdac8f2e18f9d17/linkml_runtime-1.10.0-py3-none-any.whl", hash = "sha256:b7caf806e1b49bf62005d8f398b070c282742c5f6626469fdc1660add0c9da58", size = 584001 },
+    { url = "https://files.pythonhosted.org/packages/34/28/cdcbe1f0521a98b891dd30249513eef1ddcc7bb406be953b4a8d7825e68f/linkml_runtime-1.9.5-py3-none-any.whl", hash = "sha256:fece3e8aa25a4246165c6528b6a7fe83a929b985d2ce1951cc8a0f4da1a30b90", size = 576405 },
 ]
 
 [[package]]
@@ -2293,8 +2293,8 @@ requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
     { name = "click", specifier = ">=8.1.0" },
     { name = "deep-research-client", extras = ["cyberian"], marker = "python_full_version >= '3.12' and extra == 'dev'", specifier = ">=0.2.4" },
-    { name = "linkml", specifier = ">=1.7.0" },
-    { name = "linkml-runtime", specifier = ">=1.7.0" },
+    { name = "linkml", specifier = ">=1.7.0,<1.10" },
+    { name = "linkml-runtime", specifier = ">=1.7.0,<1.10" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.5.0" },
     { name = "oaklib", specifier = ">=0.5.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0" },


### PR DESCRIPTION
Follow-up to PR #23. The thin claw-pointer stub from #23 still required users to open the claw doc and substitute six values. This commit replaces it with a copy-paste-runnable MIM-specific version: all commands have MIM's schema path / collection paths / per-record glob baked in.

The cross-Mech reference (methodology, three-axis framework, anti-patterns) still lives once at https://github.com/CultureBotAI/culturebotai-claw/blob/main/.claude/skills/schema-gap-analysis/skill.md — that file is now reframed as the bootstrap template for new Mechs.

History (PR #19 rename + 2026-05-16 audit notes) preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)