### PR TITLE
env-context Phase 3 + obsolete-CHEBI re-mapping + stale-text fix

### DIFF
--- a/scripts/add_mediaingredientmech_ids.py
+++ b/scripts/add_mediaingredientmech_ids.py
@@ -3,7 +3,7 @@
 
 Assigns stable, unique identifiers in the format MediaIngredientMech:000001
 to each ingredient record. These IDs are independent of mapping status and
-provide persistent references for KG-Hub integration.
+provide persistent references for knowledge-graph integration.
 
 Usage:
     python scripts/add_mediaingredientmech_ids.py --dry-run


### PR DESCRIPTION
## Summary

Three bundled cleanups, each reviewable per-section.

### 1. Issue #1 Phase 3 — initial `environmental_context` annotations
13 entries across 10 high-confidence records. Covers `NATURAL_SOURCE` and `ENVIRONMENT_MIMIC` relevance categories; the other three (`REQUIRED_FOR_ORGANISM`, `SELECTIVE_AGENT`, `COMMONLY_USED`) need per-organism literature review.

| Ingredient | Identifier | ENVO term(s) → relevance |
|---|---|---|
| Sea water | `ENVO:00002149` | sea water → NATURAL_SOURCE; marine biome → NATURAL_SOURCE |
| Soil | `ENVO:00001998` | soil → NATURAL_SOURCE |
| Garden soil | `ENVO:00002263` | garden soil → NATURAL_SOURCE |
| Soil extract | `MICRO:0000457` | soil → NATURAL_SOURCE |
| Filtered Seawater | `MICRO:0001773` | sea water → NATURAL_SOURCE |
| Natural sea water | `kgmicrobe.ingredient:natural_sea_water` | sea water → NATURAL_SOURCE |
| Pasteurized Seawater | `kgmicrobe.ingredient:pasteurized_seawater` | sea water → NATURAL_SOURCE |
| NaCl | `CHEBI:26710` | sea water → ENVIRONMENT_MIMIC; hypersaline lake → ENVIRONMENT_MIMIC |
| Hydrogen sulfide | `CHEBI:16136` | marine hydrothermal vent biome → ENVIRONMENT_MIMIC |
| Sulfur (elemental) | `CHEBI:26833` | marine hydrothermal vent biome → NATURAL_SOURCE; hot spring → NATURAL_SOURCE |

Every ENVO ID was verified against OLS4 before insertion. Two ENVO IDs quoted in [issue #1](https://github.com/CultureBotAI/MediaIngredientMech/issues/1) turned out to be wrong (saline lake was `ENVO:00002044` which actually labels "sludge" — real ID is `ENVO:00000019`; hypersaline lake is `ENVO:01001020`).

### 2. Re-map 2 obsolete CHEBI records

- **`CHEBI:8150` (Bacto Soytone)**: obsolete in CHEBI (OLS4 returns IRI fragment as label). Merged into `FOODON:03315720` (Soy peptone), the canonical record that already carried `"Soytone (BD-Difco)"` as a `CATALOG_VARIANT`. Synonyms unioned (`+Bacto Soytone`), occurrence_statistics summed (`+47/+47`), `merged` list extended, source set to `mapping_status: REJECTED` with `representative: FOODON:03315720`. Uses the same `MERGED_FROM_DUPLICATES` pattern `audit_mim_merge` has used elsewhere.
- **`CHEBI:1`** (preferred_term literally `"CHEBI:1"`, obsolete, 3 occurrences, no synonyms): flagged `mapping_status: NEEDS_EXPERT`. Cannot infer the intended ingredient without curator access to the 3 originating media recipes.

### 3. Drop stale `KG-Hub` text reference
`scripts/add_mediaingredientmech_ids.py` docstring referenced "KG-Hub integration" → updated to "knowledge-graph integration". One-line cosmetic fix. (The whole script is dead-code remnant of the rolled-back `MediaIngredientMech:NNNNNN` dual-ID scheme; deleting it is a separate decision.)

## Verification

- [x] `linkml-validate -s mediaingredientmech.yaml -C IngredientCollection data/curated/mapped_ingredients.yaml data/curated/unmapped_ingredients.yaml` → 0 errors
- [x] `pytest tests/test_environmental_context.py` → 49 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)