### PR TITLE
Add validate-strict CI workflow

### DIFF
--- a/.github/workflows/validate-strict.yaml
+++ b/.github/workflows/validate-strict.yaml
@@ -2,17 +2,19 @@ name: validate-strict
 
 on:
   pull_request:
-    paths:
+    paths: &trigger_paths
       - "data/ingredients/**"
       - "data/curated/**"
       - "src/mediaingredientmech/schema/**"
-      - "src/mediaingredientmech/**.py"
-      - "scripts/**.py"
+      - "src/mediaingredientmech/**/*.py"
+      - "scripts/**/*.py"
       - "justfile"
       - "pyproject.toml"
+      - "uv.lock"
       - ".github/workflows/validate-strict.yaml"
   push:
     branches: [main]
+    paths: *trigger_paths
   workflow_dispatch:
 
 permissions:
@@ -34,7 +36,10 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv sync --extra dev
+        # --frozen fails the workflow if uv.lock is stale (don't silently
+        # re-resolve in CI). Runtime deps only — this workflow doesn't run
+        # ruff/mypy/black, just validate-strict + audit-writers.
+        run: uv sync --frozen
 
       - name: Run validate-strict (closed-schema LinkML validation)
         run: just validate-strict

--- a/.github/workflows/validate-strict.yaml
+++ b/.github/workflows/validate-strict.yaml
@@ -1,0 +1,53 @@
+name: validate-strict
+
+on:
+  pull_request:
+    paths:
+      - "data/ingredients/**"
+      - "data/curated/**"
+      - "src/mediaingredientmech/schema/**"
+      - "src/mediaingredientmech/**.py"
+      - "scripts/**.py"
+      - "justfile"
+      - "pyproject.toml"
+      - ".github/workflows/validate-strict.yaml"
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-strict:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: extractions/setup-just@v3
+
+      - uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Run validate-strict (closed-schema LinkML validation)
+        run: just validate-strict
+
+      - name: Run audit-writers
+        run: just audit-writers
+
+      - name: Upload reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: validate-strict-reports-${{ github.run_id }}
+          path: |
+            reports/instance_validation_failures.tsv
+            reports/pipeline_writers_audit.tsv
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary

Locks in the 0-error closed-schema baseline established by [PR #32](https://github.com/CultureBotAI/MediaIngredientMech/pull/32) + [PR #33](https://github.com/CultureBotAI/MediaIngredientMech/pull/33). Mirrors the qc.yaml workflow shipped to [TraitMech #77](https://github.com/CultureBotAI/TraitMech/pull/77).

Runs \`just validate-strict\` + \`just audit-writers\` on PRs that touch \`data/ingredients/\`, \`data/curated/\`, the schema, source, scripts, justfile, or this workflow file. Uploads the categorized TSV reports as workflow artifacts.

## Scope

Deliberately narrower than \`just qc\` — the existing \`qc-evidence.yaml\` and \`qc-sssom.yaml\` workflows already cover those slower network-dependent checks. The new workflow is fast (in-process parallel walk over ~2,275 yamls) so it can gate every PR without becoming a bottleneck.

## Test plan

- [x] Workflow yaml is valid (passes a local lint via \`actionlint\`-equivalent shape check).
- [ ] (Verified post-merge) Workflow runs and passes on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)