### PR TITLE
Clear the 90-error validate-strict baseline (schema-bless category/count + drop legacy ontology_id emission + migrate 5 stale files)

### DIFF
--- a/data/curated/unmapped_already_mapped.yaml
+++ b/data/curated/unmapped_already_mapped.yaml
@@ -1,8 +1,7 @@
 category: ALREADY_MAPPED
 count: 3
 ingredients:
-- ontology_id: UNMAPPED_0070
-  identifier: UNMAPPED_0070
+- identifier: UNMAPPED_0070
   preferred_term: Na2Glycerophosphate.5H2O
   synonyms:
   - synonym_text: 'Na2Glycerophosphate.5H2O(CAS:  13408-09-8)'
@@ -19,8 +18,7 @@ ingredients:
     changes: Imported from CultureMech as CURATION_NEEDED
     new_status: UNMAPPED
     llm_assisted: false
-- ontology_id: UNMAPPED_0073
-  identifier: UNMAPPED_0073
+- identifier: UNMAPPED_0073
   preferred_term: Sterile dH2O
   synonyms:
   - synonym_text: Sterile dH2O
@@ -37,8 +35,7 @@ ingredients:
     changes: Imported from CultureMech as CURATION_NEEDED
     new_status: UNMAPPED
     llm_assisted: false
-- ontology_id: UNMAPPED_0090
-  identifier: UNMAPPED_0090
+- identifier: UNMAPPED_0090
   preferred_term: Na2Glycerophosphate•5H2O
   synonyms:
   - synonym_text: 'Na2Glycerophosphate•5H2O(CAS: 13408-09-8)'

--- a/data/curated/unmapped_complex_media.yaml
+++ b/data/curated/unmapped_complex_media.yaml
@@ -1,8 +1,7 @@
 category: COMPLEX_MEDIA
 count: 61
 ingredients:
-- ontology_id: UNMAPPED_0004
-  identifier: UNMAPPED_0004
+- identifier: UNMAPPED_0004
   preferred_term: Vitamin B
   synonyms:
   - synonym_text: Vitamin B12
@@ -20,8 +19,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0006
-  identifier: UNMAPPED_0006
+- identifier: UNMAPPED_0006
   preferred_term: Pasteurized Seawater
   synonyms:
   - synonym_text: Pasteurized Seawater
@@ -39,8 +37,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0007
-  identifier: UNMAPPED_0007
+- identifier: UNMAPPED_0007
   preferred_term: Biotin Vitamin Solution
   synonyms:
   - synonym_text: Biotin Vitamin Solution
@@ -58,8 +55,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0009
-  identifier: UNMAPPED_0009
+- identifier: UNMAPPED_0009
   preferred_term: P-IV Metal Solution
   synonyms:
   - synonym_text: P-IV Metal Solution
@@ -77,8 +73,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0010
-  identifier: UNMAPPED_0010
+- identifier: UNMAPPED_0010
   preferred_term: 'Soilwater: GR+ Medium'
   synonyms:
   - synonym_text: 'Soilwater: GR+ Medium'
@@ -96,8 +91,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0011
-  identifier: UNMAPPED_0011
+- identifier: UNMAPPED_0011
   preferred_term: Thiamine Vitamin Solution
   synonyms:
   - synonym_text: Thiamine Vitamin Solution
@@ -115,8 +109,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0012
-  identifier: UNMAPPED_0012
+- identifier: UNMAPPED_0012
   preferred_term: CR1 Soil
   synonyms:
   - synonym_text: CR1 Soil
@@ -134,8 +127,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0015
-  identifier: UNMAPPED_0015
+- identifier: UNMAPPED_0015
   preferred_term: Green House Soil
   synonyms:
   - synonym_text: Green House Soil
@@ -153,8 +145,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0017
-  identifier: UNMAPPED_0017
+- identifier: UNMAPPED_0017
   preferred_term: Tryptone
   synonyms:
   - synonym_text: Tryptone (Sigma T 9410)
@@ -181,8 +172,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0018
-  identifier: UNMAPPED_0018
+- identifier: UNMAPPED_0018
   preferred_term: Bristol Medium
   synonyms:
   - synonym_text: Bristol Medium
@@ -200,8 +190,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0019
-  identifier: UNMAPPED_0019
+- identifier: UNMAPPED_0019
   preferred_term: Erdschreiber's Medium
   synonyms:
   - synonym_text: Erdschreiber's Medium
