### PR TITLE
Fix stale KG-Hub/MediaIngredientMech URLs after org move to CultureBotAI

### DIFF
--- a/ATTIC/ROLE_CURATION_IMPLEMENTATION.md
+++ b/ATTIC/ROLE_CURATION_IMPLEMENTATION.md
@@ -158,7 +158,7 @@ class DOIResolver:
 evidence:
   - reference_text: "CultureMech database (1307 occurrences in media formulations)"
     reference_type: DATABASE_ENTRY
-    url: "https://github.com/KG-Hub/CultureMech"
+    url: "https://github.com/CultureBotAI/CultureMech"
     excerpt: "Role: pH dependent redox indicator; Properties: Defined component, Organic compound, Simple component"
     curator_note: "High-confidence assignment. Appears in 1307 media occurrences as 'Redox Indicator'."
 ```
@@ -179,7 +179,7 @@ evidence:
       evidence:
         - reference_type: DATABASE_ENTRY
           reference_text: "CultureMech database (1307 occurrences in media formulations)"
-          url: "https://github.com/KG-Hub/CultureMech"
+          url: "https://github.com/CultureBotAI/CultureMech"
           excerpt: "Role: pH dependent redox indicator; Properties: Defined component, Organic compound, Simple component"
           curator_note: "High-confidence assignment. Appears in 1307 media occurrences as 'Redox Indicator'."
 ```
@@ -212,7 +212,7 @@ evidence:
 evidence:
   - reference_text: "CultureMech database (6041 occurrences as 'Mineral source')"
     reference_type: DATABASE_ENTRY
-    url: "https://github.com/KG-Hub/CultureMech"
+    url: "https://github.com/CultureBotAI/CultureMech"
     excerpt: "Role: Mineral source; Properties: Defined component, Inorganic compound, Simple component"
     curator_note: "Widespread use in media formulations (6041 occurrences). High confidence based on 'Defined component' property."
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ LLM-assisted curation system for media ingredient ontology mappings.
 
 ## Overview
 
