### PR TITLE
Port audit machinery from CultureMech (validate-strict + write_validated_ingredient + record_curation_event + audit_writers)

### DIFF
--- a/.claude/skills/schema-gap-analysis/skill.md
+++ b/.claude/skills/schema-gap-analysis/skill.md
@@ -1,10 +1,10 @@
 ---
 name: schema-gap-analysis
-description: Find gaps between MIM's LinkML schema, its YAML instances, and the code that generates them. Uses linkml-validate as ground truth and reports along three axes (schema / instances / process). Copy-paste runnable.
+description: Find gaps between MIM's LinkML schema, its YAML instances, and the code that generates them. Uses linkml-validate (or the strict closed-schema harness ported from CultureMech) as ground truth and reports along three axes (schema / instances / process). Copy-paste runnable.
 category: quality
 requires_database: false
 requires_internet: false
-version: 2.1.0
+version: 2.2.0
 ---
 
 # Schema gap analysis (MIM)
@@ -13,6 +13,42 @@ The conceptual framework — why three axes (schema / instances / process), what
 https://github.com/CultureBotAI/culturebotai-claw/blob/main/.claude/skills/schema-gap-analysis/skill.md
 
 This file is the MIM-specific operational version: every command below is ready to run as-is, with MIM paths baked in.
+
+## Fast path (preferred)
+
+The CultureMech audit machinery is ported (see PR opening this section).
+Two recipes replace most of the bash boilerplate below:
+
+```bash
+just validate-strict   # closed-schema parallel walk of data/ingredients/** + data/curated/**;
+                       # writes reports/instance_validation_failures.tsv with one row per ERROR
+                       # categorized (unexpected_field / missing_required / enum_mismatch /
+                       # format_mismatch / pattern_mismatch / type_mismatch / range_violation /
+                       # other / yaml_parse_error / empty_file / validator_crash).
+                       # Excludes data/curated/backups/ and data/snapshots/.
+
+just audit-writers     # inventory every YAML-writing script and check for
+                       # write_validated_ingredient + record_curation_event
+                       # adoption. Writes reports/pipeline_writers_audit.tsv.
+```
+
+Both recipes also live in the `qc` composite (`just qc`). Histogram the
+strict-validator TSV with:
+
+```bash
+awk -F'\t' 'NR>1 {print $3}' reports/instance_validation_failures.tsv | sort | uniq -c | sort -rn
+```
+
+For deeper drill-down (e.g. distinct fields in `unexpected_field` rows):
+
+```bash
+awk -F'\t' 'NR>1 && $3=="unexpected_field" {print $4}' \
+  reports/instance_validation_failures.tsv | sort | uniq -c | sort -rn
+```
+
+The legacy `linkml-validate` invocations below remain useful when you
+need to validate a single ad-hoc file outside the standard roots or
+inspect raw validator messages with full context.
 
 ## Setup
 
@@ -136,6 +172,10 @@ linkml-validate \
 
 ## Pointers
 
+- Strict closed-schema harness (preferred entrypoint): `scripts/validate_strict.py` (`just validate-strict`)
+- Writer audit (process-axis inventory): `scripts/audit_writers.py` (`just audit-writers`)
+- Write-time validation gate (use in any new writer script): `src/mediaingredientmech/validation/write_validated.py` (`write_validated_ingredient`)
+- Curation-event helper (use to leave an audit trail): `src/mediaingredientmech/curate/curation_event.py` (`record_curation_event`)
 - Custom (tolerant) validator the skill is calibrated against: `src/mediaingredientmech/validation/schema_validator.py`
 - Schema: `src/mediaingredientmech/schema/mediaingredientmech.yaml`
 - Curator (use for instance-axis fixes): `src/mediaingredientmech/curation/ingredient_curator.py`

--- a/justfile
+++ b/justfile
@@ -30,6 +30,22 @@ import-data:
 validate-all:
     python scripts/validate_all.py --mode both
 
+# Strict closed-schema validation: in-process LinkML validator with
+# JsonschemaValidationPlugin(closed=True) so unknown fields are flagged.
+# Walks data/ingredients/{mapped,unmapped} and data/curated by default.
+# Emits a categorized TSV (reports/instance_validation_failures.tsv) and
+# exits non-zero if any ERROR rows were produced.
+validate-strict *args:
+    uv run python scripts/validate_strict.py {{args}}
+
+# Inventory YAML-writing scripts under scripts/ and the central curation /
+# utils packages. Records whether each writer validates before writing
+# and whether it appends a curation_history event. Output:
+# reports/pipeline_writers_audit.tsv. Useful for tracking adoption of
+# write_validated_ingredient + record_curation_event over time.
+audit-writers:
+    uv run python scripts/audit_writers.py --out reports/pipeline_writers_audit.tsv
+
 # Verify literature snippets in evidence claims appear verbatim in
 # cached PubMed abstracts. Anti-hallucination gate. See
 # ../culturebotai-claw/.claude/skills/evidence-reference-validation/.
@@ -49,8 +65,9 @@ fetch-pubmed *args:
 qc-sssom:
     python3 scripts/validate_sssom_invariants.py
 
-# Composite QC: schema validation + evidence reference validation + SSSOM invariants.
-qc: validate-all qc-evidence qc-sssom
+# Composite QC: schema validation + strict closed-schema check +
+# evidence reference validation + SSSOM invariants.
+qc: validate-all validate-strict qc-evidence qc-sssom
 
 # Render per-ingredient HTML detail pages from data/ingredients/*.yaml
 # into pages/ingredient/. Idempotent (skips fresh outputs); --force

--- a/scripts/add_match_level.py
+++ b/scripts/add_match_level.py
@@ -18,9 +18,7 @@ import yaml
 from rich.console import Console
 from rich.table import Table
 
-from mediaingredientmech.curate.curation_event import record_curation_event
 from mediaingredientmech.utils.yaml_handler import save_yaml
-from mediaingredientmech.validation.write_validated import ValidationFailedError
 
 console = Console()
 

--- a/scripts/add_match_level.py
+++ b/scripts/add_match_level.py
@@ -18,6 +18,10 @@ import yaml
 from rich.console import Console
 from rich.table import Table
 
+from mediaingredientmech.curate.curation_event import record_curation_event
+from mediaingredientmech.utils.yaml_handler import save_yaml
+from mediaingredientmech.validation.write_validated import ValidationFailedError
+
 console = Console()
 
 # Pattern matching rules for inferring match_level
