### PR TITLE
Republish ingredient SSSOM (2026-05-18, post schema-gap fixes)

### DIFF
--- a/data/curated/unmapped_ingredients.yaml
+++ b/data/curated/unmapped_ingredients.yaml
@@ -1,4 +1,4 @@
-generation_date: '2026-05-12T00:23:09.343796+00:00'
+generation_date: '2026-05-18T06:04:10.175642+00:00'
 total_count: 398
 mapped_count: 0
 unmapped_count: 398

--- a/mappings/ingredient_mappings.sssom.tsv
+++ b/mappings/ingredient_mappings.sssom.tsv
@@ -20,9 +20,9 @@
 #   cbclaw: "https://github.com/culturebotai/culturebotai-claw/blob/main/"
 # license: "https://creativecommons.org/publicdomain/zero/1.0/"
 # mapping_set_id: "https://w3id.org/sssom/mappings/culturebotai_mim_ingredient"
-# mapping_set_version: "2026-05-15"
+# mapping_set_version: "2026-05-18"
 # mapping_set_description: "Canonical MediaIngredientMech → ingredient-ontology mappings (CHEBI + FOODON; UBERON/ENVO when populated). One row per mapped MIM ingredient record. Per-row object_source distinguishes ontologies. Predicate is skos:exactMatch by default; narrowMatch/broadMatch/closeMatch where residual-P2.5 triage found a specificity or symmetry difference, or where mapping_quality != EXACT_MATCH. The `source` extension column records the upstream origin (MIM evidence + kg-microbe source pipeline, CHEBI only)."
-# mapping_date: "2026-05-15"
+# mapping_date: "2026-05-18"
 # creator_id:
 #   - "orcid:0000-0001-8175-045X"
 # subject_source: "MIM:ingredients"

--- a/mappings/needs_curator_review.tsv
+++ b/mappings/needs_curator_review.tsv
@@ -20,9 +20,9 @@
 #   cbclaw: "https://github.com/culturebotai/culturebotai-claw/blob/main/"
 # license: "https://creativecommons.org/publicdomain/zero/1.0/"
 # mapping_set_id: "https://w3id.org/sssom/mappings/culturebotai_mim_ingredient"
-# mapping_set_version: "2026-05-12"
+# mapping_set_version: "2026-05-18"
 # mapping_set_description: "Canonical MediaIngredientMech → ingredient-ontology mappings (CHEBI + FOODON; UBERON/ENVO when populated). One row per mapped MIM ingredient record. Per-row object_source distinguishes ontologies. Predicate is skos:exactMatch by default; narrowMatch/broadMatch/closeMatch where residual-P2.5 triage found a specificity or symmetry difference, or where mapping_quality != EXACT_MATCH. The `source` extension column records the upstream origin (MIM evidence + kg-microbe source pipeline, CHEBI only)."
-# mapping_date: "2026-05-12"
+# mapping_date: "2026-05-18"
 # creator_id:
 #   - "orcid:0000-0001-8175-045X"
 # subject_source: "MIM:ingredients"


### PR DESCRIPTION
## Summary

First SSSOM republish after the schema-gap-analysis remediation series (PRs #17–#22). Confirms that the schema fixes did not change what gets exported — same 2212 rows, same predicate breakdown, same object-prefix breakdown — only the metadata moves forward.

| metric | before | after |
|---|---:|---:|
| total rows | 2212 | 2212 |
| `skos:exactMatch` | 1711 | 1711 |
| `skos:closeMatch` | 323 | 323 |
| `skos:narrowMatch` | 178 | 178 |
| `mapping_set_version` | `2026-05-15` | `2026-05-18` |
| `mapping_date` | `2026-05-15` | `2026-05-18` |

## Process

```
python scripts/aggregate_records.py --ingredients-dir data/ingredients \
                                    --output-dir data/curated
python scripts/validate_all.py --mode individual --no-oak
cd ../culturebotai-claw && just build-sssom && just publish-sssom
cd ../MediaIngredientMech && just qc-sssom
```

## Verification

- Individual YAML validation: **2268 files, 0 errors / 0 warnings**.
- `linkml-validate` (the upstream schema validator) on the canonical collections: **0 errors** (down from 6653 before #17, see `notes/schema_gap_analysis_2026-05-16.md`).
- `just qc-sssom`: Rules A / B1 / B2 / B3 pass; Rule B4 still skipped for `BTO:` only — the one BTO row (`MIM:Cell_Lysate` → `BTO:0004304`, "cell lysate") was verified against OLS in an earlier session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)