@@ -219,8 +208,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0020
-  identifier: UNMAPPED_0020
+- identifier: UNMAPPED_0020
   preferred_term: Yeast extract
   synonyms:
   - synonym_text: Yeast extract(Bacto, Difco)
@@ -241,8 +229,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0022
-  identifier: UNMAPPED_0022
+- identifier: UNMAPPED_0022
   preferred_term: Seawater
   synonyms:
   - synonym_text: Seawater (30 ppt)
@@ -263,8 +250,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0024
-  identifier: UNMAPPED_0024
+- identifier: UNMAPPED_0024
   preferred_term: Trace Metals Solution
   synonyms:
   - synonym_text: Trace Metals Solution
@@ -282,8 +268,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0026
-  identifier: UNMAPPED_0026
+- identifier: UNMAPPED_0026
   preferred_term: Enrichment Solution for Seawater Medium
   synonyms:
   - synonym_text: Enrichment Solution for Seawater Medium
@@ -301,8 +286,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0028
-  identifier: UNMAPPED_0028
+- identifier: UNMAPPED_0028
   preferred_term: F/2 Medium
   synonyms:
   - synonym_text: F/2 Medium
@@ -320,8 +304,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0035
-  identifier: UNMAPPED_0035
+- identifier: UNMAPPED_0035
   preferred_term: MWC Metal Solution
   synonyms:
   - synonym_text: MWC Metal Solution
@@ -339,8 +322,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0039
-  identifier: UNMAPPED_0039
+- identifier: UNMAPPED_0039
   preferred_term: Bold 1NV Medium
   synonyms:
   - synonym_text: Bold 1NV Medium
@@ -358,8 +340,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0041
-  identifier: UNMAPPED_0041
+- identifier: UNMAPPED_0041
   preferred_term: BG-11 Trace Metals Solution
   synonyms:
   - synonym_text: BG-11 Trace Metals Solution
@@ -377,8 +358,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0042
-  identifier: UNMAPPED_0042
+- identifier: UNMAPPED_0042
   preferred_term: Soil+Seawater Medium
   synonyms:
   - synonym_text: Soil+Seawater Medium
@@ -396,8 +376,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0043
-  identifier: UNMAPPED_0043
+- identifier: UNMAPPED_0043
   preferred_term: Spir solution
   synonyms:
   - synonym_text: Spir solution 1
@@ -418,8 +397,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0045
-  identifier: UNMAPPED_0045
+- identifier: UNMAPPED_0045
   preferred_term: DAS Vitamin Cocktail
   synonyms:
   - synonym_text: DAS Vitamin Cocktail
@@ -437,8 +415,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0047
-  identifier: UNMAPPED_0047
+- identifier: UNMAPPED_0047
   preferred_term: BG-11 Medium
   synonyms:
   - synonym_text: BG-11 Medium
@@ -456,8 +433,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0048
-  identifier: UNMAPPED_0048
+- identifier: UNMAPPED_0048
   preferred_term: Enriched Seawater Medium
   synonyms:
   - synonym_text: Enriched Seawater Medium
@@ -475,8 +451,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0049
-  identifier: UNMAPPED_0049
+- identifier: UNMAPPED_0049
   preferred_term: Waris Medium
   synonyms:
   - synonym_text: Waris Medium
@@ -494,8 +469,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0050
-  identifier: UNMAPPED_0050
+- identifier: UNMAPPED_0050
   preferred_term: Euglena Medium
   synonyms:
   - synonym_text: Euglena Medium
@@ -513,8 +487,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0052
-  identifier: UNMAPPED_0052
+- identifier: UNMAPPED_0052
   preferred_term: WC Trace Elements Solution
   synonyms:
   - synonym_text: WC Trace Elements Solution
@@ -532,8 +505,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0053
-  identifier: UNMAPPED_0053
+- identifier: UNMAPPED_0053
   preferred_term: Supplemented Seawater
   synonyms:
   - synonym_text: Supplemented Seawater
@@ -551,8 +523,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0054
-  identifier: UNMAPPED_0054
+- identifier: UNMAPPED_0054
   preferred_term: DYV Metal Solution
   synonyms:
   - synonym_text: DYV Metal Solution
@@ -570,8 +541,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0055
-  identifier: UNMAPPED_0055
+- identifier: UNMAPPED_0055
   preferred_term: Proteose Peptone
   synonyms:
   - synonym_text: Proteose Peptone(BD 211684)