@@ -109,8 +113,8 @@ def process_batch_file(
 
     # Save if not dry run
     if not dry_run and suggestions:
-        with open(file_path, "w") as f:
-            yaml.dump(data, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
+        # Batch suggestion files are not IngredientCollections; skip validate=True.
+        save_yaml(data, file_path)
         console.print(f"  [green]✓ Saved {len(suggestions)} suggestions[/green]")
     elif dry_run:
         console.print(f"  [dim](Dry run - not saved)[/dim]")

--- a/scripts/audit_writers.py
+++ b/scripts/audit_writers.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Audit YAML-writing scripts in MediaIngredientMech.
+
+For every Python module under ``scripts/`` and the central
+``src/mediaingredientmech/{curation,utils}`` packages that writes a YAML
+(looks for ``yaml.dump``, ``yaml.safe_dump``, ``write_validated_ingredient``,
+or ``.write_text(`` on a ``.yaml`` path), record:
+
+  - target_kind: ``ingredient`` (writes back to per-ingredient or collection
+    YAML in ``data/ingredients/`` or ``data/curated/``), ``report`` (writes
+    a manifest / report / log / analysis output), ``mixed`` (does both --
+    typically importers that write ingredients plus a sibling index), or
+    ``unknown`` (couldn't classify from the script source).
+  - appends to ``curation_history``?
+  - has a ``--dry-run`` flag?
+  - calls ``write_validated_ingredient()`` (or ``linkml-validate`` etc.)
+    before writing?
+  - is mentioned in ``justfile`` (i.e. wired into a target)?
+
+TSV columns: path, writes_yaml, target_kind, appends_curation_history,
+has_dry_run, validates_before_write, wired_into_just.
+
+Use ``target_kind`` to scope follow-up work --
+``record_curation_event()`` adoption is meaningful only for ``ingredient``
+and ``mixed`` writers; reports / manifests / logs aren't ingredients and
+don't have a curation history.
+
+Output: TSV to stdout (and via ``--out`` to a file).
+
+Ported from CultureMech's ``scripts/audit_writers.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(".").resolve()
+SEARCH_DIRS = [
+    Path("scripts"),
+    Path("src/mediaingredientmech/curation"),
+    Path("src/mediaingredientmech/utils"),
+]
+
+# Patterns
+_WRITE_YAML_HINT = re.compile(r"\.ya?ml['\"]|\.yaml\b")
+_CURATION_APPEND = re.compile(
+    r"curation_history.*?(append|\+=|\.insert)"
+    r"|['\"]curator['\"]\s*:"
+    r"|append_curation_event"
+    r"|record_curation_event"
+    r"|_add_event\("
+)
+_DRY_RUN = re.compile(r"--dry[-_]run|dry_run\s*[:=]")
+_VALIDATE_BEFORE_WRITE = re.compile(
+    r"linkml[._-]?validate"
+    r"|RecipeValidator"
+    r"|validate_recipe\("
+    r"|validate_ingredient\("
+    r"|validator\.validate\("
+    r"|write_validated_ingredient\("
+    r"|write_validated_recipe\("
+    # save_yaml(..., validate=True ...) — the package-level helper's opt-in
+    # that routes through write_validated_ingredient.
+    r"|save_yaml\([^)]*validate\s*=\s*True"
+)
+# Heuristic for "writes back to an ingredient YAML under data/ingredients/
+# or data/curated/" (i.e. would benefit from a CurationEvent) vs writes a
+# report/manifest/index (where curation_history is meaningless).
+_INGREDIENT_WRITER = re.compile(
+    r"data/ingredients/"
+    r"|data/curated/"
+    r"|mapped_ingredients\.yaml"
+    r"|unmapped_[A-Za-z_]+\.yaml"
+    r"|write_validated_ingredient\("
+    r"|save_yaml\("
+    r"|IngredientCurator"
+)
+_REPORT_WRITER = re.compile(
+    # Narrowly target report/manifest/log sinks. Match argparse-style
+    # `args.output`/`args.report` and explicit report/log path names.
+    r"args\.output\b"
+    r"|args\.report\b"
+    r"|out\.write_text\b"
+    r"|report_file\b"
+    r"|report_path\b"
+    r"|log_file\b"
+    r"|manifest\b"
+    r"|reports/\S+\.(tsv|json|md|yaml)"
+    r"|\.tsv['\"]?\)"
+    r"|\.json['\"]?\)"
+)
+
+
+def script_paths() -> list[Path]:
+    out: list[Path] = []
+    for d in SEARCH_DIRS:
+        if not d.exists():
+            continue
+        out.extend(sorted(p for p in d.rglob("*.py") if "__pycache__" not in str(p)))
+    return out
+
+
+def looks_like_yaml_writer(text: str) -> bool:
+    if "yaml.safe_dump(" in text or "yaml.dump(" in text:
+        return True
+    # write_validated_ingredient is the helper that wraps yaml.safe_dump.
+    if "write_validated_ingredient(" in text:
+        return True
+    # save_yaml(...) from mediaingredientmech.utils.yaml_handler — the
+    # package-level helper that all converted writer scripts route through.
+    if "save_yaml(" in text:
+        return True
+    # `.write_text(` only counts if combined with a yaml hint nearby.
+    if ".write_text(" in text and _WRITE_YAML_HINT.search(text):
+        return True
+    return False
+
+
+def audit(path: Path, justfile_text: str) -> dict | None:
+    try:
+        text = path.read_text()
+    except (UnicodeDecodeError, OSError):
+        return None
+    if not looks_like_yaml_writer(text):
+        return None
+    # Categorize: a writer that *only* writes reports/manifests does not
+    # benefit from CurationEvent — flag separately so follow-ups stay
+    # focused on actual ingredient modifiers.
+    ingredient = bool(_INGREDIENT_WRITER.search(text))
+    report = bool(_REPORT_WRITER.search(text))
+    if ingredient and not report:
+        target = "ingredient"
+    elif report and not ingredient:
+        target = "report"
+    elif ingredient and report:
+        target = "mixed"
+    else:
+        target = "unknown"
+    return {
+        "path": str(path),
+        "writes_yaml": "yes",
+        "target_kind": target,
+        "appends_curation_history": "yes" if _CURATION_APPEND.search(text) else "no",
+        "has_dry_run": "yes" if _DRY_RUN.search(text) else "no",
+        "validates_before_write": "yes" if _VALIDATE_BEFORE_WRITE.search(text) else "no",
+        "wired_into_just": "yes" if path.stem in justfile_text or path.name in justfile_text else "no",
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--out", type=Path, default=None, help="TSV output path (default stdout)")
+    args = ap.parse_args()
+
+    justfile_path = Path("justfile")
+    justfile_text = justfile_path.read_text() if justfile_path.exists() else ""
+
+    rows: list[dict] = []
+    for p in script_paths():
+        row = audit(p, justfile_text)
+        if row is not None:
+            rows.append(row)
+
+    fields = [
+        "path",
+        "writes_yaml",
+        "target_kind",
+        "appends_curation_history",
+        "has_dry_run",
+        "validates_before_write",
+        "wired_into_just",
+    ]
+
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        with args.out.open("w", newline="") as fh:
+            w = csv.DictWriter(fh, fieldnames=fields, delimiter="\t", lineterminator="\n")
+            w.writeheader()
+            for row in rows:
+                w.writerow(row)
+        print(f"Wrote {len(rows)} rows to {args.out}", file=sys.stderr)
+    else:
+        w = csv.DictWriter(sys.stdout, fieldnames=fields, delimiter="\t")
+        w.writeheader()
+        for row in rows:
+            w.writerow(row)
+
+    # Print summary
+    def count(field: str, val: str) -> int:
+        return sum(1 for r in rows if r[field] == val)
+
+    ingredient_writers = [r for r in rows if r["target_kind"] in ("ingredient", "mixed")]
+
+    print("", file=sys.stderr)
+    print(f"=== writers audit summary ({len(rows)} writers) ===", file=sys.stderr)
+    print(
+        f"  target kind:                ingredient={count('target_kind', 'ingredient')} "
+        f"mixed={count('target_kind', 'mixed')} report={count('target_kind', 'report')} "
+        f"unknown={count('target_kind', 'unknown')}",
+        file=sys.stderr,
+    )
+    print(
+        f"  appends curation_history:   {count('appends_curation_history', 'yes')} / {len(rows)}",
+        file=sys.stderr,
+    )
+    print(
+        f"  (ingredient writers only) appends curation_history: "
+        f"{sum(1 for r in ingredient_writers if r['appends_curation_history']=='yes')} / "
+        f"{len(ingredient_writers)}",
+        file=sys.stderr,
+    )
+    print(
+        f"  has --dry-run:              {count('has_dry_run', 'yes')} / {len(rows)}",
+        file=sys.stderr,
+    )
+    print(
+        f"  validates before write:     {count('validates_before_write', 'yes')} / {len(rows)}",
+        file=sys.stderr,
+    )
+    print(
+        f"  wired into justfile:        {count('wired_into_just', 'yes')} / {len(rows)}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/audit_writers.py
+++ b/scripts/audit_writers.py
@@ -38,7 +38,6 @@ import re
 import sys
 from pathlib import Path
 
-ROOT = Path(".").resolve()
 SEARCH_DIRS = [
     Path("scripts"),
     Path("src/mediaingredientmech/curation"),

--- a/scripts/backfill_ontology_labels.py
+++ b/scripts/backfill_ontology_labels.py
@@ -28,7 +28,6 @@ import yaml
 from rich.console import Console
 from rich.progress import Progress
 
-from mediaingredientmech.curate.curation_event import record_curation_event
 from mediaingredientmech.utils.yaml_handler import save_yaml
 from mediaingredientmech.validation.write_validated import ValidationFailedError
 

--- a/scripts/backfill_ontology_labels.py
+++ b/scripts/backfill_ontology_labels.py
@@ -17,6 +17,7 @@ Usage::
 
 from __future__ import annotations
 
+import sys
 import time
 import urllib.parse
 from pathlib import Path
@@ -26,6 +27,10 @@ import requests
 import yaml
 from rich.console import Console
 from rich.progress import Progress
+
+from mediaingredientmech.curate.curation_event import record_curation_event
+from mediaingredientmech.utils.yaml_handler import save_yaml
+from mediaingredientmech.validation.write_validated import ValidationFailedError
 
 console = Console()
 
@@ -180,13 +185,12 @@ def main(input_path: Path, dry_run: bool, sleep: float):
         console.print(f"Unresolved sample: {', '.join(miss_list[:10])}")
 
     if filled:
-        # Match IngredientCurator.save() yaml.dump settings (default width=80)
-        # so this script's writes don't reformat unrelated lines.
-        with open(input_path, "w") as f:
-            yaml.dump(
-                data, f, default_flow_style=False, sort_keys=False,
-                allow_unicode=True,
-            )
+        try:
+            save_yaml(data, input_path, validate=True, target_class="IngredientCollection")
+        except ValidationFailedError as exc:
+            console.print("[red]validation failed: refusing to write[/red]")
+            print(exc.summary(), file=sys.stderr)
+            raise
         console.print(f"[bold green]Saved to {input_path}[/bold green]")
 
 

--- a/scripts/batch_curate_unmapped.py
+++ b/scripts/batch_curate_unmapped.py
@@ -30,12 +30,15 @@ from rich.table import Table
 _project_root = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_project_root / "src"))
 
+from mediaingredientmech.curate.curation_event import record_curation_event
 from mediaingredientmech.curation.ingredient_curator import IngredientCurator
 from mediaingredientmech.utils.chemical_normalizer import (
     categorize_unmapped_name,
     normalize_chemical_name,
 )
 from mediaingredientmech.utils.ontology_client import OntologyClient
+from mediaingredientmech.utils.yaml_handler import save_yaml
+from mediaingredientmech.validation.write_validated import ValidationFailedError
 
 console = Console()
 
@@ -88,9 +91,8 @@ class BatchCurationSession:
                 'decisions': self.decisions,
                 'last_updated': datetime.now(timezone.utc).isoformat(),
             }
-            self.resume_file.parent.mkdir(parents=True, exist_ok=True)
-            with open(self.resume_file, 'w') as f:
-                yaml.dump(data, f, sort_keys=False)
+            # Session resume file is not an IngredientCollection; skip validation.
+            save_yaml(data, self.resume_file)
 
     def export_decisions(self, output_path: Path) -> None:
         """Export curation decisions to CSV."""

--- a/scripts/batch_curate_unmapped.py
+++ b/scripts/batch_curate_unmapped.py
@@ -30,7 +30,6 @@ from rich.table import Table
 _project_root = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_project_root / "src"))
 
-from mediaingredientmech.curate.curation_event import record_curation_event
 from mediaingredientmech.curation.ingredient_curator import IngredientCurator
 from mediaingredientmech.utils.chemical_normalizer import (
     categorize_unmapped_name,
@@ -38,7 +37,6 @@ from mediaingredientmech.utils.chemical_normalizer import (
 )
 from mediaingredientmech.utils.ontology_client import OntologyClient
 from mediaingredientmech.utils.yaml_handler import save_yaml
-from mediaingredientmech.validation.write_validated import ValidationFailedError
 
 console = Console()
 

--- a/scripts/enrich_chemical_properties.py
+++ b/scripts/enrich_chemical_properties.py
@@ -21,7 +21,6 @@ from rich.table import Table
 _project_root = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_project_root / "src"))
 
-from mediaingredientmech.curate.curation_event import record_curation_event
 from mediaingredientmech.utils.chemical_properties_client import (
     ChemicalPropertiesClient,
 )

--- a/scripts/enrich_chemical_properties.py
+++ b/scripts/enrich_chemical_properties.py
@@ -21,9 +21,12 @@ from rich.table import Table
 _project_root = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_project_root / "src"))
 
+from mediaingredientmech.curate.curation_event import record_curation_event
 from mediaingredientmech.utils.chemical_properties_client import (
     ChemicalPropertiesClient,
 )
+from mediaingredientmech.utils.yaml_handler import save_yaml
+from mediaingredientmech.validation.write_validated import ValidationFailedError
 
 console = Console()
 
@@ -32,22 +35,6 @@ def load_ingredients(yaml_path: Path) -> dict:
     """Load ingredients from YAML file."""
     with open(yaml_path) as f:
         return yaml.safe_load(f)
-
-
-def save_ingredients(yaml_path: Path, data: dict):
-    """Save ingredients to YAML file.
-
-    Matches IngredientCurator.save() yaml.dump settings (default width=80)
-    so enrichment runs don't reformat unrelated lines.
-    """
-    with open(yaml_path, "w") as f:
-        yaml.dump(
-            data,
-            f,
-            default_flow_style=False,
-            sort_keys=False,
-            allow_unicode=True,
-        )
 
 
 def filter_chebi_without_properties(data: dict) -> list[dict]:
@@ -253,7 +240,12 @@ def main(
     if enriched_count > 0:
         # Save output
         output_path = output_path or input_path
-        save_ingredients(output_path, data)
+        try:
+            save_yaml(data, output_path, validate=True, target_class="IngredientCollection")
+        except ValidationFailedError as exc:
+            console.print("\n[red]validation failed: refusing to write[/red]")
+            print(exc.summary(), file=sys.stderr)
+            raise
         console.print(f"\n[bold green]Saved to {output_path}[/bold green]")
     else:
         console.print("\n[yellow]No enrichment performed - nothing to save[/yellow]")

--- a/scripts/enrich_from_ols.py
+++ b/scripts/enrich_from_ols.py
@@ -14,7 +14,6 @@ import json
 import sys
 import time
 from pathlib import Path
-from datetime import datetime, timezone
 
 import yaml
 from rich.console import Console
@@ -23,8 +22,11 @@ from rich.progress import Progress, SpinnerColumn, TimeElapsedColumn, TimeRemain
 # Add src to path
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
+from mediaingredientmech.curate.curation_event import record_curation_event
 from mediaingredientmech.curation.ingredient_curator import IngredientCurator
+from mediaingredientmech.utils.yaml_handler import save_yaml
 from mediaingredientmech.validation.ingredient_reviewer import IngredientReviewer
+from mediaingredientmech.validation.write_validated import ValidationFailedError
 
 console = Console()
 
@@ -47,10 +49,17 @@ def save_mapped_ingredients(collection):
     metadata (`generation_date`, `total_count`, `mapped_count`,
     `unmapped_count`) instead of writing only `{"ingredients": ...}`.
     """
-    with open(MAPPED_FILE, "w") as f:
-        yaml.dump(
-            collection, f, default_flow_style=False, sort_keys=False, allow_unicode=True
+    try:
+        save_yaml(
+            collection,
+            MAPPED_FILE,
+            validate=True,
+            target_class="IngredientCollection",
         )
+    except ValidationFailedError as exc:
+        console.print("[red]validation failed: refusing to write[/red]")
+        print(exc.summary(), file=sys.stderr)
+        raise
 
 
 def load_checkpoint() -> dict:
@@ -174,20 +183,15 @@ def main():
                         # Add chemical properties
                         ingredient["chemical_properties"] = properties
 
-                        # Add curation history event
-                        if "curation_history" not in ingredient:
-                            ingredient["curation_history"] = []
-
-                        ingredient["curation_history"].append({
-                            "timestamp": datetime.now(timezone.utc).isoformat(),
-                            "curator": "enrich_from_ols.py",
-                            "action": "AUTO_BACKFILL_CHEBI_CHEMISTRY",
-                            "changes": (
+                        record_curation_event(
+                            ingredient,
+                            curator="enrich_from_ols.py",
+                            action="AUTO_BACKFILL_CHEBI_CHEMISTRY",
+                            changes=(
                                 "Enriched chemical_properties from EBI OLS v4: "
                                 + ", ".join(sorted(properties.keys()))
                             ),
-                            "llm_assisted": False,
-                        })
+                        )
 
                         enriched_count += 1
 

--- a/scripts/enrich_with_concentration_notes.py
+++ b/scripts/enrich_with_concentration_notes.py
@@ -14,11 +14,16 @@ Usage:
 import argparse
 import os
 import re
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 import yaml
+
+from mediaingredientmech.curate.curation_event import record_curation_event
+from mediaingredientmech.utils.yaml_handler import save_yaml
+from mediaingredientmech.validation.write_validated import ValidationFailedError
 
 
 # Default paths are relative to the repo root. Override the sibling
@@ -40,13 +45,6 @@ def load_yaml(path: Path) -> dict:
     """Load a YAML file."""
     with open(path, "r", encoding="utf-8") as f:
         return yaml.safe_load(f)
-
-
-def save_yaml(data: dict, path: Path):
-    """Save data to YAML file."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "w", encoding="utf-8") as f:
-        yaml.dump(data, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
 
 
 def normalize_term(term: str) -> str:
@@ -131,14 +129,13 @@ def enrich_ingredient(mi_record: dict, cm_ingredient: dict) -> int:
 
     # Add curation event if synonyms were added
     if new_count > 0:
-        event = {
-            "timestamp": TIMESTAMP,
-            "curator": "enrich_with_concentration_notes",
-            "action": "SYNONYMS_ENRICHED",
-            "changes": f"Added {new_count} role annotations from CultureMech concentration_info",
-            "llm_assisted": False,
-        }
-        mi_record.setdefault("curation_history", []).append(event)
+        record_curation_event(
+            mi_record,
+            curator="enrich_with_concentration_notes",
+            action="SYNONYMS_ENRICHED",
+            changes=f"Added {new_count} role annotations from CultureMech concentration_info",
+            timestamp=TIMESTAMP,
+        )
 
     return new_count
 
@@ -235,7 +232,12 @@ def perform_enrichment(dry_run: bool = False) -> dict:
     # Save if not dry-run
     if not dry_run:
         print("\nSaving enriched data...")
-        save_yaml(mi_data, mi_path)
+        try:
+            save_yaml(mi_data, mi_path, validate=True, target_class="IngredientCollection")
+        except ValidationFailedError as exc:
+            print("validation failed: refusing to write", file=sys.stderr)
+            print(exc.summary(), file=sys.stderr)
+            raise
         print(f"✅ Saved to {mi_path}")
     else:
         print("\n[DRY RUN] No files written.")

--- a/scripts/import_from_culturemech.py
+++ b/scripts/import_from_culturemech.py
@@ -9,11 +9,16 @@ Usage:
 """
 
 import argparse
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 import yaml
+
+from mediaingredientmech.curate.curation_event import record_curation_event
+from mediaingredientmech.utils.yaml_handler import save_yaml
+from mediaingredientmech.validation.write_validated import ValidationFailedError
 
 
 # Default paths
@@ -31,18 +36,6 @@ def load_source(path: Path) -> dict:
     """Load a CultureMech YAML file."""
     with open(path, "r", encoding="utf-8") as f:
         return yaml.safe_load(f)
-
-
-def make_curation_event() -> dict:
-    """Create an initial IMPORTED curation event."""
-    return {
-        "timestamp": TIMESTAMP,
-        "curator": "import_from_culturemech",
-        "action": "IMPORTED",
-        "changes": "Initial import from CultureMech pipeline",
-        "new_status": None,  # set per-record
-        "llm_assisted": False,
-    }
 
 
 def extract_synonyms(ingredient: dict) -> list[dict]:
@@ -116,9 +109,6 @@ def convert_mapped_ingredient(ingredient: dict) -> dict:
     ontology_id = ingredient["ontology_id"]
     ontology_source = ingredient.get("ontology_source", "CHEBI")
 
-    event = make_curation_event()
-    event["new_status"] = "MAPPED"
-
     record: dict[str, Any] = {
         "ontology_id": ontology_id,
         "preferred_term": ingredient["preferred_term"],
@@ -141,8 +131,16 @@ def convert_mapped_ingredient(ingredient: dict) -> dict:
             "total_occurrences": ingredient.get("occurrence_count", 0),
             "media_count": len(ingredient.get("media_occurrences", [])),
         },
-        "curation_history": [event],
     }
+
+    record_curation_event(
+        record,
+        curator="import_from_culturemech",
+        action="IMPORTED",
+        changes="Initial import from CultureMech pipeline",
+        new_status="MAPPED",
+        timestamp=TIMESTAMP,
+    )
 
     return record
 
@@ -155,9 +153,6 @@ def convert_unmapped_ingredient(ingredient: dict, index: int) -> dict:
     # Use parsed_chemical_name as preferred_term if available, else placeholder_id
     preferred_term = ingredient.get("parsed_chemical_name", placeholder) or placeholder or f"Unmapped ingredient {index}"
 
-    event = make_curation_event()
-    event["new_status"] = "UNMAPPED"
-
     record: dict[str, Any] = {
         "ontology_id": identifier,
         "preferred_term": preferred_term,
@@ -167,9 +162,17 @@ def convert_unmapped_ingredient(ingredient: dict, index: int) -> dict:
             "total_occurrences": ingredient.get("occurrence_count", 0),
             "media_count": len(ingredient.get("media_occurrences", [])),
         },
-        "curation_history": [event],
         "notes": f"CultureMech placeholder_id: {placeholder}",
     }
+
+    record_curation_event(
+        record,
+        curator="import_from_culturemech",
+        action="IMPORTED",
+        changes="Initial import from CultureMech pipeline",
+        new_status="UNMAPPED",
+        timestamp=TIMESTAMP,
+    )
 
     return record
 
@@ -196,9 +199,11 @@ def import_mapped(source_dir: Path, output_dir: Path) -> int:
     collection = build_collection(records, mapped_count=len(records), unmapped_count=0)
 
     output_path = output_dir / "mapped_ingredients.yaml"
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(output_path, "w", encoding="utf-8") as f:
-        yaml.dump(collection, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
+    try:
+        save_yaml(collection, output_path, validate=True, target_class="IngredientCollection")
+    except ValidationFailedError as exc:
+        print(exc.summary(), file=sys.stderr)
+        raise
 
     print(f"Wrote {len(records)} mapped ingredients to {output_path}")
     return len(records)
@@ -217,9 +222,11 @@ def import_unmapped(source_dir: Path, output_dir: Path) -> int:
     collection = build_collection(records, mapped_count=0, unmapped_count=len(records))
 
     output_path = output_dir / "unmapped_ingredients.yaml"
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(output_path, "w", encoding="utf-8") as f:
-        yaml.dump(collection, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
+    try:
+        save_yaml(collection, output_path, validate=True, target_class="IngredientCollection")
+    except ValidationFailedError as exc:
+        print(exc.summary(), file=sys.stderr)
+        raise
 
     print(f"Wrote {len(records)} unmapped ingredients to {output_path}")
     return len(records)

--- a/scripts/map_batch_priority.py
+++ b/scripts/map_batch_priority.py
@@ -1,9 +1,14 @@
 #!/usr/bin/env python3
 """Map high-priority unmapped ingredients from curation list."""
 
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 import yaml
+
+from mediaingredientmech.curate.curation_event import record_curation_event
+from mediaingredientmech.utils.yaml_handler import save_yaml
+from mediaingredientmech.validation.write_validated import ValidationFailedError
 
 # Paths
 DATA_DIR = Path(__file__).parent.parent / "data" / "curated"
@@ -50,12 +55,6 @@ def load_yaml(path):
         return yaml.safe_load(f)
 
 
-def save_yaml(data, path):
-    """Save YAML file."""
-    with open(path, "w", encoding="utf-8") as f:
-        yaml.dump(data, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
-
-
 def map_ingredient(record, mapping):
     """Apply mapping to ingredient record."""
     # Update core fields
@@ -82,13 +81,12 @@ def map_ingredient(record, mapping):
     }
 
     # Add curation event
-    record.setdefault("curation_history", []).append({
-        "timestamp": TIMESTAMP,
-        "curator": "map_batch_priority",
-        "action": "MAPPED",
-        "changes": f"Mapped to {mapping['ontology_id']} ({mapping['ontology_label']})",
-        "llm_assisted": False,
-    })
+    record_curation_event(
+        record,
+        curator="map_batch_priority",
+        action="MAPPED",
+        changes=f"Mapped to {mapping['ontology_id']} ({mapping['ontology_label']})",
+    )
 
     return record
 
@@ -149,8 +147,13 @@ def main():
 
     # Save files
     print("Saving updated files...")
-    save_yaml(unmapped_data, UNMAPPED_PATH)
-    save_yaml(mapped_data, MAPPED_PATH)
+    try:
+        save_yaml(unmapped_data, UNMAPPED_PATH, validate=True, target_class="IngredientCollection")
+        save_yaml(mapped_data, MAPPED_PATH, validate=True, target_class="IngredientCollection")
+    except ValidationFailedError as exc:
+        print(f"  ✗ validation failed: refusing to write", file=sys.stderr)
+        print(exc.summary(), file=sys.stderr)
+        raise
     print(f"  ✓ Saved {UNMAPPED_PATH}")
     print(f"  ✓ Saved {MAPPED_PATH}")
     print()

--- a/scripts/map_final_two.py
+++ b/scripts/map_final_two.py
@@ -1,9 +1,14 @@
 #!/usr/bin/env python3
 """Map the final 2 ingredients from OTHER category."""
 
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 import yaml
+
+from mediaingredientmech.curate.curation_event import record_curation_event
+from mediaingredientmech.utils.yaml_handler import save_yaml
+from mediaingredientmech.validation.write_validated import ValidationFailedError
 
 # Paths
 DATA_DIR = Path(__file__).parent.parent / "data" / "curated"
@@ -43,12 +48,6 @@ def load_yaml(path):
         return yaml.safe_load(f)
 
 
-def save_yaml(data, path):
-    """Save YAML file."""
-    with open(path, "w", encoding="utf-8") as f:
-        yaml.dump(data, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
-
-
 def map_ingredient(record, mapping):
     """Apply mapping to ingredient record."""
     # Update core fields
@@ -75,13 +74,12 @@ def map_ingredient(record, mapping):
     }
 
     # Add curation event
-    record.setdefault("curation_history", []).append({
-        "timestamp": TIMESTAMP,
-        "curator": "map_final_two",
-        "action": "MAPPED",
-        "changes": f"Mapped to {mapping['ontology_id']} ({mapping['ontology_label']})",
-        "llm_assisted": False,
-    })
+    record_curation_event(
+        record,
+        curator="map_final_two",
+        action="MAPPED",
+        changes=f"Mapped to {mapping['ontology_id']} ({mapping['ontology_label']})",
+    )
 
     return record
 
@@ -143,8 +141,13 @@ def main():
 
     # Save files
     print("Saving updated files...")
-    save_yaml(unmapped_data, UNMAPPED_PATH)
-    save_yaml(mapped_data, MAPPED_PATH)
+    try:
+        save_yaml(unmapped_data, UNMAPPED_PATH, validate=True, target_class="IngredientCollection")
+        save_yaml(mapped_data, MAPPED_PATH, validate=True, target_class="IngredientCollection")
+    except ValidationFailedError as exc:
+        print(f"  ✗ validation failed: refusing to write", file=sys.stderr)
+        print(exc.summary(), file=sys.stderr)
+        raise
     print(f"  ✓ Saved {UNMAPPED_PATH}")
     print(f"  ✓ Saved {MAPPED_PATH}")
     print()

--- a/scripts/map_incomplete_formulas.py
+++ b/scripts/map_incomplete_formulas.py
@@ -5,9 +5,14 @@ Based on formula repair analysis with CAS verification and existing mapping
 cross-reference.
 """
 
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 import yaml
+
+from mediaingredientmech.curate.curation_event import record_curation_event
+from mediaingredientmech.utils.yaml_handler import save_yaml
+from mediaingredientmech.validation.write_validated import ValidationFailedError
 
 # Paths
 DATA_DIR = Path(__file__).parent.parent / "data" / "curated"
@@ -159,12 +164,6 @@ def load_yaml(path):
         return yaml.safe_load(f)
 
 
-def save_yaml(data, path):
-    """Save YAML file."""
-    with open(path, "w", encoding="utf-8") as f:
-        yaml.dump(data, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
-
-
 def map_repaired_formula(record, repair):
     """Apply formula repair mapping to ingredient record."""
     # Update core fields
@@ -213,13 +212,12 @@ def map_repaired_formula(record, repair):
     }
 
     # Add curation event
-    record.setdefault("curation_history", []).append({
-        "timestamp": TIMESTAMP,
-        "curator": "map_incomplete_formulas",
-        "action": "FORMULA_REPAIRED",
-        "changes": f"Repaired incomplete formula '{repair['incomplete']}' → '{repair['complete_formula']}' and mapped to {repair['ontology_id']} ({repair['ontology_label']})",
-        "llm_assisted": False,
-    })
+    record_curation_event(
+        record,
+        curator="map_incomplete_formulas",
+        action="FORMULA_REPAIRED",
+        changes=f"Repaired incomplete formula '{repair['incomplete']}' → '{repair['complete_formula']}' and mapped to {repair['ontology_id']} ({repair['ontology_label']})",
+    )
 
     # Update preferred term to corrected formula
     record["preferred_term"] = repair["complete_formula"]
@@ -289,8 +287,13 @@ def main():
 
     # Save files
     print("Saving updated files...")
-    save_yaml(unmapped_data, UNMAPPED_PATH)
-    save_yaml(mapped_data, MAPPED_PATH)
+    try:
+        save_yaml(unmapped_data, UNMAPPED_PATH, validate=True, target_class="IngredientCollection")
+        save_yaml(mapped_data, MAPPED_PATH, validate=True, target_class="IngredientCollection")
+    except ValidationFailedError as exc:
+        print(f"  ✗ validation failed: refusing to write", file=sys.stderr)
+        print(exc.summary(), file=sys.stderr)
+        raise
     print(f"  ✓ Saved {UNMAPPED_PATH}")
     print(f"  ✓ Saved {MAPPED_PATH}")
     print()

--- a/scripts/map_other_category.py
+++ b/scripts/map_other_category.py
@@ -1,9 +1,14 @@
 #!/usr/bin/env python3
 """Map the 5 mappable ingredients from OTHER category."""
 
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 import yaml
+
+from mediaingredientmech.curate.curation_event import record_curation_event
+from mediaingredientmech.utils.yaml_handler import save_yaml
+from mediaingredientmech.validation.write_validated import ValidationFailedError
 
 # Paths
 DATA_DIR = Path(__file__).parent.parent / "data" / "curated"
@@ -68,12 +73,6 @@ def load_yaml(path):
         return yaml.safe_load(f)
 
 
-def save_yaml(data, path):
-    """Save YAML file."""
-    with open(path, "w", encoding="utf-8") as f:
-        yaml.dump(data, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
-
-
 def map_ingredient(record, mapping):
     """Apply mapping to ingredient record."""
     # Update core fields
@@ -100,13 +99,12 @@ def map_ingredient(record, mapping):
     }
 
     # Add curation event
-    record.setdefault("curation_history", []).append({
-        "timestamp": TIMESTAMP,
-        "curator": "map_other_category",
-        "action": "MAPPED",
-        "changes": f"Mapped to {mapping['ontology_id']} ({mapping['ontology_label']})",
-        "llm_assisted": False,
-    })
+    record_curation_event(
+        record,
+        curator="map_other_category",
+        action="MAPPED",
+        changes=f"Mapped to {mapping['ontology_id']} ({mapping['ontology_label']})",
+    )
 
     return record
 
@@ -167,8 +165,13 @@ def main():
 
     # Save files
     print("Saving updated files...")
-    save_yaml(unmapped_data, UNMAPPED_PATH)
-    save_yaml(mapped_data, MAPPED_PATH)
+    try:
+        save_yaml(unmapped_data, UNMAPPED_PATH, validate=True, target_class="IngredientCollection")
+        save_yaml(mapped_data, MAPPED_PATH, validate=True, target_class="IngredientCollection")
+    except ValidationFailedError as exc:
+        print(f"  ✗ validation failed: refusing to write", file=sys.stderr)
+        print(exc.summary(), file=sys.stderr)
+        raise
     print(f"  ✓ Saved {UNMAPPED_PATH}")
     print(f"  ✓ Saved {MAPPED_PATH}")
     print()

--- a/scripts/merge_culturemech_updates.py
+++ b/scripts/merge_culturemech_updates.py
@@ -22,6 +22,10 @@ from typing import Any
 
 import yaml
 
+from mediaingredientmech.curate.curation_event import record_curation_event
+from mediaingredientmech.utils.yaml_handler import save_yaml
+from mediaingredientmech.validation.write_validated import ValidationFailedError
+
 
 # Default paths
 CULTUREMECH_DIR = Path(
@@ -43,13 +47,6 @@ def load_yaml(path: Path) -> dict:
         return yaml.safe_load(f)
 
 
-def save_yaml(data: dict, path: Path):
-    """Save data to YAML file."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "w", encoding="utf-8") as f:
-        yaml.dump(data, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
-
-
 def normalize_term(term: str) -> str:
     """Normalize an ingredient term for matching."""
     # Remove whitespace, lowercase, remove special chars
@@ -60,17 +57,6 @@ def normalize_term(term: str) -> str:
     # Remove extra whitespace
     normalized = re.sub(r"\s+", " ", normalized)
     return normalized
-
-
-def make_curation_event(action: str, changes: str, curator: str = "merge_culturemech_updates") -> dict:
-    """Create a curation history event."""
-    return {
-        "timestamp": TIMESTAMP,
-        "curator": curator,
-        "action": action,
-        "changes": changes,
-        "llm_assisted": False,
-    }
 
 
 def merge_synonyms(mi_record: dict, cm_ingredient: dict) -> list[dict]:
@@ -149,12 +135,13 @@ def merge_ingredient(mi_record: dict, cm_ingredient: dict, verbose: bool = False
                 "ontology_label", cm_ingredient["preferred_term"]
             )
 
-        # Add curation event
-        event = make_curation_event(
+        record_curation_event(
+            merged,
+            curator="merge_culturemech_updates",
             action="ONTOLOGY_UPDATE",
-            changes=f"Ontology changed from {mi_ontology} to {cm_ontology} (CultureMech update)"
+            changes=f"Ontology changed from {mi_ontology} to {cm_ontology} (CultureMech update)",
+            timestamp=TIMESTAMP,
         )
-        merged.setdefault("curation_history", []).append(event)
 
     # Merge synonyms
     merged_synonyms = merge_synonyms(mi_record, cm_ingredient)
@@ -164,11 +151,13 @@ def merge_ingredient(mi_record: dict, cm_ingredient: dict, verbose: bool = False
 
     # Add merge event if any changes
     if changes:
-        event = make_curation_event(
+        record_curation_event(
+            merged,
+            curator="merge_culturemech_updates",
             action="MERGED_UPDATE",
-            changes=f"Merged CultureMech update: {', '.join(changes.keys())}"
+            changes=f"Merged CultureMech update: {', '.join(changes.keys())}",
+            timestamp=TIMESTAMP,
         )
-        merged.setdefault("curation_history", []).append(event)
 
     if verbose and changes:
         print(f"  Updated {mi_record['preferred_term']}: {list(changes.keys())}")
@@ -218,12 +207,6 @@ def import_new_ingredient(cm_ingredient: dict) -> dict:
     }
     quality = quality_map.get(cm_ingredient.get("mapping_quality", "DIRECT_MATCH"), "PROVISIONAL")
 
-    event = make_curation_event(
-        action="IMPORTED",
-        changes="Imported from CultureMech update 2026-03-15"
-    )
-    event["new_status"] = "MAPPED"
-
     record = {
         "ontology_id": ontology_id,
         "preferred_term": cm_ingredient["preferred_term"],
@@ -246,8 +229,16 @@ def import_new_ingredient(cm_ingredient: dict) -> dict:
             "total_occurrences": cm_ingredient.get("occurrence_count", 0),
             "media_count": len(cm_ingredient.get("media_occurrences", [])),
         },
-        "curation_history": [event],
     }
+
+    record_curation_event(
+        record,
+        curator="merge_culturemech_updates",
+        action="IMPORTED",
+        changes="Imported from CultureMech update 2026-03-15",
+        new_status="MAPPED",
+        timestamp=TIMESTAMP,
+    )
 
     return record
 
@@ -258,11 +249,13 @@ def archive_ingredient(mi_record: dict, reason: str) -> dict:
     archived["mapping_status"] = "ARCHIVED"
     archived["archive_reason"] = reason
 
-    event = make_curation_event(
+    record_curation_event(
+        archived,
+        curator="merge_culturemech_updates",
         action="ARCHIVED",
-        changes=reason
+        changes=reason,
+        timestamp=TIMESTAMP,
     )
-    archived.setdefault("curation_history", []).append(event)
 
     return archived
 
@@ -424,7 +417,11 @@ def perform_merge(dry_run: bool = False, verbose: bool = False) -> dict:
     # Save outputs
     if not dry_run:
         print("\nSaving merged data...")
-        save_yaml(output_data, mi_mapped_path)
+        try:
+            save_yaml(output_data, mi_mapped_path, validate=True, target_class="IngredientCollection")
+        except ValidationFailedError as exc:
+            print(exc.summary(), file=sys.stderr)
+            raise
         print(f"Saved {len(all_ingredients)} ingredients to {mi_mapped_path}")
 
         # Save merge plan
@@ -437,6 +434,7 @@ def perform_merge(dry_run: bool = False, verbose: bool = False) -> dict:
             "archived_ingredients": [ing["preferred_term"] for ing in archived_ingredients],
         }
         plan_path = ANALYSIS_DIR / "merge_plan.yaml"
+        # Merge plan is not an IngredientCollection; skip validation.
         save_yaml(plan, plan_path)
         print(f"Saved merge plan to {plan_path}")
     else:
@@ -453,6 +451,7 @@ def perform_merge(dry_run: bool = False, verbose: bool = False) -> dict:
             "archived_ingredients": [ing["preferred_term"] for ing in archived_ingredients],
         }
         plan_path = ANALYSIS_DIR / "merge_plan_dryrun.yaml"
+        # Dry-run plan is not an IngredientCollection; skip validation.
         save_yaml(plan, plan_path)
         print(f"Saved dry-run plan to {plan_path}")
 

--- a/scripts/prepare_unmapped_for_curation.py
+++ b/scripts/prepare_unmapped_for_curation.py
@@ -14,11 +14,16 @@ Usage:
 
 import os
 import re
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 import yaml
+
+from mediaingredientmech.curate.curation_event import record_curation_event
+from mediaingredientmech.utils.yaml_handler import save_yaml
+from mediaingredientmech.validation.write_validated import ValidationFailedError
 
 
 # Default paths are relative to the repo root (this script lives in
@@ -41,13 +46,6 @@ def load_yaml(path: Path) -> dict:
     """Load a YAML file."""
     with open(path, "r", encoding="utf-8") as f:
         return yaml.safe_load(f)
-
-
-def save_yaml(data: dict, path: Path):
-    """Save data to YAML file."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "w", encoding="utf-8") as f:
-        yaml.dump(data, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
 
 
 def normalize_term(term: str) -> str:
@@ -147,17 +145,16 @@ def convert_unmapped_ingredient(cm_unmapped: dict, index: int, category: str) ->
             "total_occurrences": cm_unmapped.get("occurrence_count", 0),
             "media_count": len(cm_unmapped.get("media_occurrences", [])),
         },
-        "curation_history": [
-            {
-                "timestamp": TIMESTAMP,
-                "curator": "prepare_unmapped_for_curation",
-                "action": "IMPORTED",
-                "changes": f"Imported from CultureMech as {category}",
-                "new_status": "UNMAPPED",
-                "llm_assisted": False,
-            }
-        ],
     }
+
+    record_curation_event(
+        record,
+        curator="prepare_unmapped_for_curation",
+        action="IMPORTED",
+        changes=f"Imported from CultureMech as {category}",
+        new_status="UNMAPPED",
+        timestamp=TIMESTAMP,
+    )
 
     # Add category note
     if category == "PLACEHOLDER":
@@ -260,7 +257,11 @@ def prepare_unmapped():
 
     # Save
     output_path = MI_DATA_DIR / "unmapped_ingredients.yaml"
-    save_yaml(collection, output_path)
+    try:
+        save_yaml(collection, output_path, validate=True, target_class="IngredientCollection")
+    except ValidationFailedError as exc:
+        print(exc.summary(), file=sys.stderr)
+        raise
 
     # Report
     print("\n" + "="*80)

--- a/scripts/remove_duplicate_unmapped.py
+++ b/scripts/remove_duplicate_unmapped.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python3
 """Remove encoding duplicates from unmapped ingredients."""
 
+import sys
 from pathlib import Path
 import yaml
+
+from mediaingredientmech.utils.yaml_handler import save_yaml
+from mediaingredientmech.validation.write_validated import ValidationFailedError
 
 # Paths
 DATA_DIR = Path(__file__).parent.parent / "data" / "curated"
@@ -20,12 +24,6 @@ def load_yaml(path):
     """Load YAML file."""
     with open(path, encoding="utf-8") as f:
         return yaml.safe_load(f)
-
-
-def save_yaml(data, path):
-    """Save YAML file."""
-    with open(path, "w", encoding="utf-8") as f:
-        yaml.dump(data, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
 
 
 def main():
@@ -64,7 +62,11 @@ def main():
 
     # Save
     print("Saving updated file...")
-    save_yaml(data, UNMAPPED_PATH)
+    try:
+        save_yaml(data, UNMAPPED_PATH, validate=True, target_class="IngredientCollection")
+    except ValidationFailedError as exc:
+        print(exc.summary(), file=sys.stderr)
+        raise
     print(f"  ✓ Saved {UNMAPPED_PATH}")
     print()
 

--- a/scripts/update_water_quality.py
+++ b/scripts/update_water_quality.py
@@ -1,9 +1,14 @@
 #!/usr/bin/env python3
 """Update mapping quality for dH2O variants to CLOSE_MATCH."""
 
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 import yaml
+
+from mediaingredientmech.curate.curation_event import record_curation_event
+from mediaingredientmech.utils.yaml_handler import save_yaml
+from mediaingredientmech.validation.write_validated import ValidationFailedError
 
 # Paths
 DATA_DIR = Path(__file__).parent.parent / "data" / "curated"
@@ -16,12 +21,6 @@ def load_yaml(path):
     """Load YAML file."""
     with open(path, encoding="utf-8") as f:
         return yaml.safe_load(f)
-
-
-def save_yaml(data, path):
-    """Save YAML file."""
-    with open(path, "w", encoding="utf-8") as f:
-        yaml.dump(data, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
 
 
 def update_water_quality():
@@ -63,13 +62,12 @@ def update_water_quality():
                     evidence["confidence_score"] = 0.85  # Slightly lower due to purity distinction
 
                 # Add curation event
-                record.setdefault("curation_history", []).append({
-                    "timestamp": TIMESTAMP,
-                    "curator": "update_water_quality",
-                    "action": "QUALITY_UPDATE",
-                    "changes": f"Updated mapping quality from {old_quality} to CLOSE_MATCH to reflect purity distinction",
-                    "llm_assisted": False,
-                })
+                record_curation_event(
+                    record,
+                    curator="update_water_quality",
+                    action="QUALITY_UPDATE",
+                    changes=f"Updated mapping quality from {old_quality} to CLOSE_MATCH to reflect purity distinction",
+                )
 
                 print(f"  ✓ Updated quality: {old_quality} → CLOSE_MATCH")
                 updated_count += 1
@@ -79,7 +77,12 @@ def update_water_quality():
 
     # Save
     print("Saving updated file...")
-    save_yaml(data, MAPPED_PATH)
+    try:
+        save_yaml(data, MAPPED_PATH, validate=True, target_class="IngredientCollection")
+    except ValidationFailedError as exc:
+        print(f"  ✗ validation failed: refusing to write", file=sys.stderr)
+        print(exc.summary(), file=sys.stderr)
+        raise
     print(f"  ✓ Saved {MAPPED_PATH}")
     print()
 

--- a/scripts/validate_strict.py
+++ b/scripts/validate_strict.py
@@ -32,20 +32,21 @@ import csv
 import os
 import re
 import sys
+from collections.abc import Iterable
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
-from typing import Iterable
 
 import yaml
 from linkml.validator import Validator
 from linkml.validator.plugins import JsonschemaValidationPlugin
 from linkml.validator.report import Severity
 
-SCHEMA_PATH = Path("src/mediaingredientmech/schema/mediaingredientmech.yaml")
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = _REPO_ROOT / "src" / "mediaingredientmech" / "schema" / "mediaingredientmech.yaml"
 DEFAULT_ROOTS = [
-    Path("data/ingredients/mapped"),
-    Path("data/ingredients/unmapped"),
-    Path("data/curated"),
+    _REPO_ROOT / "data" / "ingredients" / "mapped",
+    _REPO_ROOT / "data" / "ingredients" / "unmapped",
+    _REPO_ROOT / "data" / "curated",
 ]
 
 
@@ -257,13 +258,13 @@ def main() -> int:
         files_with_errors.add(row["file"])
 
     print("", file=sys.stderr)
-    print(f"=== validate-strict summary ===", file=sys.stderr)
+    print("=== validate-strict summary ===", file=sys.stderr)
     print(f"  files scanned:      {len(files)}", file=sys.stderr)
     print(f"  files with ERROR:   {len(files_with_errors)}", file=sys.stderr)
     print(f"  total ERROR rows:   {len(all_rows)}", file=sys.stderr)
     print(f"  TSV:                {args.out}", file=sys.stderr)
     if by_cat:
-        print(f"  by layer/category:", file=sys.stderr)
+        print("  by layer/category:", file=sys.stderr)
         for (layer, cat), count in sorted(by_cat.items(), key=lambda kv: -kv[1]):
             print(f"    {layer:>10s} {cat:24s} {count:>8d}", file=sys.stderr)
 

--- a/scripts/validate_strict.py
+++ b/scripts/validate_strict.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Strict LinkML validation harness for MediaIngredientMech instance records.
+
+Wraps the in-process ``linkml.validator`` with ``JsonschemaValidationPlugin(closed=True)``
+so unknown fields are flagged. (The existing ``just validate-schema`` /
+``just validate-all`` targets shell out to ``linkml-validate`` in *open* mode
+and silently let unknown fields pass.) Emits a structured TSV of every
+ERROR result and exits non-zero if any are found.
+
+Usage::
+
+    python scripts/validate_strict.py [PATH ...]
+    python scripts/validate_strict.py --sample 50
+    python scripts/validate_strict.py --out reports/instance_validation_failures.tsv
+
+Paths may be files or directories; directories are walked for ``*.yaml``.
+
+Default scope when no paths given:
+    data/ingredients/mapped, data/ingredients/unmapped, data/curated
+
+Ported from CultureMech's ``scripts/validate_strict.py``. The external
+``--layer terms`` / ``--layer references`` wrappers are omitted because MIM
+does not ship ``linkml-term-validator`` or ``linkml-reference-validator``
+at corpus scale; reference validation is covered by the existing
+``just qc-evidence`` target.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import re
+import sys
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+from typing import Iterable
+
+import yaml
+from linkml.validator import Validator
+from linkml.validator.plugins import JsonschemaValidationPlugin
+from linkml.validator.report import Severity
+
+SCHEMA_PATH = Path("src/mediaingredientmech/schema/mediaingredientmech.yaml")
+DEFAULT_ROOTS = [
+    Path("data/ingredients/mapped"),
+    Path("data/ingredients/unmapped"),
+    Path("data/curated"),
+]
+
+
+def infer_target_class(instance: dict) -> str:
+    """Pick the right root class for this record.
+
+    ``data/curated/*.yaml`` files are ``IngredientCollection``s (top-level
+    ``ingredients: [...]`` list); individual ``data/ingredients/**/*.yaml``
+    files are ``IngredientRecord``s (top-level ``identifier:``).
+
+    Keep in sync with
+    ``src/mediaingredientmech/validation/write_validated.py:infer_target_class``.
+    """
+    if not isinstance(instance, dict):
+        return "IngredientRecord"
+    if isinstance(instance.get("ingredients"), list):
+        return "IngredientCollection"
+    return "IngredientRecord"
+
+
+# Per-worker singleton — built lazily after fork so the schema parses once per
+# worker process, not once per file.
+_VALIDATOR: Validator | None = None
+
+
+def _get_validator() -> Validator:
+    global _VALIDATOR
+    if _VALIDATOR is None:
+        _VALIDATOR = Validator(
+            schema=str(SCHEMA_PATH),
+            validation_plugins=[JsonschemaValidationPlugin(closed=True)],
+        )
+    return _VALIDATOR
+
+
+# Classifier regexes — keep narrow so each category is meaningful and the rest
+# fall into "other" for manual review rather than getting silently bucketed.
+_CATEGORY_RULES: list[tuple[str, re.Pattern[str]]] = [
+    ("unexpected_field",
+     re.compile(r"Additional properties are not allowed \('(?P<key>[^']+)' was unexpected\) in (?P<path>\S+)")),
+    ("missing_required",
+     re.compile(r"'(?P<key>[^']+)' is a required property in (?P<path>\S+)")),
+    ("enum_mismatch",
+     re.compile(r"'(?P<value>[^']+)' is not one of \[(?P<choices>[^\]]+)\]")),
+    ("type_mismatch",
+     re.compile(r"(?P<value>'[^']+'|\S+) is not of type '(?P<type>[^']+)'")),
+    ("pattern_mismatch",
+     re.compile(r"(?P<value>'[^']+'|\S+) does not match (?P<pattern>'[^']+')")),
+    ("format_mismatch",
+     re.compile(r"(?P<value>'[^']+'|\S+) is not a '(?P<format>[^']+)'")),
+    ("range_violation",
+     re.compile(r"(?P<value>\S+) is (less than|greater than) (?P<bound>\S+)")),
+]
+
+
+def classify(message: str) -> tuple[str, str]:
+    """Return (category, detail) for a validator message."""
+    for name, rule in _CATEGORY_RULES:
+        m = rule.search(message)
+        if m:
+            parts = m.groupdict()
+            detail = "|".join(f"{k}={v}" for k, v in parts.items())
+            return name, detail
+    return "other", ""
+
+
+def validate_one(path: Path) -> list[dict]:
+    """Validate a single YAML file. Returns one dict per ERROR result."""
+    validator = _get_validator()
+    try:
+        with path.open() as f:
+            instance = yaml.safe_load(f)
+    except yaml.YAMLError as e:
+        return [{
+            "file": str(path),
+            "layer": "schema",
+            "category": "yaml_parse_error",
+            "detail": "",
+            "path": "",
+            "message": str(e).splitlines()[0][:300],
+        }]
+    if instance is None:
+        return [{
+            "file": str(path),
+            "layer": "schema",
+            "category": "empty_file",
+            "detail": "",
+            "path": "",
+            "message": "file parsed as None",
+        }]
+
+    target_class = infer_target_class(instance)
+    try:
+        report = validator.validate(instance, target_class=target_class)
+    except Exception as e:  # noqa: BLE001 — surface anything weird as a row
+        return [{
+            "file": str(path),
+            "layer": "schema",
+            "category": "validator_crash",
+            "detail": type(e).__name__,
+            "path": "",
+            "message": str(e)[:300],
+        }]
+
+    rows = []
+    for result in report.results:
+        if result.severity != Severity.ERROR:
+            continue
+        category, detail = classify(result.message)
+        rows.append({
+            "file": str(path),
+            "layer": "schema",
+            "category": category,
+            "detail": detail,
+            "path": result.instance_index or "",
+            "message": result.message[:300],
+        })
+    return rows
+
+
+_DEFAULT_EXCLUDE_PARTS = {"backups", "snapshots", ".backups"}
+
+
+def iter_yaml_files(paths: Iterable[Path]) -> list[Path]:
+    """Walk inputs, filtering out backup/snapshot subtrees.
+
+    ``data/curated/backups/`` holds rotating per-write snapshots created by
+    ``save_yaml``'s ``backup=True`` path. They contain frozen (sometimes
+    malformed) historical state and shouldn't gate validation. Pass an
+    explicit path to override.
+    """
+    out: list[Path] = []
+    for p in paths:
+        if p.is_file():
+            out.append(p)
+        elif p.is_dir():
+            for f in sorted(p.rglob("*.yaml")):
+                if _DEFAULT_EXCLUDE_PARTS.intersection(f.parts):
+                    continue
+                out.append(f)
+    return out
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="*", type=Path,
+                        help="Files or directories. Defaults to standard ingredient/curated subdirs.")
+    parser.add_argument("--out", type=Path, default=Path("reports/instance_validation_failures.tsv"),
+                        help="TSV output path.")
+    parser.add_argument("--sample", type=int, metavar="N",
+                        help="Validate only the first N files (after sorting). Useful for smoke tests.")
+    parser.add_argument("--workers", type=int, default=max(1, (os.cpu_count() or 4) - 1),
+                        help="Process pool size. Default: ncpu - 1.")
+    parser.add_argument("--fail-on", choices=("error", "never"), default="error",
+                        help="Exit non-zero policy. 'error' (default) exits 1 if any ERROR row was emitted.")
+    parser.add_argument("--quiet", action="store_true",
+                        help="Suppress per-file progress lines.")
+    args = parser.parse_args()
+
+    roots = args.paths or DEFAULT_ROOTS
+    files = iter_yaml_files(roots)
+    if args.sample:
+        files = files[: args.sample]
+    if not files:
+        print("No YAML files found.", file=sys.stderr)
+        return 2
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+
+    print(
+        f"Validating {len(files)} files with {args.workers} workers; "
+        f"schema={SCHEMA_PATH}",
+        file=sys.stderr,
+    )
+
+    all_rows: list[dict] = []
+    with ProcessPoolExecutor(max_workers=args.workers) as pool:
+        futures = {pool.submit(validate_one, p): p for p in files}
+        done = 0
+        for fut in as_completed(futures):
+            done += 1
+            rows = fut.result()
+            all_rows.extend(rows)
+            if not args.quiet and done % 250 == 0:
+                print(
+                    f"  {done}/{len(files)} files processed, "
+                    f"{len(all_rows)} ERROR rows so far",
+                    file=sys.stderr,
+                )
+
+    # Sort for deterministic TSV output (avoids noisy diffs from worker scheduling).
+    all_rows.sort(key=lambda r: (r["file"], r["layer"], r["path"], r["category"], r["message"]))
+    with args.out.open("w", newline="") as fh:
+        writer = csv.DictWriter(
+            fh,
+            fieldnames=["file", "layer", "category", "detail", "path", "message"],
+            delimiter="\t",
+            quoting=csv.QUOTE_MINIMAL,
+            lineterminator="\n",
+        )
+        writer.writeheader()
+        writer.writerows(all_rows)
+
+    by_cat: dict[tuple[str, str], int] = {}
+    files_with_errors: set[str] = set()
+    for row in all_rows:
+        key = (row["layer"], row["category"])
+        by_cat[key] = by_cat.get(key, 0) + 1
+        files_with_errors.add(row["file"])
+
+    print("", file=sys.stderr)
+    print(f"=== validate-strict summary ===", file=sys.stderr)
+    print(f"  files scanned:      {len(files)}", file=sys.stderr)
+    print(f"  files with ERROR:   {len(files_with_errors)}", file=sys.stderr)
+    print(f"  total ERROR rows:   {len(all_rows)}", file=sys.stderr)
+    print(f"  TSV:                {args.out}", file=sys.stderr)
+    if by_cat:
+        print(f"  by layer/category:", file=sys.stderr)
+        for (layer, cat), count in sorted(by_cat.items(), key=lambda kv: -kv[1]):
+            print(f"    {layer:>10s} {cat:24s} {count:>8d}", file=sys.stderr)
+
+    if args.fail_on == "error" and all_rows:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/mediaingredientmech/curate/__init__.py
+++ b/src/mediaingredientmech/curate/__init__.py
@@ -1,0 +1,1 @@
+"""Curation helpers shared across MediaIngredientMech writer scripts."""

--- a/src/mediaingredientmech/curate/curation_event.py
+++ b/src/mediaingredientmech/curate/curation_event.py
@@ -1,0 +1,122 @@
+"""Standard helper for appending CurationEvent entries to an ingredient record.
+
+Every script that mutates an IngredientRecord YAML should call
+``record_curation_event`` to leave an audit trail. Centralizing here means:
+
+* timestamps are ISO-8601 with UTC tz, consistently;
+* the ``curation_history`` slot is created on demand;
+* re-runs of idempotent migration scripts can short-circuit when the most
+  recent event already matches (``skip_if_recent`` flag);
+* the schema's ``CurationEvent`` field names (timestamp / curator / action /
+  changes / previous_status / new_status / llm_assisted / llm_model)
+  are honored, so future schema diffs only need to touch one file.
+
+Drop-in usage::
+
+    from mediaingredientmech.curate.curation_event import record_curation_event
+
+    record_curation_event(
+        record,
+        curator="enrich_from_ols.py",
+        action="ENRICHED_OLS_LABELS",
+        changes="Filled preferred_label from OLS",
+    )
+
+Ported from CultureMech's ``src/culturemech/curate/curation_event.py``.
+Field signature differs from CultureMech's because the MIM
+``CurationEvent`` class doesn't define ``source`` or ``notes`` — pass
+narrative detail in ``changes`` instead.
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Any
+
+__all__ = ["record_curation_event", "now_iso"]
+
+
+def now_iso() -> str:
+    """Current UTC timestamp as an ISO-8601 string."""
+    return datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+
+def record_curation_event(
+    record: dict[str, Any],
+    *,
+    curator: str,
+    action: str,
+    changes: str | None = None,
+    previous_status: str | None = None,
+    new_status: str | None = None,
+    llm_assisted: bool = False,
+    llm_model: str | None = None,
+    timestamp: str | None = None,
+    skip_if_recent: bool = False,
+) -> dict[str, Any]:
+    """Append a CurationEvent to ``record['curation_history']``.
+
+    Args:
+        record: The ingredient record dict being mutated. Mutated in place.
+        curator: Script / human identifier (e.g. ``"migrate_legacy_fields.py"``
+            or ``"jane.smith"``). Required because the schema requires it.
+        action: SCREAMING_SNAKE_CASE action label (e.g.
+            ``"ENRICHED_CHEBI"``, ``"MERGED_DUPLICATES"``). Required; must
+            match the schema's pattern ``^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$``.
+        changes: Optional human-readable description of what changed
+            (e.g. ``"Set mapping_status to MAPPED (was UNMAPPED)"``).
+            Maps to ``CurationEvent.changes`` — also the right field to use
+            for narrative notes since the schema has no separate ``notes``.
+        previous_status: Optional ``MappingStatusEnum`` value held before
+            this action.
+        new_status: Optional ``MappingStatusEnum`` value held after this
+            action.
+        llm_assisted: True when an LLM produced this change. When True the
+            field is emitted; when False the field is omitted so downstream
+            consumers can distinguish "explicitly not LLM" from "older
+            event written before this field existed".
+        llm_model: LLM model identifier (e.g. ``"claude-sonnet-4-6"``);
+            emitted only when ``llm_assisted`` is True.
+        timestamp: Override the ISO-8601 timestamp (used for tests /
+            deterministic snapshots). Defaults to current UTC.
+        skip_if_recent: When True, do nothing if the most recent
+            curation_history entry already matches the same
+            ``(curator, action)`` pair. Useful when refactoring a script
+            into the helper without producing duplicate trail entries
+            during a re-run.
+
+    Returns:
+        The appended event dict (or the most recent matching one if
+        ``skip_if_recent`` short-circuited).
+    """
+    history = record.setdefault("curation_history", [])
+    if history is None:
+        record["curation_history"] = history = []
+
+    if skip_if_recent and history:
+        last = history[-1]
+        if (
+            isinstance(last, dict)
+            and last.get("curator") == curator
+            and last.get("action") == action
+        ):
+            return last
+
+    event: dict[str, Any] = {
+        "timestamp": timestamp or now_iso(),
+        "curator": curator,
+        "action": action,
+    }
+    if changes is not None:
+        event["changes"] = changes
+    if previous_status is not None:
+        event["previous_status"] = previous_status
+    if new_status is not None:
+        event["new_status"] = new_status
+    if llm_assisted:
+        event["llm_assisted"] = True
+        if llm_model is not None:
+            event["llm_model"] = llm_model
+
+    history.append(event)
+    return event

--- a/src/mediaingredientmech/curation/ingredient_curator.py
+++ b/src/mediaingredientmech/curation/ingredient_curator.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 import logging
 import re
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
 
 import yaml
 
+from mediaingredientmech.curate.curation_event import now_iso, record_curation_event
 from mediaingredientmech.utils.ontology_client import OntologyCandidate, OntologyClient
+from mediaingredientmech.utils.yaml_handler import save_yaml
 
 logger = logging.getLogger(__name__)
 
@@ -98,8 +99,8 @@ VALID_CITATION_TYPES = {
 DOI_PATTERN = re.compile(r"^10\.\d{4,}/[-._;()/:A-Za-z0-9]+$")
 
 
-def _now_iso() -> str:
-    return datetime.now(timezone.utc).isoformat()
+# Backwards-compatible alias: prefer ``now_iso`` from the curate package.
+_now_iso = now_iso
 
 
 class IngredientCurator:
@@ -141,9 +142,15 @@ class IngredientCurator:
         return self._records
 
     def save(self) -> None:
-        """Save current state back to YAML file."""
+        """Save current state back to YAML file.
+
+        Routes through ``save_yaml(..., validate=True)`` so the collection
+        is checked against the LinkML schema in closed mode before disk
+        is touched. A ``ValidationFailedError`` here means a record was
+        mutated into an invalid state in memory and the change is being
+        refused at the write boundary rather than silently persisted.
+        """
         path = Path(self.data_path)
-        path.parent.mkdir(parents=True, exist_ok=True)
 
         # Update counts
         mapped = sum(1 for r in self._records if r.get("mapping_status") == "MAPPED")
@@ -153,8 +160,7 @@ class IngredientCurator:
         self._collection["unmapped_count"] = unmapped
         self._collection["ingredients"] = self._records
 
-        with open(path, "w") as f:
-            yaml.dump(self._collection, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
+        save_yaml(self._collection, path, validate=True, target_class="IngredientCollection")
 
         self._dirty = False
         logger.info("Saved %d records to %s", len(self._records), path)
@@ -388,30 +394,27 @@ class IngredientCurator:
         llm_model: Optional[str] = None,
         notes: Optional[str] = None,
     ) -> dict[str, Any]:
-        """Append a curation event to a record's history."""
-        event: dict[str, Any] = {
-            "timestamp": _now_iso(),
-            "curator": self.curator_name,
-            "action": action,
-        }
-        if changes:
-            event["changes"] = changes
-        if previous_status:
-            event["previous_status"] = previous_status
-        if new_status:
-            event["new_status"] = new_status
-        if llm_assisted:
-            event["llm_assisted"] = True
-            if llm_model:
-                event["llm_model"] = llm_model
+        """Append a curation event to a record's history.
+
+        Thin wrapper over :func:`record_curation_event` that injects
+        ``self.curator_name`` as the curator. ``notes`` is folded into
+        ``changes`` (the MIM ``CurationEvent`` schema has no ``notes``
+        field) — pass narrative detail in ``changes`` directly to avoid
+        the fold.
+        """
+        merged_changes = changes
         if notes:
-            event["notes"] = notes
-
-        if "curation_history" not in record or record["curation_history"] is None:
-            record["curation_history"] = []
-        record["curation_history"].append(event)
-
-        return event
+            merged_changes = f"{changes}\n{notes}" if changes else notes
+        return record_curation_event(
+            record,
+            curator=self.curator_name,
+            action=action,
+            changes=merged_changes,
+            previous_status=previous_status,
+            new_status=new_status,
+            llm_assisted=llm_assisted,
+            llm_model=llm_model,
+        )
 
     def get_progress_report(self) -> dict[str, Any]:
         """Generate a summary of curation progress."""

--- a/src/mediaingredientmech/utils/yaml_handler.py
+++ b/src/mediaingredientmech/utils/yaml_handler.py
@@ -1,4 +1,11 @@
-"""Safe YAML I/O with error handling and backups."""
+"""Safe YAML I/O with error handling and backups.
+
+The ``save_yaml`` helper accepts an opt-in ``validate=`` flag that routes
+the write through ``write_validated_ingredient`` for closed-schema
+validation. Callers that write IngredientRecord / IngredientCollection
+YAMLs should pass ``validate=True``; callers that write reports, indexes,
+or UMAP outputs should leave it off (default).
+"""
 
 import shutil
 from datetime import datetime
@@ -31,23 +38,52 @@ def load_yaml(path: str | Path) -> dict:
     return data
 
 
-def save_yaml(data: Any, path: str | Path, *, backup: bool = True) -> Path:
-    """Save data to a YAML file with optional backup.
+def save_yaml(
+    data: Any,
+    path: str | Path,
+    *,
+    backup: bool = True,
+    validate: bool = False,
+    target_class: str | None = None,
+) -> Path:
+    """Save data to a YAML file with optional backup and optional validation.
 
     Args:
         data: Data to serialize.
         path: Output file path.
         backup: If True and file exists, create timestamped backup.
+        validate: When True, route the write through
+            ``write_validated_ingredient`` so the data is checked against
+            the LinkML schema in closed mode before disk is touched. Use
+            for IngredientRecord / IngredientCollection writes. Leave off
+            for reports / indexes / non-ingredient YAML.
+        target_class: Optional LinkML target class override (e.g.
+            ``"IngredientCollection"`` or ``"IngredientRecord"``). Only
+            consulted when ``validate=True``; defaults to auto-detect from
+            the data shape.
 
     Returns:
         Path to saved file.
+
+    Raises:
+        ValidationFailedError: When ``validate=True`` and the data fails
+            closed-schema validation. Disk is not modified.
     """
     path = Path(path)
-    path.parent.mkdir(parents=True, exist_ok=True)
 
     if backup and path.exists():
         _create_backup(path)
 
+    if validate:
+        # Local import to avoid a circular dependency at module import time.
+        from mediaingredientmech.validation.write_validated import (
+            write_validated_ingredient,
+        )
+
+        write_validated_ingredient(data, path, target_class=target_class)
+        return path
+
+    path.parent.mkdir(parents=True, exist_ok=True)
     with open(path, "w", encoding="utf-8") as f:
         yaml.dump(data, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
 

--- a/src/mediaingredientmech/utils/yaml_handler.py
+++ b/src/mediaingredientmech/utils/yaml_handler.py
@@ -71,18 +71,29 @@ def save_yaml(
     """
     path = Path(path)
 
-    if backup and path.exists():
-        _create_backup(path)
-
     if validate:
         # Local import to avoid a circular dependency at module import time.
         from mediaingredientmech.validation.write_validated import (
+            validate_ingredient,
             write_validated_ingredient,
         )
 
+        # Validate before snapshotting so a failing validation neither
+        # touches the destination nor creates a backup of the existing
+        # good copy (which would spam backups/ on repeated bad runs).
+        errors = validate_ingredient(data, target_class=target_class)
+        if errors:
+            from mediaingredientmech.validation.write_validated import (
+                ValidationFailedError,
+            )
+            raise ValidationFailedError(path, errors)
+        if backup and path.exists():
+            _create_backup(path)
         write_validated_ingredient(data, path, target_class=target_class)
         return path
 
+    if backup and path.exists():
+        _create_backup(path)
     path.parent.mkdir(parents=True, exist_ok=True)
     with open(path, "w", encoding="utf-8") as f:
         yaml.dump(data, f, default_flow_style=False, sort_keys=False, allow_unicode=True)

--- a/src/mediaingredientmech/validation/write_validated.py
+++ b/src/mediaingredientmech/validation/write_validated.py
@@ -127,12 +127,16 @@ def write_validated_ingredient(
     )
     if errors:
         raise ValidationFailedError(path, errors)
+    # Match the existing repo convention (yaml_handler.save_yaml +
+    # IngredientCurator) so re-running this helper over an existing file
+    # produces a byte-identical diff instead of churning block / flow style.
     opts = {
+        "default_flow_style": False,
         "sort_keys": False,
         "allow_unicode": True,
         "width": 80,
         **(yaml_kwargs or {}),
     }
     path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w") as f:
+    with path.open("w", encoding="utf-8") as f:
         yaml.safe_dump(record, f, **opts)

--- a/src/mediaingredientmech/validation/write_validated.py
+++ b/src/mediaingredientmech/validation/write_validated.py
@@ -1,0 +1,138 @@
+"""Write-time validation: dump an ingredient record (or collection) to YAML
+*only if* it passes closed-schema LinkML validation.
+
+This is the write-time gate that the audit found missing across the 23+
+YAML writers in this repo: writes go through `yaml.safe_dump(...)` with no
+validation, so structural drift (unknown fields, missing required fields,
+enum / pattern violations) only surfaces at downstream consumers.
+
+Use::
+
+    from mediaingredientmech.validation.write_validated import (
+        write_validated_ingredient,
+        ValidationFailedError,
+    )
+
+    try:
+        write_validated_ingredient(record, output_path)
+    except ValidationFailedError as exc:
+        # Bad record refused; print categorized errors and abort.
+        print(exc.summary())
+        raise
+
+The validator is shared across calls (LinkML schema parse + JSON-schema
+emit is the slow part), so calling this in a tight migration loop is
+cheap.
+
+Ported from CultureMech's `src/culturemech/validation/write_validated.py`.
+Keep the two in sync if the semantics ever diverge.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from threading import Lock
+from typing import Any
+
+import yaml
+from linkml.validator import Validator
+from linkml.validator.plugins import JsonschemaValidationPlugin
+from linkml.validator.report import Severity, ValidationResult
+
+DEFAULT_SCHEMA_PATH = Path(__file__).resolve().parents[1] / "schema" / "mediaingredientmech.yaml"
+
+_VALIDATORS: dict[Path, Validator] = {}
+_VALIDATOR_LOCK = Lock()
+
+
+class ValidationFailedError(Exception):
+    """Raised when an ingredient fails closed-schema validation before write."""
+
+    def __init__(self, path: Path | None, errors: list[ValidationResult]):
+        self.path = path
+        self.errors = errors
+        super().__init__(self.summary())
+
+    def summary(self) -> str:
+        lines = [
+            f"validation failed: {len(self.errors)} error(s)"
+            + (f" for {self.path}" if self.path else "")
+        ]
+        for err in self.errors[:10]:
+            lines.append(f"  - {err.message[:200]}")
+        if len(self.errors) > 10:
+            lines.append(f"  ... + {len(self.errors) - 10} more")
+        return "\n".join(lines)
+
+
+def _get_validator(schema_path: Path) -> Validator:
+    """Cache validators keyed by resolved schema path so callers can mix
+    schemas in the same process without silently reusing a stale instance."""
+    key = Path(schema_path).resolve()
+    with _VALIDATOR_LOCK:
+        if key not in _VALIDATORS:
+            _VALIDATORS[key] = Validator(
+                schema=str(key),
+                validation_plugins=[JsonschemaValidationPlugin(closed=True)],
+            )
+        return _VALIDATORS[key]
+
+
+def infer_target_class(instance: dict[str, Any]) -> str:
+    """Pick the right root class for this record.
+
+    `data/curated/*.yaml` files are `IngredientCollection`s (top-level
+    `ingredients: [...]` list); individual `data/ingredients/**/*.yaml`
+    files are `IngredientRecord`s (top-level `identifier:`).
+
+    Mirrors `scripts/validate_strict.py:infer_target_class` — keep the two
+    in sync if routing rules change.
+    """
+    if not isinstance(instance, dict):
+        return "IngredientRecord"
+    if isinstance(instance.get("ingredients"), list):
+        return "IngredientCollection"
+    return "IngredientRecord"
+
+
+def validate_ingredient(
+    record: dict[str, Any],
+    *,
+    target_class: str | None = None,
+    schema_path: Path = DEFAULT_SCHEMA_PATH,
+) -> list[ValidationResult]:
+    """Return the list of ERROR-severity validation results (empty when clean)."""
+    validator = _get_validator(schema_path)
+    tc = target_class or infer_target_class(record)
+    report = validator.validate(record, target_class=tc)
+    return [r for r in report.results if r.severity == Severity.ERROR]
+
+
+def write_validated_ingredient(
+    record: dict[str, Any],
+    path: Path,
+    *,
+    target_class: str | None = None,
+    schema_path: Path = DEFAULT_SCHEMA_PATH,
+    yaml_kwargs: dict[str, Any] | None = None,
+) -> None:
+    """Write `record` to `path` as YAML, but only if validation passes.
+
+    Raises `ValidationFailedError` (without writing) when closed-schema
+    validation finds any error. Use in place of `yaml.safe_dump(record, fh)`
+    inside enrichment / migration / merge scripts.
+    """
+    errors = validate_ingredient(
+        record, target_class=target_class, schema_path=schema_path
+    )
+    if errors:
+        raise ValidationFailedError(path, errors)
+    opts = {
+        "sort_keys": False,
+        "allow_unicode": True,
+        "width": 80,
+        **(yaml_kwargs or {}),
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as f:
+        yaml.safe_dump(record, f, **opts)

--- a/uv.lock
+++ b/uv.lock
@@ -2275,6 +2275,7 @@ dependencies = [
     { name = "linkml-runtime" },
     { name = "oaklib" },
     { name = "pyyaml" },
+    { name = "requests" },
     { name = "rich" },
 ]
 
@@ -2300,6 +2301,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "requests", specifier = ">=2.28.0" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
 ]


### PR DESCRIPTION
## Summary

Ports the CultureMech audit cycle's four core artifacts to MIM:

- **`scripts/validate_strict.py`** — in-process LinkML validator with `JsonschemaValidationPlugin(closed=True)`, parallel walk of `data/ingredients/**` + `data/curated/**` (excluding `backups/` and `snapshots/`), structured TSV output, non-zero exit on any ERROR.
- **`scripts/audit_writers.py`** — inventory of every YAML-writing script, flagging whether each validates before writing and appends a `curation_history` entry.
- **`src/mediaingredientmech/validation/write_validated.py`** — `write_validated_ingredient()` + `ValidationFailedError`, the write-time gate that refuses to dump invalid records.
- **`src/mediaingredientmech/curate/curation_event.py`** — `record_curation_event()`, the standard helper for appending a `CurationEvent` to a record's history. MIM-adapted signature (no `notes` / `source`; first-class `previous_status` / `new_status` / `llm_assisted` / `llm_model` to match the existing `CurationEvent` class).

Why now: the May 2026 CultureMech audit surfaced **59,401 silent ERROR rows across 8,669 of 15,827 records** because `linkml-validate` runs in open-schema mode by default and the looped `just validate-all` recipe swallowed non-zero exit codes. MIM has the same drift class — validation is hand-coded (`schema_validator.py`) and doesn't use LinkML's `closed=True`, so unknown fields slip through silently. This port establishes MIM's "0 errors under closed-schema validation" baseline and gates every YAML write behind validation, mirroring the CultureMech cycle.

## Wiring

- `justfile` gains `validate-strict` + `audit-writers` recipes; `qc` composite now includes `validate-strict`.
- `utils/yaml_handler.save_yaml()` gains opt-in `validate=True` (+ `target_class=`) that routes through `write_validated_ingredient`. Default-off so non-ingredient YAML writers (UMAP reports, browser exports, etc.) are unaffected.
- `IngredientCurator.save()` validates before writing; `IngredientCurator._add_event()` reimplemented as a wrapper over `record_curation_event` (preserves all existing kwargs including the `notes`→`changes` fold).
- **15 writer scripts under `scripts/`** converted to use the new helpers: local `save_yaml` defs removed, inline `curation_history.append({...})` blocks replaced with `record_curation_event(...)`, collection writes wrapped in `try/except ValidationFailedError` (re-raise so collection writes stay all-or-nothing).
- `.claude/skills/schema-gap-analysis/skill.md` updated with a "Fast path" section pointing at the new recipes while preserving the existing ad-hoc `linkml-validate` procedures.

## Baseline (not committed — `reports/` is gitignored)

First strict run on this branch: **90 ERROR rows across 5 files**.

| Files | Issues |
|---|---|
| `data/curated/unmapped_{already_mapped,complex_media,incomplete_formula,other,placeholder}.yaml` | top-level `category` + `count` keys (5 rows, `other`); legacy top-level `ontology_id` on each record (85 rows, `unexpected_field`) |

These are real schema gaps — out of scope for this port. Cleanup is a separate concern (could be a schema-additive change for `category`/`count`, plus a data migration moving `ontology_id` → `ontology_mapping.ontology_id`).

`reports/pipeline_writers_audit.tsv` baseline (also regenerable): 34 writers detected; 16/34 now validate before writing (the 18 not yet validating are pure report writers + a few unmapped helper scripts that weren't in scope for this PR).

## Out of scope

- Replacing the existing hand-coded `src/mediaingredientmech/validation/schema_validator.py` (lives alongside the new strict harness; serves the per-record curator API).
- CommunityMech port (separate follow-up — needs schema additions for `CurationEvent` + `curation_history`).
- Pure report-generating scripts (`analyze_*`, `generate_*_report`, `compare_with_culturemech`, `reconcile_unmapped`, `repair_incomplete_formulas`, `categorize_unmapped`) — they don't mutate ingredient YAMLs, so `record_curation_event` is meaningless for them.
- Cleanup of the 90 baseline errors (separate PR, modelled on CultureMech's iterative pattern).

## Test plan

- [x] `uv run python -c "from mediaingredientmech.validation.write_validated import write_validated_ingredient; from mediaingredientmech.curate.curation_event import record_curation_event"` — imports resolve.
- [x] `uv run python scripts/validate_strict.py --sample 100` — runs cleanly on 100-file sample (0 errors).
- [x] Full corpus `uv run python scripts/validate_strict.py` — 2,275 files / 90 ERROR rows in 5 files (baseline documented above).
- [x] `uv run python scripts/audit_writers.py` — 34 writers detected, 16 now validating.
- [x] End-to-end: real ingredient roundtrips byte-identically; corrupted ingredient (added `totally_unexpected_field`) is refused with a clear `ValidationFailedError.summary()`.
- [x] All 15 converted scripts pass `ast.parse`.
- [x] Existing tests pass: `pytest tests/` → 231 passed.
- [ ] (Manual, post-merge) Run one of the converted writers against real data to confirm the new gate doesn't regress an active workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)