-MediaIngredientMech provides a structured workflow for curating media ingredient ontology mappings with full audit trails. It manages 995 mapped and 136 unmapped ingredients aggregated from 10,657 media recipes in [CultureMech](https://github.com/KG-Hub/CultureMech).
+MediaIngredientMech provides a structured workflow for curating media ingredient ontology mappings with full audit trails. It manages 995 mapped and 136 unmapped ingredients aggregated from 10,657 media recipes in [CultureMech](https://github.com/CultureBotAI/CultureMech).
 
 **Key Features:**
 - Ingredient-centric data model with LinkML schemas

--- a/docs/ROLE_CURATION_WORKFLOW.md
+++ b/docs/ROLE_CURATION_WORKFLOW.md
@@ -102,7 +102,7 @@ media_roles:
     evidence:
       - reference_type: DATABASE_ENTRY
         reference_text: "CultureMech database (6041 occurrences as 'Mineral source')"
-        url: "https://github.com/KG-Hub/CultureMech"
+        url: "https://github.com/CultureBotAI/CultureMech"
         excerpt: "Role: Mineral source; Properties: Defined component, Inorganic compound, Simple component"
         curator_note: "Widespread use in media formulations (6041 occurrences). High confidence based on 'Defined component' property."
 ```
@@ -217,7 +217,7 @@ evidence:
 evidence:
   - reference_text: "CultureMech database (1307 occurrences as 'pH dependent redox indicator')"
     reference_type: DATABASE_ENTRY
-    url: "https://github.com/KG-Hub/CultureMech"
+    url: "https://github.com/CultureBotAI/CultureMech"
     excerpt: "Role: pH dependent redox indicator; Properties: Defined component, Organic compound, Simple component"
     curator_note: "Widespread use in anaerobic media formulations (1307 occurrences). High confidence based on 'Defined component' property."
 ```
@@ -401,7 +401,7 @@ cat data/analysis/role_statistics_report.yaml
 
 ## References
 
-1. **CultureMech Repository**: https://github.com/KG-Hub/CultureMech
+1. **CultureMech Repository**: https://github.com/CultureBotAI/CultureMech
 2. **MediaIngredientMech Schema**: `src/mediaingredientmech/schema/mediaingredientmech.yaml`
 3. **Role Enum Documentation**: Lines 466-502 in schema
 4. **Crossref API**: https://api.crossref.org/ (for DOI resolution)

--- a/docs/index.html
+++ b/docs/index.html
@@ -216,7 +216,7 @@
             <div class="card">
                 <h2>💾 GitHub Repository</h2>
                 <p>Access the source code, scripts, and contribute to the curation workflow.</p>
-                <a href="https://github.com/KG-Hub/MediaIngredientMech" class="btn">View on GitHub</a>
+                <a href="https://github.com/CultureBotAI/MediaIngredientMech" class="btn">View on GitHub</a>
             </div>
         </div>
 
@@ -240,8 +240,8 @@
     <footer>
         <p>
             <strong>MediaIngredientMech</strong> |
-            Part of the <a href="https://github.com/KG-Hub/CultureMech">CultureMech</a> Knowledge Graph Hub |
-            <a href="https://github.com/KG-Hub/MediaIngredientMech">GitHub</a>
+            Part of the <a href="https://github.com/CultureBotAI/CultureMech">CultureMech</a> Knowledge Graph Hub |
+            <a href="https://github.com/CultureBotAI/MediaIngredientMech">GitHub</a>
         </p>
         <p style="margin-top: 1rem; font-size: 0.9rem;">
             Generated: 2026-03-06 | Schema Version: 1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,8 +50,8 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/KG-Hub/MediaIngredientMech"
-Repository = "https://github.com/KG-Hub/MediaIngredientMech"
+Homepage = "https://github.com/CultureBotAI/MediaIngredientMech"
+Repository = "https://github.com/CultureBotAI/MediaIngredientMech"
 
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]

--- a/scripts/enrich_existing_roles.py
+++ b/scripts/enrich_existing_roles.py
@@ -107,7 +107,7 @@ def enrich_role_citation(
     new_evidence = {
         "reference_text": f"CultureMech database ({occurrence_count} occurrences as '{role_text}')",
         "reference_type": "DATABASE_ENTRY",
-        "url": "https://github.com/KG-Hub/CultureMech",
+        "url": "https://github.com/CultureBotAI/CultureMech",
         "excerpt": excerpt,
         "curator_note": curator_note,
     }

--- a/scripts/extract_top100_roles.py
+++ b/scripts/extract_top100_roles.py
@@ -146,7 +146,7 @@ def extract_roles_for_top100(
                     confidence=confidence,
                     reference_text=f"CultureMech database ({occurrence_count} occurrences in media formulations)",
                     reference_type="DATABASE_ENTRY",
-                    url="https://github.com/KG-Hub/CultureMech",
+                    url="https://github.com/CultureBotAI/CultureMech",
                     excerpt=excerpt,
                     curator_note=curator_note,
                 )

--- a/src/mediaingredientmech/schema/mediaingredientmech.yaml
+++ b/src/mediaingredientmech/schema/mediaingredientmech.yaml
@@ -7,8 +7,8 @@ description: >-
 
 license: MIT
 see_also:
-  - https://github.com/KG-Hub/MediaIngredientMech
-  - https://github.com/KG-Hub/CultureMech
+  - https://github.com/CultureBotAI/MediaIngredientMech
+  - https://github.com/CultureBotAI/CultureMech
 
 prefixes:
   linkml: https://w3id.org/linkml/


### PR DESCRIPTION
## Summary

- Replace `https://github.com/KG-Hub/{MediaIngredientMech,CultureMech}` URLs with the new `CultureBotAI/*` paths across 8 files.
- All references now consistent with the current `origin` remote (`https://github.com/CultureBotAI/MediaIngredientMech.git`).
- 16 substitutions, no other changes.

## Files touched

- `README.md`
- `pyproject.toml` (Homepage + Repository)
- `src/mediaingredientmech/schema/mediaingredientmech.yaml` (`see_also` block)
- `docs/index.html`, `docs/ROLE_CURATION_WORKFLOW.md`
- `scripts/extract_top100_roles.py`, `scripts/enrich_existing_roles.py`
- `ATTIC/ROLE_CURATION_IMPLEMENTATION.md` (archived but still publicly served — updated for link health)

## Test plan

- [x] `grep -ri "github\.com/kg-hub" --include="*.md" --include="*.yaml" --include="*.toml" --include="*.py" --include="*.html"` returns no matches.
- [x] `git diff --stat` shows 16+/16- only.
- [ ] Reviewer: confirm whether ATTIC/ should remain frozen historical (revert that one file if so).

🤖 Generated with [Claude Code](https://claude.com/claude-code)