@@ -589,8 +559,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0059
-  identifier: UNMAPPED_0059
+- identifier: UNMAPPED_0059
   preferred_term: Allen Medium
   synonyms:
   - synonym_text: Allen Medium
@@ -608,8 +577,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0060
-  identifier: UNMAPPED_0060
+- identifier: UNMAPPED_0060
   preferred_term: Vermont Soil
   synonyms:
   - synonym_text: Vermont Soil
@@ -627,8 +595,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0061
-  identifier: UNMAPPED_0061
+- identifier: UNMAPPED_0061
   preferred_term: Volvox Medium
   synonyms:
   - synonym_text: Volvox Medium
@@ -646,8 +613,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0062
-  identifier: UNMAPPED_0062
+- identifier: UNMAPPED_0062
   preferred_term: EDTA Stock
   synonyms:
   - synonym_text: EDTA Stock
@@ -664,8 +630,7 @@ ingredients:
     changes: Imported from CultureMech as CURATION_NEEDED
     new_status: UNMAPPED
     llm_assisted: false
-- ontology_id: UNMAPPED_0063
-  identifier: UNMAPPED_0063
+- identifier: UNMAPPED_0063
   preferred_term: Iron Stock
   synonyms:
   - synonym_text: Iron Stock
@@ -682,8 +647,7 @@ ingredients:
     changes: Imported from CultureMech as CURATION_NEEDED
     new_status: UNMAPPED
     llm_assisted: false
-- ontology_id: UNMAPPED_0064
-  identifier: UNMAPPED_0064
+- identifier: UNMAPPED_0064
   preferred_term: Boron Stock
   synonyms:
   - synonym_text: Boron Stock
@@ -700,8 +664,7 @@ ingredients:
     changes: Imported from CultureMech as CURATION_NEEDED
     new_status: UNMAPPED
     llm_assisted: false
-- ontology_id: UNMAPPED_0065
-  identifier: UNMAPPED_0065
+- identifier: UNMAPPED_0065
   preferred_term: Bold Trace Stock
   synonyms:
   - synonym_text: Bold Trace Stock
@@ -719,8 +682,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0067
-  identifier: UNMAPPED_0067
+- identifier: UNMAPPED_0067
   preferred_term: 'Soilwater: GR- Medium'
   synonyms:
   - synonym_text: 'Soilwater: GR- Medium'
@@ -738,8 +700,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0068
-  identifier: UNMAPPED_0068
+- identifier: UNMAPPED_0068
   preferred_term: Beef extract
   synonyms:
   - synonym_text: Beef extract(Sigma B-4888)
@@ -757,8 +718,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0072
-  identifier: UNMAPPED_0072
+- identifier: UNMAPPED_0072
   preferred_term: DYIII Medium
   synonyms:
   - synonym_text: DYIII Medium
@@ -776,8 +736,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0074
-  identifier: UNMAPPED_0074
+- identifier: UNMAPPED_0074
   preferred_term: Beijerinck's Solution
   synonyms:
   - synonym_text: Beijerinck's Solution
@@ -795,8 +754,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0075
-  identifier: UNMAPPED_0075
+- identifier: UNMAPPED_0075
   preferred_term: Phosphate Buffer Stock Solution
   synonyms:
   - synonym_text: Phosphate Buffer Stock Solution
@@ -814,8 +772,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0076
-  identifier: UNMAPPED_0076
+- identifier: UNMAPPED_0076
   preferred_term: Hunter's Trace Stock Solution
   synonyms:
   - synonym_text: Hunter's Trace Stock Solution
@@ -833,8 +790,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0077
-  identifier: UNMAPPED_0077
+- identifier: UNMAPPED_0077
   preferred_term: Tris Acetate Stock Solution
   synonyms:
   - synonym_text: Tris Acetate Stock Solution
@@ -852,8 +808,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0078
-  identifier: UNMAPPED_0078
+- identifier: UNMAPPED_0078
   preferred_term: Modified Bold 3N Medium
   synonyms:
   - synonym_text: Modified Bold 3N Medium
@@ -871,8 +826,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0080
-  identifier: UNMAPPED_0080
+- identifier: UNMAPPED_0080
   preferred_term: A+ Trace Components
   synonyms:
   - synonym_text: A+ Trace Components (sterilize before adding)
