### PR TITLE
Fix stale KG-Hub/MediaIngredientMech URLs after org move to CultureBotAI

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -216,7 +216,7 @@
             <div class="card">
                 <h2>💾 GitHub Repository</h2>
                 <p>Access the source code, scripts, and contribute to the curation workflow.</p>
-                <a href="https://github.com/KG-Hub/MediaIngredientMech" class="btn">View on GitHub</a>
+                <a href="https://github.com/CultureBotAI/MediaIngredientMech" class="btn">View on GitHub</a>
             </div>
         </div>
 
@@ -241,7 +241,7 @@
         <p>
             <strong>MediaIngredientMech</strong> |
             Part of the <a href="https://github.com/KG-Hub/CultureMech">CultureMech</a> Knowledge Graph Hub |
-            <a href="https://github.com/KG-Hub/MediaIngredientMech">GitHub</a>
+            <a href="https://github.com/CultureBotAI/MediaIngredientMech">GitHub</a>
         </p>
         <p style="margin-top: 1rem; font-size: 0.9rem;">
             Generated: 2026-03-06 | Schema Version: 1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,8 +50,8 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/KG-Hub/MediaIngredientMech"
-Repository = "https://github.com/KG-Hub/MediaIngredientMech"
+Homepage = "https://github.com/CultureBotAI/MediaIngredientMech"
+Repository = "https://github.com/CultureBotAI/MediaIngredientMech"
 
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]

--- a/src/mediaingredientmech/schema/mediaingredientmech.yaml
+++ b/src/mediaingredientmech/schema/mediaingredientmech.yaml
@@ -7,7 +7,7 @@ description: >-
 
 license: MIT
 see_also:
-  - https://github.com/KG-Hub/MediaIngredientMech
+  - https://github.com/CultureBotAI/MediaIngredientMech
   - https://github.com/KG-Hub/CultureMech
 
 prefixes:


### PR DESCRIPTION
## Summary

The repo lives at `CultureBotAI/MediaIngredientMech`, but five non-regenerated references still point at the old (now-404) location `KG-Hub/MediaIngredientMech`. This PR updates them in place.

```
$ curl -sI https://github.com/KG-Hub/MediaIngredientMech | head -1
HTTP/2 404
$ curl -sI https://github.com/CultureBotAI/MediaIngredientMech | head -1
HTTP/2 200
```

## Changes

| File | Lines | Change |
|---|---|---|
| `pyproject.toml` | 53, 54 | `Homepage` / `Repository` URLs |
| `docs/index.html` | 219, 244 | "View on GitHub" button + footer link |
| `src/mediaingredientmech/schema/mediaingredientmech.yaml` | 10 | `see_also` entry |

`KG-Hub/CultureMech` references (a separate repo, not in scope here) are intentionally untouched.

## Out of scope (needs follow-up in the SSSOM builder repo)

The MIM CURIE prefix definition embedded in the regenerated SSSOM files —

```
# curie_map:
#   ...
#   MIM: \"https://github.com/KG-Hub/MediaIngredientMech/blob/main/data/ingredients/mapped/\"
```

appears in `mappings/ingredient_mappings.sssom.tsv:14` and `mappings/needs_curator_review.tsv:14`, both auto-generated by the claw builder referenced from `scripts/validate_sssom_invariants.py`. Patching the TSV directly would be reverted on the next builder run. A complementary one-line fix to the claw builder (`scripts/build_mim_ingredient_sssom.py`) is being opened as a separate PR.

## Why it matters

- "View on GitHub" from the published docs currently hits a 404
- `pip`-driven project metadata exposes a broken homepage
- LinkML schema consumers following `see_also` get a dead link
- Downstream tooling (e.g. `kg-microbe`'s `scripts/consolidate_chemical_mappings.py`) previously pointed contributors at the wrong clone URL (already fixed downstream)

## Test plan

- [ ] CI passes (no schema or test changes — pure URL substitution)
- [ ] Confirm published docs page renders the corrected button
- [ ] Confirm `pyproject.toml` metadata renders correctly on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)