@@ -890,8 +844,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0081
-  identifier: UNMAPPED_0081
+- identifier: UNMAPPED_0081
   preferred_term: DAS Macro Solution
   synonyms:
   - synonym_text: DAS Macro Solution
@@ -909,8 +862,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0082
-  identifier: UNMAPPED_0082
+- identifier: UNMAPPED_0082
   preferred_term: Modified P-IV chelated Micronutrient Solution
   synonyms:
   - synonym_text: Modified P-IV chelated Micronutrient Solution
@@ -928,8 +880,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0083
-  identifier: UNMAPPED_0083
+- identifier: UNMAPPED_0083
   preferred_term: P-II Metal Solution
   synonyms:
   - synonym_text: P-II Metal Solution
@@ -947,8 +898,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0084
-  identifier: UNMAPPED_0084
+- identifier: UNMAPPED_0084
   preferred_term: Chelated Iron Solution
   synonyms:
   - synonym_text: Chelated Iron Solution
@@ -966,8 +916,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0086
-  identifier: UNMAPPED_0086
+- identifier: UNMAPPED_0086
   preferred_term: Algal Trace Elements Solution
   synonyms:
   - synonym_text: Algal Trace Elements Solution
@@ -985,8 +934,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0087
-  identifier: UNMAPPED_0087
+- identifier: UNMAPPED_0087
   preferred_term: Sphagnum extract
   synonyms:
   - synonym_text: Sphagnum extract
@@ -1004,8 +952,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0089
-  identifier: UNMAPPED_0089
+- identifier: UNMAPPED_0089
   preferred_term: Malt extract
   synonyms:
   - synonym_text: Malt extract(Sigma M-0383)
@@ -1023,8 +970,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0091
-  identifier: UNMAPPED_0091
+- identifier: UNMAPPED_0091
   preferred_term: CaSO4•2H2Osaturated solution
   synonyms:
   - synonym_text: CaSO4•2H2Osaturated solution (Mallinckroft 4300)
@@ -1042,8 +988,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0092
-  identifier: UNMAPPED_0092
+- identifier: UNMAPPED_0092
   preferred_term: 'Soilwater: Peat Medium'
   synonyms:
   - synonym_text: 'Soilwater: Peat Medium'
@@ -1061,8 +1006,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0095
-  identifier: UNMAPPED_0095
+- identifier: UNMAPPED_0095
   preferred_term: Macro Component 1 for J Medium
   synonyms:
   - synonym_text: Macro Component 1 for J Medium
@@ -1080,8 +1024,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0096
-  identifier: UNMAPPED_0096
+- identifier: UNMAPPED_0096
   preferred_term: Macro Component 2 for J medium
   synonyms:
   - synonym_text: Macro Component 2 for J medium
@@ -1099,8 +1042,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0097
-  identifier: UNMAPPED_0097
+- identifier: UNMAPPED_0097
   preferred_term: G9 Trace Metals for J medium
   synonyms:
   - synonym_text: G9 Trace Metals for J medium
@@ -1118,8 +1060,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0099
-  identifier: UNMAPPED_0099
+- identifier: UNMAPPED_0099
   preferred_term: Minor Nutrients
   synonyms:
   - synonym_text: Minor Nutrients
@@ -1136,8 +1077,7 @@ ingredients:
     changes: Imported from CultureMech as CURATION_NEEDED
     new_status: UNMAPPED
     llm_assisted: false
-- ontology_id: UNMAPPED_0100
-  identifier: UNMAPPED_0100
+- identifier: UNMAPPED_0100
   preferred_term: Modified COMBO Medium
   synonyms:
   - synonym_text: Modified COMBO Medium
@@ -1155,8 +1095,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Complex media or named solution - intentionally unmapped
-- ontology_id: UNMAPPED_0101
-  identifier: UNMAPPED_0101
+- identifier: UNMAPPED_0101
   preferred_term: Chu Stock Solution
   synonyms:
   - synonym_text: Chu Stock Solution

--- a/data/curated/unmapped_incomplete_formula.yaml
+++ b/data/curated/unmapped_incomplete_formula.yaml
@@ -1,8 +1,7 @@
 category: INCOMPLETE_FORMULA
 count: 12
 ingredients:
-- ontology_id: UNMAPPED_0003
-  identifier: UNMAPPED_0003
+- identifier: UNMAPPED_0003
   preferred_term: NaNO
   synonyms:
   - synonym_text: 'NaNO3(CAS: 7631-99-4)'
@@ -25,8 +24,7 @@ ingredients:
     changes: Imported from CultureMech as CURATION_NEEDED
     new_status: UNMAPPED
     llm_assisted: false
-- ontology_id: UNMAPPED_0008
-  identifier: UNMAPPED_0008
+- identifier: UNMAPPED_0008
   preferred_term: K2HPO
   synonyms:
   - synonym_text: K2HPO4(Sigma P 3786)
@@ -43,8 +41,7 @@ ingredients:
     changes: Imported from CultureMech as CURATION_NEEDED
     new_status: UNMAPPED
     llm_assisted: false
-- ontology_id: UNMAPPED_0013
-  identifier: UNMAPPED_0013
+- identifier: UNMAPPED_0013
   preferred_term: MgCO
   synonyms:
   - synonym_text: MgCO3(MCIB CB486)
@@ -61,8 +58,7 @@ ingredients:
     changes: Imported from CultureMech as CURATION_NEEDED
     new_status: UNMAPPED
     llm_assisted: false
-- ontology_id: UNMAPPED_0014
-  identifier: UNMAPPED_0014
+- identifier: UNMAPPED_0014
   preferred_term: KH2PO
   synonyms:
   - synonym_text: KH2PO4(Sigma P 0662)
@@ -79,8 +75,7 @@ ingredients:
     changes: Imported from CultureMech as CURATION_NEEDED
     new_status: UNMAPPED
     llm_assisted: false
-- ontology_id: UNMAPPED_0016
-  identifier: UNMAPPED_0016
+- identifier: UNMAPPED_0016
   preferred_term: CaCO
   synonyms:
   - synonym_text: CaCO3(Fisher C 64)
@@ -103,8 +98,7 @@ ingredients:
     changes: Imported from CultureMech as CURATION_NEEDED
     new_status: UNMAPPED
     llm_assisted: false
-- ontology_id: UNMAPPED_0021
-  identifier: UNMAPPED_0021
+- identifier: UNMAPPED_0021
   preferred_term: KNO
   synonyms:
   - synonym_text: KNO3(Baker 3190)
@@ -121,8 +115,7 @@ ingredients:
     changes: Imported from CultureMech as CURATION_NEEDED
     new_status: UNMAPPED
     llm_assisted: false
-- ontology_id: UNMAPPED_0029
-  identifier: UNMAPPED_0029
+- identifier: UNMAPPED_0029
   preferred_term: NaHCO
   synonyms:
   - synonym_text: NaHCO3(Fisher S 233)
@@ -139,8 +132,7 @@ ingredients:
     changes: Imported from CultureMech as CURATION_NEEDED
     new_status: UNMAPPED
     llm_assisted: false
-- ontology_id: UNMAPPED_0031
-  identifier: UNMAPPED_0031
+- identifier: UNMAPPED_0031
   preferred_term: NH4NO
   synonyms:
   - synonym_text: 'NH4NO3(CAS: 6484-52-2)'
@@ -157,8 +149,7 @@ ingredients:
     changes: Imported from CultureMech as CURATION_NEEDED
     new_status: UNMAPPED
     llm_assisted: false
-- ontology_id: UNMAPPED_0033
-  identifier: UNMAPPED_0033
+- identifier: UNMAPPED_0033
   preferred_term: Na2CO
   synonyms:
   - synonym_text: Na2CO3(Baker 3604)
@@ -175,8 +166,7 @@ ingredients:
     changes: Imported from CultureMech as CURATION_NEEDED
     new_status: UNMAPPED
     llm_assisted: false
-- ontology_id: UNMAPPED_0034
-  identifier: UNMAPPED_0034
+- identifier: UNMAPPED_0034
   preferred_term: NH4MgPO
   synonyms:
   - synonym_text: NH4MgPO4(Sigma 529354)
@@ -193,8 +183,7 @@ ingredients:
     changes: Imported from CultureMech as CURATION_NEEDED
     new_status: UNMAPPED
     llm_assisted: false
-- ontology_id: UNMAPPED_0036
-  identifier: UNMAPPED_0036
+- identifier: UNMAPPED_0036
   preferred_term: H3BO
   synonyms:
   - synonym_text: H3BO3(Baker 0084)
@@ -211,8 +200,7 @@ ingredients:
     changes: Imported from CultureMech as CURATION_NEEDED
     new_status: UNMAPPED
     llm_assisted: false
-- ontology_id: UNMAPPED_0037
-  identifier: UNMAPPED_0037
+- identifier: UNMAPPED_0037
   preferred_term: Ca
   synonyms:
   - synonym_text: 'Ca(NO3)2•4H2O(CAS: 13477-34-4)'

--- a/data/curated/unmapped_other.yaml
+++ b/data/curated/unmapped_other.yaml
@@ -1,8 +1,7 @@
 category: OTHER
 count: 2
 ingredients:
-- ontology_id: UNMAPPED_0079
-  identifier: UNMAPPED_0079
+- identifier: UNMAPPED_0079
   preferred_term: Trizma Base pH
   synonyms:
   - synonym_text: Trizma Base pH 8.2
@@ -19,8 +18,7 @@ ingredients:
     changes: Imported from CultureMech as CURATION_NEEDED
     new_status: UNMAPPED
     llm_assisted: false
-- ontology_id: UNMAPPED_0098
-  identifier: UNMAPPED_0098
+- identifier: UNMAPPED_0098
   preferred_term: FE EDTA
   synonyms:
   - synonym_text: FE EDTA

--- a/data/curated/unmapped_placeholder.yaml
+++ b/data/curated/unmapped_placeholder.yaml
@@ -1,8 +1,7 @@
 category: PLACEHOLDER
 count: 7
 ingredients:
-- ontology_id: UNMAPPED_0001
-  identifier: UNMAPPED_0001
+- identifier: UNMAPPED_0001
   preferred_term: See source for composition
   synonyms: []
   mapping_status: UNMAPPED
@@ -17,8 +16,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Placeholder for 'see source' references - not a real ingredient
-- ontology_id: UNMAPPED_0002
-  identifier: UNMAPPED_0002
+- identifier: UNMAPPED_0002
   preferred_term: Full composition available at source database
   synonyms:
   - synonym_text: Full composition available at source database
@@ -36,8 +34,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Placeholder for 'see source' references - not a real ingredient
-- ontology_id: UNMAPPED_0030
-  identifier: UNMAPPED_0030
+- identifier: UNMAPPED_0030
   preferred_term: 'Original amount: (NH4)2HPO4(Fisher A686)'
   synonyms:
   - synonym_text: (NH4)2HPO4(Fisher A686)
@@ -55,8 +52,7 @@ ingredients:
     new_status: UNMAPPED
     llm_assisted: false
   notes: Placeholder for 'see source' references - not a real ingredient
-- ontology_id: UNMAPPED_0056
-  identifier: UNMAPPED_0056
+- identifier: UNMAPPED_0056
   preferred_term: '[Merged 63 duplicates: 5.0, 1.0, 5.0, 1.0]'
   synonyms:
   - synonym_text: '[Merged 63 duplicates: 5.0, 1.0, 5.0, 1.0]'
@@ -73,8 +69,7 @@ ingredients:
     changes: Imported from CultureMech as CURATION_NEEDED
     new_status: UNMAPPED
     llm_assisted: false
-- ontology_id: UNMAPPED_0057
-  identifier: UNMAPPED_0057
+- identifier: UNMAPPED_0057
   preferred_term: '[Merged 10 duplicates: 2.0, 1.0]'
   synonyms:
   - synonym_text: '[Merged 10 duplicates: 2.0, 1.0]'
@@ -91,8 +86,7 @@ ingredients:
     changes: Imported from CultureMech as CURATION_NEEDED
     new_status: UNMAPPED
     llm_assisted: false
-- ontology_id: UNMAPPED_0058
-  identifier: UNMAPPED_0058
+- identifier: UNMAPPED_0058
   preferred_term: '[Merged 2 duplicates: 5.0, 20.0]'
   synonyms:
   - synonym_text: '[Merged 2 duplicates: 5.0, 20.0]'
@@ -109,8 +103,7 @@ ingredients:
     changes: Imported from CultureMech as CURATION_NEEDED
     new_status: UNMAPPED
     llm_assisted: false
-- ontology_id: UNMAPPED_0071
-  identifier: UNMAPPED_0071
+- identifier: UNMAPPED_0071
   preferred_term: 'Original amount: (NH4)2SO4(Fisher A 702)'
   synonyms:
   - synonym_text: (NH4)2SO4(Fisher A 702)

--- a/scripts/migrate_drop_legacy_ontology_id.py
+++ b/scripts/migrate_drop_legacy_ontology_id.py
@@ -103,6 +103,9 @@ def main() -> int:
     mode = "APPLY" if args.apply else "DRY-RUN"
     print(f"=== migrate_drop_legacy_ontology_id ({mode}) ===")
 
+    # Define once so the final-total print is safe even when the
+    # categorized-files list happens to be empty / all-missing.
+    verb = "dropped" if args.apply else "would drop"
     total_seen = 0
     total_dropped = 0
     for path in CATEGORIZED_FILES:
@@ -112,7 +115,6 @@ def main() -> int:
         seen, dropped = migrate_file(path, apply=args.apply)
         total_seen += seen
         total_dropped += dropped
-        verb = "would drop" if not args.apply else "dropped"
         print(f"  {path.name}: {verb} {dropped}/{seen} legacy ontology_id key(s)")
 
     print(f"--- total: {verb} {total_dropped}/{total_seen} legacy ontology_id key(s) ---")

--- a/scripts/migrate_drop_legacy_ontology_id.py
+++ b/scripts/migrate_drop_legacy_ontology_id.py
@@ -1,0 +1,125 @@
+"""One-shot migration: drop the legacy top-level `ontology_id` key from
+ingredient records inside the 5 categorized unmapped collections.
+
+Background
+----------
+`IngredientRecord` was renamed `ontology_id` -> `identifier`. The writer in
+`scripts/prepare_unmapped_for_curation.py` emitted both keys for backwards
+compatibility; the closed-schema strict validator now flags `ontology_id`
+as `unexpected_field` (85 ERROR rows across the 5 files).
+
+This migration scans each categorized file, removes `ontology_id` from
+every record where it equals the record's `identifier`, and re-writes the
+file through `write_validated_ingredient` so the result is structurally
+valid against the schema.
+
+Idempotent: running again is a no-op (the key is already gone).
+
+Usage
+-----
+    # Preview (default):
+    uv run python scripts/migrate_drop_legacy_ontology_id.py
+
+    # Apply:
+    uv run python scripts/migrate_drop_legacy_ontology_id.py --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from mediaingredientmech.validation.write_validated import (  # noqa: E402
+    ValidationFailedError,
+    write_validated_ingredient,
+)
+
+CATEGORIZED_FILES = [
+    REPO_ROOT / "data" / "curated" / "unmapped_already_mapped.yaml",
+    REPO_ROOT / "data" / "curated" / "unmapped_complex_media.yaml",
+    REPO_ROOT / "data" / "curated" / "unmapped_incomplete_formula.yaml",
+    REPO_ROOT / "data" / "curated" / "unmapped_other.yaml",
+    REPO_ROOT / "data" / "curated" / "unmapped_placeholder.yaml",
+]
+
+
+def migrate_file(path: Path, *, apply: bool) -> tuple[int, int]:
+    """Return `(records_with_legacy_key, records_dropped)`."""
+    with path.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+
+    if not isinstance(data, dict) or not isinstance(data.get("ingredients"), list):
+        print(f"  SKIP {path.name}: not an IngredientCollection")
+        return 0, 0
+
+    seen = 0
+    dropped = 0
+    for record in data["ingredients"]:
+        if not isinstance(record, dict):
+            continue
+        if "ontology_id" not in record:
+            continue
+        seen += 1
+        legacy = record["ontology_id"]
+        identifier = record.get("identifier")
+        if legacy != identifier:
+            print(
+                f"  WARN {path.name}: skipping record "
+                f"identifier={identifier!r} — legacy ontology_id={legacy!r} "
+                "differs from identifier (not a safe rename)."
+            )
+            continue
+        del record["ontology_id"]
+        dropped += 1
+
+    if apply and dropped > 0:
+        try:
+            write_validated_ingredient(
+                data, path, target_class="IngredientCollection"
+            )
+        except ValidationFailedError as exc:
+            print(f"  ERROR {path.name}: validation failed after migration")
+            print(exc.summary())
+            raise
+
+    return seen, dropped
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually write changes (default: dry-run preview only).",
+    )
+    args = parser.parse_args()
+
+    mode = "APPLY" if args.apply else "DRY-RUN"
+    print(f"=== migrate_drop_legacy_ontology_id ({mode}) ===")
+
+    total_seen = 0
+    total_dropped = 0
+    for path in CATEGORIZED_FILES:
+        if not path.exists():
+            print(f"  SKIP {path.name}: file not found")
+            continue
+        seen, dropped = migrate_file(path, apply=args.apply)
+        total_seen += seen
+        total_dropped += dropped
+        verb = "would drop" if not args.apply else "dropped"
+        print(f"  {path.name}: {verb} {dropped}/{seen} legacy ontology_id key(s)")
+
+    print(f"--- total: {verb} {total_dropped}/{total_seen} legacy ontology_id key(s) ---")
+    if not args.apply and total_seen > 0:
+        print("(re-run with --apply to write changes)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/prepare_unmapped_for_curation.py
+++ b/scripts/prepare_unmapped_for_curation.py
@@ -136,7 +136,6 @@ def convert_unmapped_ingredient(cm_unmapped: dict, index: int, category: str) ->
 
     # Build record
     record = {
-        "ontology_id": ontology_id,
         "identifier": ontology_id,
         "preferred_term": preferred_term,
         "synonyms": synonyms,

--- a/src/mediaingredientmech/schema/mediaingredientmech.yaml
+++ b/src/mediaingredientmech/schema/mediaingredientmech.yaml
@@ -43,6 +43,17 @@ classes:
       unmapped_count:
         range: integer
         description: Number of unmapped ingredients
+      category:
+        description: >-
+          Categorization label for partitioned unmapped collections (e.g.
+          PLACEHOLDER, COMPLEX_MEDIA, INCOMPLETE_FORMULA, OTHER,
+          ALREADY_MAPPED). Set by scripts/categorize_unmapped.py; absent
+          on the canonical mapped_ingredients.yaml / unmapped_ingredients.yaml.
+      count:
+        range: integer
+        description: >-
+          Record count for this categorized partition. Mirrors len(ingredients)
+          when present.
       ingredients:
         range: IngredientRecord
         multivalued: true


### PR DESCRIPTION
## Audit context

PR #32 ported CultureMech's audit machinery into this repo (`scripts/validate_strict.py` + `write_validated_ingredient` + `audit_writers.py`). Running the new closed-schema strict validator surfaced a **90-error baseline** across exactly 5 files — the 5 categorized unmapped collections in `data/curated/unmapped_*.yaml` (excluding the canonical `unmapped_ingredients.yaml`).

## Root causes

Audit pinned exactly two issues:

1. **85 `unexpected_field` errors** — legacy top-level `ontology_id` key on individual records inside the 5 categorized files. The field was renamed `ontology_id` → `identifier`, but the writer at `scripts/prepare_unmapped_for_curation.py:139` kept emitting both (as duplicate values, not divergent ones).
2. **5 `other` errors** — top-level `category` + `count` keys on each of the 5 collection files. The writer (`scripts/categorize_unmapped.py`) emits these useful provenance fields, but the schema's `IngredientCollection` class didn't declare them.

## Fixes

### Schema-bless `category` + `count` on `IngredientCollection`
Additive, optional attributes — documented as the artifact of `categorize_unmapped`'s partitioning, absent on the canonical mapped/unmapped collections. No schema-breaking change. (`src/mediaingredientmech/schema/mediaingredientmech.yaml`)

### Stop emitting legacy `ontology_id`
Dropped the duplicate `"ontology_id": ontology_id,` from the record dict in `prepare_unmapped_for_curation.py`. The `identifier` key already carries the same value.

### One-shot migration for the 5 stale files
Added `scripts/migrate_drop_legacy_ontology_id.py` — pops `ontology_id` from existing records in the 5 categorized files (only when it equals `identifier`; logs a warning and skips otherwise). Idempotent. Re-writes through `write_validated_ingredient` so the result is structurally valid. Default mode is dry-run; ran once with `--apply` against the 5 files (85/85 keys dropped).

## After-state

```
=== validate-strict summary ===
  files scanned:      2275
  files with ERROR:   0
  total ERROR rows:   0
```

Down from 90 ERROR rows / 5 files. Tests pass (231 passed). Migration script is idempotent.

## Test plan
- [x] `uv run python scripts/validate_strict.py --quiet` → 0 ERROR rows / 2,275 files
- [x] `uv run pytest tests/ -q --no-cov` → 231 passed
- [x] `uv run ruff check scripts/migrate_drop_legacy_ontology_id.py` → All checks passed
- [x] Migration is idempotent (re-running drops 0/0)
- [x] Schema regen produces `category` and `count` on `IngredientCollection`