### PR TITLE
Extend role coverage to 40.2% (name-list categories) + finalize dup-identifier review

### DIFF
--- a/data/ingredients/mapped/14-B-D-Galactobiose.yaml
+++ b/data/ingredients/mapped/14-B-D-Galactobiose.yaml
@@ -48,6 +48,10 @@ curation_history:
   action: BACKFILL_PARENT_CHEBI
   changes: set ontology_mapping parent=CHEBI:36226 (pubchem-xref)
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.730391+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 2152-98-9
   data_source: CultureBotHT compounds_to_cas.csv
@@ -57,3 +61,10 @@ chemical_properties:
   inchi: InChI=1S/C12H22O11/c13-1-3-5(15)6(16)9(19)12(22-3)23-10-4(2-14)21-11(20)8(18)7(10)17/h3-20H,1-2H2/t3-,4-,5+,6+,7-,8-,9-,10+,11?,12+/m1/s1
   pubchem_cid: 9548802
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/3-O-Methyl-D-glucopyranose.yaml
+++ b/data/ingredients/mapped/3-O-Methyl-D-glucopyranose.yaml
@@ -39,6 +39,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.732200+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 13224-94-7
   data_source: CultureBotHT compounds_to_cas.csv
@@ -48,3 +52,10 @@ chemical_properties:
   inchi: InChI=1S/C7H14O6/c1-12-6-4(9)3(2-8)13-7(11)5(6)10/h3-11H,2H2,1H3/t3-,4-,5-,6+,7+/m1/s1
   pubchem_cid: 83246
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/3-O-methyl-glucose.yaml
+++ b/data/ingredients/mapped/3-O-methyl-glucose.yaml
@@ -40,6 +40,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.732231+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 146-72-5
   data_source: CultureBotHT compounds_to_cas.csv
@@ -48,3 +52,10 @@ chemical_properties:
   inchi: InChI=1S/C7H14O6/c1-13-7(5(11)3-9)6(12)4(10)2-8/h3-8,10-12H,2H2,1H3/t4-,5+,6-,7-/m1/s1
   smiles: CO[C@@H]([C@H](O)[C@H](O)CO)[C@@H](O)C=O
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/3-fucosyllactose.yaml
+++ b/data/ingredients/mapped/3-fucosyllactose.yaml
@@ -48,6 +48,10 @@ curation_history:
   action: BACKFILL_PARENT_CHEBI
   changes: set ontology_mapping parent=CHEBI:90065 (pubchem-xref)
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.732339+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 41312-47-4
   data_source: CultureBotHT compounds_to_cas.csv
@@ -57,3 +61,10 @@ chemical_properties:
   inchi: InChI=1S/C18H32O15/c1-4-7(21)9(23)11(25)17(29-4)33-15-13(27)16(28)30-6(3-20)14(15)32-18-12(26)10(24)8(22)5(2-19)31-18/h4-28H,2-3H2,1H3/t4-,5+,6+,7+,8-,9+,10-,11-,12+,13+,14+,15+,16?,17-,18-/m0/s1
   pubchem_cid: 16216990
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/3-sialyllactose_Sodium_Salt.yaml
+++ b/data/ingredients/mapped/3-sialyllactose_Sodium_Salt.yaml
@@ -49,6 +49,10 @@ curation_history:
   action: BACKFILL_PARENT_CHEBI
   changes: set ontology_mapping parent=CHEBI:26714 (stem-substring)
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.732555+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 128596-80-5
   data_source: CultureBotHT compounds_to_cas.csv
@@ -58,3 +62,10 @@ chemical_properties:
   inchi: InChI=1S/C23H39NO19.Na/c1-7(29)24-13-8(30)2-23(22(38)39,42-19(13)15(35)10(32)4-26)43-20-16(36)12(6-28)40-21(17(20)37)41-18(11(33)5-27)14(34)9(31)3-25;/h3,8-21,26-28,30-37H,2,4-6H2,1H3,(H,24,29)(H,38,39);/q;+1/p-1/t8-,9-,10+,11+,12+,13+,14+,15+,16-,17+,18+,19+,20-,21-,23-;/m0./s1
   pubchem_cid: 71308479
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/6-O-Acetyl-D-glucose.yaml
+++ b/data/ingredients/mapped/6-O-Acetyl-D-glucose.yaml
@@ -38,6 +38,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.733650+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 7286-45-5
   data_source: CultureBotHT compounds_to_cas.csv
@@ -46,3 +50,10 @@ chemical_properties:
   inchi: InChI=1S/C8H14O7/c1-3(9)14-2-4-5(10)6(11)7(12)8(13)15-4/h4-8,10-13H,2H2,1H3/t4-,5-,6+,7-,8?/m1/s1
   smiles: CC(=O)OC[C@H]1OC(O)[C@H](O)[C@@H](O)[C@@H]1O
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/6-O-sialyllactose_Sodium_Salt.yaml
+++ b/data/ingredients/mapped/6-O-sialyllactose_Sodium_Salt.yaml
@@ -49,6 +49,10 @@ curation_history:
   action: BACKFILL_PARENT_CHEBI
   changes: set ontology_mapping parent=CHEBI:26714 (stem-substring)
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.733686+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 157574-76-0
   data_source: CultureBotHT compounds_to_cas.csv
@@ -58,3 +62,10 @@ chemical_properties:
   inchi: InChI=1S/C23H39NO19.Na/c1-7(28)24-13-8(29)2-23(22(38)39,43-20(13)15(34)10(31)4-26)40-6-12-16(35)17(36)18(37)21(41-12)42-19(11(32)5-27)14(33)9(30)3-25;/h3,8-21,26-27,29-37H,2,4-6H2,1H3,(H,24,28)(H,38,39);/q;+1/p-1/t8-,9-,10+,11+,12+,13+,14+,15+,16-,17-,18+,19+,20+,21-,23+;/m0./s1
   pubchem_cid: 132285181
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Aces.yaml
+++ b/data/ingredients/mapped/Aces.yaml
@@ -54,9 +54,20 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (CHEBI primary)
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.734016+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: BUFFER (confidence: 0.80)'
 chemical_properties:
   cas_rn: 7365-82-4
   data_source: PubChem API
   retrieval_date: '2026-04-05T19:50:57.924216+00:00'
 kg_microbe_node_id: CHEBI:39061
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: BUFFER
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Acetylated_Xylan.yaml
+++ b/data/ingredients/mapped/Acetylated_Xylan.yaml
@@ -37,8 +37,19 @@ curation_history:
   previous_status: UNMAPPED
   new_status: MAPPED
   llm_assisted: true
+- timestamp: '2026-06-03T02:06:01.734116+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 notes: Imported from CultureBotHT (compounds_to_cas.csv (no CAS-RN)). No CAS-RN or
   CHEBI mapping available; curated to CHEBI:134431 acetyl xylan by local CHEBI exact
   synonym review on 2026-05-11.
 kg_microbe_node_id: CHEBI:134431
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Agar.yaml
+++ b/data/ingredients/mapped/Agar.yaml
@@ -136,9 +136,20 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (CHEBI primary)
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.734333+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: SOLIDIFYING_AGENT (confidence: 0.80)'
 chemical_properties:
   cas_rn: 9002-18-0
   data_source: PubChem API
   retrieval_date: '2026-04-05T19:50:59.360831+00:00'
 kg_microbe_node_id: CHEBI:2509
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: SOLIDIFYING_AGENT
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Arabinobiose.yaml
+++ b/data/ingredients/mapped/Arabinobiose.yaml
@@ -48,6 +48,10 @@ curation_history:
   action: BACKFILL_PARENT_MESH
   changes: set ontology_mapping parent=mesh:C434937 (label-exact)
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.734897+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 78088-21-8
   data_source: CultureBotHT compounds_to_cas.csv
@@ -57,3 +61,10 @@ chemical_properties:
   inchi: InChI=1S/C10H18O9/c11-1-4(13)7(15)5(14)3-18-10-9(17)8(16)6(2-12)19-10/h1,4-10,12-17H,2-3H2/t4-,5-,6-,7+,8-,9+,10+/m0/s1
   pubchem_cid: 165359509
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Arabinotriose.yaml
+++ b/data/ingredients/mapped/Arabinotriose.yaml
@@ -48,6 +48,10 @@ curation_history:
   action: BACKFILL_PARENT_CHEBI
   changes: set ontology_mapping parent=CHEBI:62799 (pubchem-xref)
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.734915+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 89315-59-3
   data_source: CultureBotHT compounds_to_cas.csv
@@ -57,3 +61,10 @@ chemical_properties:
   inchi: InChI=1S/C15H26O13/c16-1-4-7(17)11(21)14(27-4)25-3-6-9(19)12(22)15(28-6)24-2-5-8(18)10(20)13(23)26-5/h4-23H,1-3H2/t4-,5-,6-,7-,8-,9-,10+,11+,12+,13+,14+,15+/m0/s1
   pubchem_cid: 53356682
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Arabinoxylan_Rye_Flour.yaml
+++ b/data/ingredients/mapped/Arabinoxylan_Rye_Flour.yaml
@@ -21,6 +21,10 @@ curation_history:
   action: AUTO_UPGRADE_TO_FOODON
   changes: primary UNMAPPED_0176 → FOODON:03302492 (strategy=stem-match)
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.734942+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 notes: Imported from CultureBotHT (compounds_to_cas.csv (no CAS-RN)). No CAS-RN or
   CHEBI mapping available; curator review needed.
 ontology_mapping:
@@ -33,3 +37,10 @@ ontology_mapping:
     source: FOODON via OLS (resolve_unmapped_v2 strategy=stem-match)
     notes: Auto-upgraded from UNMAPPED_0176; matched via 'Arabinoxylan (Rye Flour)';
       stem-substring
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/B-Mannan_Borohydrate_Reduced_Carob_Seed.yaml
+++ b/data/ingredients/mapped/B-Mannan_Borohydrate_Reduced_Carob_Seed.yaml
@@ -40,6 +40,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.735314+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 9036-88-8
   data_source: CultureBotHT compounds_to_cas.csv
@@ -49,3 +53,10 @@ chemical_properties:
   inchi: InChI=1S/C24H42O21/c25-1-5-9(29)10(30)15(35)22(40-5)44-19-7(3-27)42-24(17(37)12(19)32)45-20-8(4-28)41-23(16(36)13(20)33)43-18-6(2-26)39-21(38)14(34)11(18)31/h5-38H,1-4H2
   pubchem_cid: 870
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Bacto-tryptone.yaml
+++ b/data/ingredients/mapped/Bacto-tryptone.yaml
@@ -59,4 +59,15 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'tryptone')
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.735363+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: PROTEIN_SOURCE (confidence: 0.80)'
 ingredient_type: UNDEFINED_MIXTURE
+media_roles:
+- role: PROTEIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Bacto_Brain_Heart_Infusion.yaml
+++ b/data/ingredients/mapped/Bacto_Brain_Heart_Infusion.yaml
@@ -26,6 +26,10 @@ curation_history:
   action: AUTO_UPGRADE_TO_MICRO
   changes: primary UNMAPPED_0331 → MICRO:0000193 (strategy=stem-match)
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.735385+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: PROTEIN_SOURCE (confidence: 0.80)'
 notes: Imported from mim-queue (source_id=mediadive.ingredient:965); no CAS-RN or
   CHEBI/NCIT match. Curator review needed.
 ingredient_type: UNDEFINED_MIXTURE
@@ -39,3 +43,10 @@ ontology_mapping:
     source: MICRO via OLS (resolve_unmapped_v2 strategy=stem-match)
     notes: Auto-upgraded from UNMAPPED_0331; matched via 'Bacto brain heart infusion';
       stem-substring
+media_roles:
+- role: PROTEIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Bacto_Peptone.yaml
+++ b/data/ingredients/mapped/Bacto_Peptone.yaml
@@ -135,4 +135,15 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'peptone')
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.735397+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: PROTEIN_SOURCE (confidence: 0.80)'
 ingredient_type: UNDEFINED_MIXTURE
+media_roles:
+- role: PROTEIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Bakers_Yeast.yaml
+++ b/data/ingredients/mapped/Bakers_Yeast.yaml
@@ -26,6 +26,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'yeast')
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.735494+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: PROTEIN_SOURCE (confidence: 0.80)'
 notes: Imported from mim-queue (source_id=mediadive.ingredient:17); no CAS-RN or CHEBI/NCIT
   match. Curator review needed.
 ontology_mapping:
@@ -38,3 +42,10 @@ ontology_mapping:
     source: FOODON via OLS search
     notes: Auto-upgraded from 'UNMAPPED_0335'; match=label-exact
 ingredient_type: UNDEFINED_MIXTURE
+media_roles:
+- role: PROTEIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Beef.yaml
+++ b/data/ingredients/mapped/Beef.yaml
@@ -31,4 +31,15 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Beef')
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.735617+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: PROTEIN_SOURCE (confidence: 0.80)'
 ingredient_type: UNDEFINED_MIXTURE
+media_roles:
+- role: PROTEIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Beef_Brain_Powder.yaml
+++ b/data/ingredients/mapped/Beef_Brain_Powder.yaml
@@ -32,6 +32,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Beef')
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.735631+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: PROTEIN_SOURCE (confidence: 0.80)'
 notes: Imported from mim-queue (source_id=mediadive.ingredient:1660); no CAS-RN or
   CHEBI/NCIT match. Curator review needed.
 ontology_mapping:
@@ -49,3 +53,10 @@ ontology_mapping:
       specificity beyond FOODON:02020911 (beef brain). Parent relationship persists
       via skos:narrowMatch in SSSOM emission.
 ingredient_type: UNDEFINED_MIXTURE
+media_roles:
+- role: PROTEIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Beef_Extract.yaml
+++ b/data/ingredients/mapped/Beef_Extract.yaml
@@ -69,9 +69,20 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Beef')
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.735643+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: PROTEIN_SOURCE (confidence: 0.80)'
 notes: 'CultureMech placeholder_id: 2'
 chemical_properties:
   cas_rn: 103-47-9
   data_source: PubChem API
   retrieval_date: '2026-04-05T19:54:20.671500+00:00'
 ingredient_type: UNDEFINED_MIXTURE
+media_roles:
+- role: PROTEIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Beef_Heart.yaml
+++ b/data/ingredients/mapped/Beef_Heart.yaml
@@ -27,6 +27,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Beef')
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.735652+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: PROTEIN_SOURCE (confidence: 0.80)'
 notes: 'Imported from CultureBotHT (compounds_to_cas.csv (no CAS-RN)). Used in 7 CultureBot
   media; samples: BHIS_PIPES, BHIS_HOMOPIPES, BHIS_K3…. No CAS-RN or CHEBI mapping
   available; curator review needed.'
@@ -40,3 +44,10 @@ ontology_mapping:
     source: FOODON via OLS search
     notes: Auto-upgraded from 'UNMAPPED_0171'; match=label-exact
 ingredient_type: UNDEFINED_MIXTURE
+media_roles:
+- role: PROTEIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Beef_Heart_Infusion.yaml
+++ b/data/ingredients/mapped/Beef_Heart_Infusion.yaml
@@ -33,6 +33,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Beef')
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.735667+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: PROTEIN_SOURCE (confidence: 0.80)'
 notes: 'Imported from CultureBotHT (compounds_to_cas.csv (no CAS-RN)). Used in 2 CultureBot
   media; samples: ACY, Columbia. No CAS-RN or CHEBI mapping available; curator review
   needed.'
@@ -51,3 +55,10 @@ ontology_mapping:
       specificity beyond FOODON:00004410 (beef heart). Parent relationship persists
       via skos:narrowMatch in SSSOM emission.
 ingredient_type: UNDEFINED_MIXTURE
+media_roles:
+- role: PROTEIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Bicine_Buffer.yaml
+++ b/data/ingredients/mapped/Bicine_Buffer.yaml
@@ -53,6 +53,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.736002+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: BUFFER (confidence: 0.80)'
 chemical_properties:
   cas_rn: 150-25-4
   data_source: PubChem API
@@ -61,3 +65,10 @@ chemical_properties:
   inchi: InChI=1S/C6H13NO4/c8-3-1-7(2-4-9)5-6(10)11/h8-9H,1-5H2,(H,10,11)
   smiles: O=C(O)CN(CCO)CCO
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: BUFFER
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Biotin_Vitamin_Solution.yaml
+++ b/data/ingredients/mapped/Biotin_Vitamin_Solution.yaml
@@ -35,6 +35,10 @@ curation_history:
   previous_status: MAPPED
   new_status: MAPPED
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.736065+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: VITAMIN_SOURCE (confidence: 0.80)'
 notes: 'CultureMech placeholder_id: 9 Biotin vitamin solution is a formulation variant,
   not identical to the generic vitamin solution class.'
 ingredient_type: STOCK_SOLUTION
@@ -49,3 +53,10 @@ ontology_mapping:
     notes: Biotin vitamin solution is a formulation variant, not identical to the
       generic vitamin solution class.
 kg_microbe_node_id: kgmicrobe.ingredient:biotin_vitamin_solution
+media_roles:
+- role: VITAMIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Bis-tris.yaml
+++ b/data/ingredients/mapped/Bis-tris.yaml
@@ -73,6 +73,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.736097+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: BUFFER (confidence: 0.80)'
 chemical_properties:
   cas_rn: 6976-37-0
   data_source: PubChem API
@@ -81,3 +85,10 @@ chemical_properties:
   inchi: InChI=1S/C8H19NO5/c10-3-1-9(2-4-11)8(5-12,6-13)7-14/h10-14H,1-7H2
   smiles: OCCN(CCO)C(CO)(CO)CO
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: BUFFER
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Brain_Heart_Infusion.yaml
+++ b/data/ingredients/mapped/Brain_Heart_Infusion.yaml
@@ -26,6 +26,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'infusion')
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.736217+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: PROTEIN_SOURCE (confidence: 0.80)'
 notes: Imported from mim-queue (source_id=mediadive.ingredient:186); no CAS-RN or
   CHEBI/NCIT match. Curator review needed.
 ontology_mapping:
@@ -38,3 +42,10 @@ ontology_mapping:
     source: MICRO via OLS search
     notes: Auto-upgraded from 'UNMAPPED_0346'; match=label-exact
 ingredient_type: UNDEFINED_MIXTURE
+media_roles:
+- role: PROTEIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Calcium_D-Pantothenate.yaml
+++ b/data/ingredients/mapped/Calcium_D-Pantothenate.yaml
@@ -33,6 +33,10 @@ curation_history:
   changes: molecular_formula=2C9H16NO5.Ca; inchi=InChI=1S/2C9H17NO5.Ca/c2*1-9(2,5-11)7(14)8(15)10-4;
     smiles=CC(C)(CO)[C@@H](O)C(=O)NCCC(=O)[O-].CC(C)(CO)[C@@H
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.736555+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: VITAMIN_SOURCE (confidence: 0.80)'
 notes: Imported from mim-queue (source_id=mediadive.ingredient:1585); no CAS-RN or
   CHEBI/NCIT match. Curator review needed.
 ontology_mapping:
@@ -52,3 +56,10 @@ chemical_properties:
   smiles: CC(C)(CO)[C@@H](O)C(=O)NCCC(=O)[O-].CC(C)(CO)[C@@H](O)C(=O)NCCC(=O)[O-].[Ca+2]
   data_source: CHEBI sqlite (oaklib)
 kg_microbe_node_id: CHEBI:31345
+media_roles:
+- role: VITAMIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Caps_Buffer.yaml
+++ b/data/ingredients/mapped/Caps_Buffer.yaml
@@ -82,6 +82,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.736662+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: BUFFER (confidence: 0.80)'
 kg_microbe_node_id: CHEBI:191088
 chemical_properties:
   cas_rn: 1135-40-6
@@ -91,3 +95,10 @@ chemical_properties:
   inchi: InChI=1S/C9H19NO3S/c11-14(12,13)8-4-7-10-9-5-2-1-3-6-9/h9-10H,1-8H2,(H,11,12,13)
   smiles: O=S(=O)(O)CCCNC1CCCCC1
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: BUFFER
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Carboxymethyl_Cellulose.yaml
+++ b/data/ingredients/mapped/Carboxymethyl_Cellulose.yaml
@@ -107,9 +107,20 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (CHEBI primary)
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.736720+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 kg_microbe_node_id: CHEBI:85146
 chemical_properties:
   cas_rn: 9004-32-4
   data_source: CultureBotHT/compounds_to_cas.csv
   retrieval_date: '2026-04-09T00:32:50.689620+00:00'
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Carboxymethyl_Cellulose_Sodium_Salt.yaml
+++ b/data/ingredients/mapped/Carboxymethyl_Cellulose_Sodium_Salt.yaml
@@ -21,6 +21,10 @@ curation_history:
   action: AUTO_UPGRADE_TO_FOODON
   changes: primary UNMAPPED_0602 → FOODON:03460374 (strategy=stem-match)
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.736761+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 notes: Imported from communitymech-unmapped (source_id=communitymech.ingredient:Carboxymethyl_cellulose_(sodium_salt));
   no CAS-RN or CHEBI/NCIT match. Curator review needed.
 ontology_mapping:
@@ -33,3 +37,10 @@ ontology_mapping:
     source: FOODON via OLS (resolve_unmapped_v2 strategy=stem-match)
     notes: Auto-upgraded from UNMAPPED_0602; matched via 'Carboxymethyl cellulose
       (sodium salt)'; stem-substring
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Casamino_Acids.yaml
+++ b/data/ingredients/mapped/Casamino_Acids.yaml
@@ -102,6 +102,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.736872+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: PROTEIN_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 65072-00-6
   data_source: CultureBotHT compounds_to_cas.csv
@@ -111,3 +115,10 @@ chemical_properties:
   smiles: CCCCCCCCCCCCCCCCCCCCCCCCCCC(=O)[O-]
 kg_microbe_node_id: CHEBI:78020
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: PROTEIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Casamino_Acids_Vitamin_Assay.yaml
+++ b/data/ingredients/mapped/Casamino_Acids_Vitamin_Assay.yaml
@@ -26,6 +26,10 @@ curation_history:
   action: AUTO_UPGRADE_TO_MESH
   changes: primary UNMAPPED_0185 → mesh:C017721 (strategy=stem-match)
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.736894+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: PROTEIN_SOURCE (confidence: 0.80)'
 notes: Imported from CultureBotHT (compounds_to_cas.csv (no CAS-RN)). No CAS-RN or
   CHEBI mapping available; curator review needed.
 ingredient_type: UNDEFINED_MIXTURE
@@ -39,3 +43,10 @@ ontology_mapping:
     source: MESH via OLS (resolve_unmapped_v2 strategy=stem-match)
     notes: Auto-upgraded from UNMAPPED_0185; matched via 'Casamino acids (vitamin
       assay)'; stem-substring
+media_roles:
+- role: PROTEIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Casein_Peptone.yaml
+++ b/data/ingredients/mapped/Casein_Peptone.yaml
@@ -81,4 +81,15 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Casein')
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.736906+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: PROTEIN_SOURCE (confidence: 0.80)'
 ingredient_type: UNDEFINED_MIXTURE
+media_roles:
+- role: PROTEIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Casein_hydrolysate.yaml
+++ b/data/ingredients/mapped/Casein_hydrolysate.yaml
@@ -21,4 +21,15 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Casein')
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.736920+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: PROTEIN_SOURCE (confidence: 0.80)'
 ingredient_type: UNDEFINED_MIXTURE
+media_roles:
+- role: PROTEIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Casitone.yaml
+++ b/data/ingredients/mapped/Casitone.yaml
@@ -54,4 +54,15 @@ curation_history:
   action: UPGRADE_FOODON_PARENT_TO_MICRO_SPECIFIC
   changes: FOODON:03315719 → MICRO:0000606 (more specific MICRO term)
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.736928+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: PROTEIN_SOURCE (confidence: 0.80)'
 ingredient_type: UNDEFINED_MIXTURE
+media_roles:
+- role: PROTEIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Cell_Lysate.yaml
+++ b/data/ingredients/mapped/Cell_Lysate.yaml
@@ -23,6 +23,10 @@ curation_history:
   action: AUTO_UPGRADE_TO_BTO
   changes: UNMAPPED_0308 → BTO:0004304
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.737022+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: PROTEIN_SOURCE (confidence: 0.80)'
 notes: 'Imported from CultureBotHT (consolidated_media.json (media-only)). Used in
   4 CultureBot media; samples: FilteredGW Cell lysate 1/2500, FilteredGW Cell lysate
   1/250, FilteredGW_Cell lysate_1/250…. No CAS-RN or CHEBI mapping available; curator
@@ -37,3 +41,10 @@ ontology_mapping:
     source: BTO via OLS (resolve_unmapped_v2 any-ontology cascade)
     notes: BTO has the precise term cell lysate (BRENDA Tissue Ontology); v1 missed
       because cascade did not include BTO.
+media_roles:
+- role: PROTEIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Chitin.yaml
+++ b/data/ingredients/mapped/Chitin.yaml
@@ -37,9 +37,20 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.737167+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 ingredient_type: SINGLE_INGREDIENT
 chemical_properties:
   molecular_formula: (C8H13NO5)n.H2O
   inchi: InChI=1S/C8H15NO6/c1-3(11)9-5-7(13)6(12)4(2-10)15-8(5)14/h4-8,10,12-14H,2H2,1H3,(H,9,11)/t4-,5-,6-,7-,8-/m1/s1
   smiles: '[H]O[C@@H]1O[C@H](CO)[C@@H](O)[C@H](O)[C@H]1NC(C)=O'
   data_source: CHEBI sqlite (oaklib)
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/D-Fructose_6-phosphate_Disodium_Salt_Hydrate.yaml
+++ b/data/ingredients/mapped/D-Fructose_6-phosphate_Disodium_Salt_Hydrate.yaml
@@ -48,6 +48,10 @@ curation_history:
   action: BACKFILL_PARENT_CHEBI
   changes: set ontology_mapping parent=CHEBI:190546 (pubchem-xref)
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.738391+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 26177-86-6
   data_source: CultureBotHT compounds_to_cas.csv
@@ -57,3 +61,10 @@ chemical_properties:
   inchi: InChI=1S/C6H13O9P.2Na/c7-1-3(8)5(10)6(11)4(9)2-15-16(12,13)14;;/h4-7,9-11H,1-2H2,(H2,12,13,14);;/q;2*+1/p-2/t4-,5-,6-;;/m1../s1
   pubchem_cid: 22812950
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/D-Glucose-6-Phosphate_Sodium_Salt.yaml
+++ b/data/ingredients/mapped/D-Glucose-6-Phosphate_Sodium_Salt.yaml
@@ -50,6 +50,10 @@ curation_history:
   action: BACKFILL_PARENT_CHEBI
   changes: set ontology_mapping parent=CHEBI:26714 (stem-substring)
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.738518+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 54010-71-8
   data_source: CultureBotHT compounds_to_cas.csv
@@ -59,3 +63,10 @@ chemical_properties:
   inchi: InChI=1S/C6H13O9P.Na/c7-1-3(8)5(10)6(11)4(9)2-15-16(12,13)14;/h1,3-6,8-11H,2H2,(H2,12,13,14);/q;+1/p-1/t3-,4+,5+,6+;/m0./s1
   pubchem_cid: 23677332
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/D-Leucrose.yaml
+++ b/data/ingredients/mapped/D-Leucrose.yaml
@@ -40,6 +40,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.738610+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 7158-70-5
   data_source: CultureBotHT compounds_to_cas.csv
@@ -49,3 +53,10 @@ chemical_properties:
   inchi: InChI=1S/C12H22O11/c13-1-4(16)7(17)8(18)5(2-14)22-12-11(21)10(20)9(19)6(3-15)23-12/h5-15,17-21H,1-3H2/t5-,6-,7-,8-,9-,10+,11-,12+/m1/s1
   pubchem_cid: 165577
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/D-Maltose_Monohydrate.yaml
+++ b/data/ingredients/mapped/D-Maltose_Monohydrate.yaml
@@ -58,6 +58,10 @@ curation_history:
   action: BACKFILL_PARENT_CHEBI
   changes: set ontology_mapping parent=CHEBI:233428 (pubchem-xref)
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.738635+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 6363-53-7
   data_source: CultureBotHT compounds_to_cas.csv
@@ -67,3 +71,10 @@ chemical_properties:
   inchi: InChI=1S/C12H22O11.H2O/c13-1-4(16)7(18)11(5(17)2-14)23-12-10(21)9(20)8(19)6(3-15)22-12;/h1,4-12,14-21H,2-3H2;1H2/t4-,5+,6+,7+,8+,9-,10+,11+,12+;/m0./s1
   pubchem_cid: 23615261
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/D-Mannose_6-phosphate_Sodium_Salt.yaml
+++ b/data/ingredients/mapped/D-Mannose_6-phosphate_Sodium_Salt.yaml
@@ -49,6 +49,10 @@ curation_history:
   action: BACKFILL_PARENT_CHEBI
   changes: set ontology_mapping parent=CHEBI:17369 (stem-substring)
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.738671+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 70442-25-0
   data_source: CultureBotHT compounds_to_cas.csv
@@ -58,3 +62,10 @@ chemical_properties:
   inchi: InChI=1S/C6H13O9P.Na/c7-1-3(8)5(10)6(11)4(9)2-15-16(12,13)14;/h1,3-6,8-11H,2H2,(H2,12,13,14);/q;+1/p-1/t3-,4-,5-,6-;/m1./s1
   pubchem_cid: 23681585
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/D-Raffinose_Pentahydrate.yaml
+++ b/data/ingredients/mapped/D-Raffinose_Pentahydrate.yaml
@@ -48,6 +48,10 @@ curation_history:
   action: BACKFILL_PARENT_CHEBI
   changes: set ontology_mapping parent=CHEBI:189430 (pubchem-xref)
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.738699+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 17629-30-0
   data_source: CultureBotHT compounds_to_cas.csv
@@ -57,3 +61,10 @@ chemical_properties:
   inchi: InChI=1S/C18H32O16.5H2O/c19-1-5-8(22)11(25)13(27)16(31-5)30-3-7-9(23)12(26)14(28)17(32-7)34-18(4-21)15(29)10(24)6(2-20)33-18;;;;;/h5-17,19-29H,1-4H2;5*1H2/t5-,6-,7-,8+,9-,10-,11+,12+,13-,14-,15+,16+,17-,18+;;;;;/m1...../s1
   pubchem_cid: 2724100
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/D-_-melezitose_Hydrate.yaml
+++ b/data/ingredients/mapped/D-_-melezitose_Hydrate.yaml
@@ -40,6 +40,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.738273+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 207511-10-2
   data_source: CultureBotHT compounds_to_cas.csv
@@ -49,3 +53,10 @@ chemical_properties:
   inchi: InChI=1S/C18H32O16.H2O/c19-1-5-8(23)11(26)13(28)16(30-5)32-15-10(25)7(3-21)33-18(15,4-22)34-17-14(29)12(27)9(24)6(2-20)31-17;/h5-17,19-29H,1-4H2;1H2/t5-,6-,7-,8-,9-,10-,11+,12+,13-,14-,15+,16-,17-,18+;/m1./s1
   pubchem_cid: 16217716
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/D-_-melezitose_Monohydrate.yaml
+++ b/data/ingredients/mapped/D-_-melezitose_Monohydrate.yaml
@@ -40,6 +40,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.738307+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 10030-67-8
   data_source: CultureBotHT compounds_to_cas.csv
@@ -49,3 +53,10 @@ chemical_properties:
   inchi: InChI=1S/C18H32O16.H2O/c19-1-5-8(23)11(26)13(28)16(30-5)32-15-10(25)7(3-21)33-18(15,4-22)34-17-14(29)12(27)9(24)6(2-20)31-17;/h5-17,19-29H,1-4H2;1H2/t5-,6-,7-,8-,9-,10-,11+,12+,13-,14-,15+,16-,17-,18+;/m1./s1
   pubchem_cid: 16217716
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/D-trehalose_Dihydrate.yaml
+++ b/data/ingredients/mapped/D-trehalose_Dihydrate.yaml
@@ -52,6 +52,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.739059+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 notes: Created from FEBA ontology enrichment workflow. Used in 15 FEBA media formulations.
 chemical_properties:
   cas_rn: 6138-23-4
@@ -61,3 +65,10 @@ chemical_properties:
   inchi: InChI=1S/C12H22O11.2H2O/c13-1-3-5(15)7(17)9(19)11(21-3)23-12-10(20)8(18)6(16)4(2-14)22-12;;/h3-20H,1-2H2;2*1H2/t3-,4-,5-,6-,7+,8+,9-,10-,11-,12-;;/m1../s1
   smiles: O.O.[H][C@]1(O[C@@]2([H])O[C@]([H])(CO)[C@@]([H])(O)[C@]([H])(O)[C@@]2([H])O)O[C@]([H])(CO)[C@@]([H])(O)[C@]([H])(O)[C@@]1([H])O
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/D-xylose_5-phosphate_Lithium_Salt.yaml
+++ b/data/ingredients/mapped/D-xylose_5-phosphate_Lithium_Salt.yaml
@@ -49,6 +49,10 @@ curation_history:
   changes: molecular_formula=C5H11O8P; inchi=InChI=1S/C5H11O8P/c6-1-3(7)5(9)4(8)2-13-14(10,11)1;
     smiles=O=C[C@H](O)[C@@H](O)[C@H](O)COP(=O)(O)O
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.738784+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 66768-39-6
   data_source: CultureBotHT compounds_to_cas.csv
@@ -57,3 +61,10 @@ chemical_properties:
   inchi: InChI=1S/C5H11O8P/c6-1-3(7)5(9)4(8)2-13-14(10,11)12/h1,3-5,7-9H,2H2,(H2,10,11,12)/t3-,4+,5+/m0/s1
   smiles: O=C[C@H](O)[C@@H](O)[C@H](O)COP(=O)(O)O
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/DL-Glycerol_1-phosphate_Sodium_Salt_Hydrate.yaml
+++ b/data/ingredients/mapped/DL-Glycerol_1-phosphate_Sodium_Salt_Hydrate.yaml
@@ -48,6 +48,10 @@ curation_history:
   action: BACKFILL_PARENT_CHEBI
   changes: set ontology_mapping parent=CHEBI:14336 (stem-substring)
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.738936+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 17603-42-8
   data_source: CultureBotHT compounds_to_cas.csv
@@ -57,3 +61,10 @@ chemical_properties:
   inchi: InChI=1S/C3H9O6P.Na/c4-1-3(5)2-9-10(6,7)8;/h3-5H,1-2H2,(H2,6,7,8);/q;+1/p-1
   pubchem_cid: 23672316
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/DL-Histidine_Monohydrochloride_Monohydrate.yaml
+++ b/data/ingredients/mapped/DL-Histidine_Monohydrochloride_Monohydrate.yaml
@@ -48,6 +48,10 @@ curation_history:
   action: BACKFILL_PARENT_NCIT
   changes: set ontology_mapping parent=NCIT:C87334 (stem-substring)
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.738974+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: AMINO_ACID_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 123333-71-1
   data_source: CultureBotHT compounds_to_cas.csv
@@ -57,3 +61,10 @@ chemical_properties:
   inchi: InChI=1S/C6H9N3O2.ClH.H2O/c7-5(6(10)11)1-4-2-8-3-9-4;;/h2-3,5H,1,7H2,(H,8,9)(H,10,11);1H;1H2
   pubchem_cid: 517335
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: AMINO_ACID_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Deuterated_Glucose.yaml
+++ b/data/ingredients/mapped/Deuterated_Glucose.yaml
@@ -47,6 +47,10 @@ curation_history:
   action: BACKFILL_PARENT_NCIT
   changes: set ontology_mapping parent=NCIT:C200498 (label-exact)
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.739317+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 201417-01-8
   data_source: CultureBotHT compounds_to_cas.csv
@@ -56,3 +60,10 @@ chemical_properties:
   inchi: InChI=1S/C6H12O6/c7-1-3(9)5(11)6(12)4(10)2-8/h1,3-6,8-12H,2H2/t3-,4+,5+,6+/m0/s1/i1+1D,2+1D2,3+1D,4+1D,5+1D,6+1D
   pubchem_cid: 71777455
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Fish_peptone.yaml
+++ b/data/ingredients/mapped/Fish_peptone.yaml
@@ -21,4 +21,15 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Fish')
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.740742+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: PROTEIN_SOURCE (confidence: 0.80)'
 ingredient_type: UNDEFINED_MIXTURE
+media_roles:
+- role: PROTEIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Fructooligosaccharides_Fos.yaml
+++ b/data/ingredients/mapped/Fructooligosaccharides_Fos.yaml
@@ -47,6 +47,10 @@ curation_history:
   action: BACKFILL_PARENT_CHEBI
   changes: set ontology_mapping parent=CHEBI:28645 (pubchem-xref)
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.740889+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 308066-66-2
   data_source: CultureBotHT compounds_to_cas.csv
@@ -56,3 +60,10 @@ chemical_properties:
   inchi: InChI=1S/C6H12O6/c7-1-3-4(9)5(10)6(11,2-8)12-3/h3-5,7-11H,1-2H2/t3-,4-,5+,6-/m1/s1
   pubchem_cid: 439709
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Fructose-6-phosphate.yaml
+++ b/data/ingredients/mapped/Fructose-6-phosphate.yaml
@@ -40,6 +40,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.740913+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 643-13-0
   data_source: CultureBotHT compounds_to_cas.csv
@@ -48,3 +52,10 @@ chemical_properties:
   inchi: InChI=1S/C6H13O9P/c7-1-3(8)5(10)6(11)4(9)2-15-16(12,13)14/h4-7,9-11H,1-2H2,(H2,12,13,14)/t4-,5-,6-/m1/s1
   smiles: O=C(CO)[C@@H](O)[C@H](O)[C@H](O)COP(=O)(O)O
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Fructose-asparagine.yaml
+++ b/data/ingredients/mapped/Fructose-asparagine.yaml
@@ -40,6 +40,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.740934+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 34393-27-6
   data_source: CultureBotHT compounds_to_cas.csv
@@ -49,3 +53,10 @@ chemical_properties:
   inchi: InChI=1S/C10H18N2O8/c11-6(14)1-4(9(17)18)12-3-10(19)8(16)7(15)5(13)2-20-10/h4-5,7-8,12-13,15-16,19H,1-3H2,(H2,11,14)(H,17,18)/t4-,5-,7-,8+,10?/m1/s1
   pubchem_cid: 71316980
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Galactomannan_From_Guar.yaml
+++ b/data/ingredients/mapped/Galactomannan_From_Guar.yaml
@@ -48,6 +48,10 @@ curation_history:
   action: BACKFILL_PARENT_CHEBI
   changes: set ontology_mapping parent=CHEBI:27680 (pubchem-xref)
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.741075+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 11078-30-1
   data_source: CultureBotHT compounds_to_cas.csv
@@ -57,3 +61,10 @@ chemical_properties:
   inchi: InChI=1S/C18H32O16/c19-1-4-7(21)9(23)13(27)17(32-4)30-3-6-15(11(25)12(26)16(29)31-6)34-18-14(28)10(24)8(22)5(2-20)33-18/h4-29H,1-3H2/t4-,5-,6-,7+,8-,9+,10+,11-,12+,13-,14+,15-,16-,17+,18+/m1/s1
   pubchem_cid: 439336
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Galactose_1-phosphate_Dipotassium_Salt_Pentahydrate.yaml
+++ b/data/ingredients/mapped/Galactose_1-phosphate_Dipotassium_Salt_Pentahydrate.yaml
@@ -40,6 +40,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.741130+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 19046-60-7
   data_source: CultureBotHT compounds_to_cas.csv
@@ -49,3 +53,10 @@ chemical_properties:
   inchi: InChI=1S/C6H13O9P.2K/c7-1-2-3(8)4(9)5(10)6(14-2)15-16(11,12)13;;/h2-10H,1H2,(H2,11,12,13);;/q;2*+1/p-2/t2-,3+,4+,5-,6-;;/m1../s1
   pubchem_cid: 87916
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Glucomannan_Konjac.yaml
+++ b/data/ingredients/mapped/Glucomannan_Konjac.yaml
@@ -59,6 +59,10 @@ curation_history:
   previous_status: MAPPED
   new_status: MAPPED
   llm_assisted: true
+- timestamp: '2026-06-03T02:06:01.741284+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 11078-31-2
   data_source: CultureBotHT compounds_to_cas.csv
@@ -68,3 +72,10 @@ chemical_properties:
   inchi: InChI=1S/C24H42O21/c25-1-5-9(29)10(30)15(35)22(40-5)44-19-7(3-27)42-24(17(37)12(19)32)45-20-8(4-28)41-23(16(36)13(20)33)43-18-6(2-26)39-21(38)14(34)11(18)31/h5-38H,1-4H2/t5-,6-,7-,8-,9-,10+,11-,12-,13-,14+,15+,16+,17-,18?,19-,20-,21-,22+,23+,24+/m1/s1
   pubchem_cid: 24892726
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Glycerol_Phosphate_Disodium_Salt_Hydrate.yaml
+++ b/data/ingredients/mapped/Glycerol_Phosphate_Disodium_Salt_Hydrate.yaml
@@ -40,6 +40,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.741473+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 55073-41-1
   data_source: CultureBotHT compounds_to_cas.csv
@@ -49,3 +53,10 @@ chemical_properties:
   inchi: InChI=1S/C3H9O6P.2Na/c4-1-3(5)2-9-10(6,7)8;;/h3-5H,1-2H2,(H2,6,7,8);;/q;2*+1/p-2
   pubchem_cid: 14754
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Glycogen_From_Bovine_Liver.yaml
+++ b/data/ingredients/mapped/Glycogen_From_Bovine_Liver.yaml
@@ -40,6 +40,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.741541+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 9005-79-2
   data_source: CultureBotHT compounds_to_cas.csv
@@ -49,3 +53,10 @@ chemical_properties:
   inchi: InChI=1S/C24H42O21/c25-1-5-9(28)11(30)16(35)22(41-5)39-4-8-20(45-23-17(36)12(31)10(29)6(2-26)42-23)14(33)18(37)24(43-8)44-19-7(3-27)40-21(38)15(34)13(19)32/h5-38H,1-4H2/t5-,6-,7-,8-,9-,10-,11+,12+,13-,14-,15-,16-,17-,18-,19-,20-,21+,22+,23-,24-/m1/s1
   pubchem_cid: 439177
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Ground_Beef.yaml
+++ b/data/ingredients/mapped/Ground_Beef.yaml
@@ -26,6 +26,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'beef')
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.741754+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: PROTEIN_SOURCE (confidence: 0.80)'
 notes: Imported from mim-queue (source_id=mediadive.ingredient:128); no CAS-RN or
   CHEBI/NCIT match. Curator review needed.
 ontology_mapping:
@@ -38,3 +42,10 @@ ontology_mapping:
     source: FOODON via OLS search
     notes: Auto-upgraded from 'UNMAPPED_0396'; match=fuzzy-top
 ingredient_type: UNDEFINED_MIXTURE
+media_roles:
+- role: PROTEIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Inositol.yaml
+++ b/data/ingredients/mapped/Inositol.yaml
@@ -51,6 +51,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.742694+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: VITAMIN_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 87-89-8
   data_source: PubChem API
@@ -60,3 +64,10 @@ chemical_properties:
   smiles: OC1C(O)C(O)C(O)C(O)C1O
 kg_microbe_node_id: CHEBI:24848
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: VITAMIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Kao_And_Michayluk_Vitamin_Solution.yaml
+++ b/data/ingredients/mapped/Kao_And_Michayluk_Vitamin_Solution.yaml
@@ -36,6 +36,10 @@ curation_history:
   previous_status: MAPPED
   new_status: MAPPED
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.742953+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: VITAMIN_SOURCE (confidence: 0.80)'
 notes: Imported from mim-queue (source_id=mediadive.ingredient:1988); no CAS-RN or
   CHEBI/NCIT match. Curator review needed. Kao and Michayluk vitamin solution is a
   named formulation, not identical to the generic vitamin solution class.
@@ -51,3 +55,10 @@ ontology_mapping:
     notes: Kao and Michayluk vitamin solution is a named formulation, not identical
       to the generic vitamin solution class.
 kg_microbe_node_id: kgmicrobe.ingredient:kao_and_michayluk_vitamin_solution
+media_roles:
+- role: VITAMIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/L-Asparagine_Monohydrate.yaml
+++ b/data/ingredients/mapped/L-Asparagine_Monohydrate.yaml
@@ -47,6 +47,10 @@ curation_history:
   action: BACKFILL_PARENT_NCIT
   changes: set ontology_mapping parent=NCIT:C87433 (stem-substring)
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.743006+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: AMINO_ACID_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 5794-13-8
   data_source: CultureBotHT compounds_to_cas.csv
@@ -56,3 +60,10 @@ chemical_properties:
   inchi: InChI=1S/C4H8N2O3.H2O/c5-2(4(8)9)1-3(6)7;/h2H,1,5H2,(H2,6,7)(H,8,9);1H2/t2-;/m0./s1
   pubchem_cid: 170358
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: AMINO_ACID_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/L-Aspartic_Acid_Potassium_Salt.yaml
+++ b/data/ingredients/mapped/L-Aspartic_Acid_Potassium_Salt.yaml
@@ -49,6 +49,10 @@ curation_history:
   action: BACKFILL_PARENT_CHEBI
   changes: set ontology_mapping parent=CHEBI:17053 (stem-substring)
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.743033+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: AMINO_ACID_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 1115-63-5
   data_source: CultureBotHT compounds_to_cas.csv
@@ -58,3 +62,10 @@ chemical_properties:
   inchi: InChI=1S/C4H7NO4.K/c5-2(4(8)9)1-3(6)7;/h2H,1,5H2,(H,6,7)(H,8,9);/q;+1/p-1/t2-;/m0./s1
   pubchem_cid: 23672742
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: AMINO_ACID_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/L-Aspartic_Acid_Sodium_Salt_Monohydrate.yaml
+++ b/data/ingredients/mapped/L-Aspartic_Acid_Sodium_Salt_Monohydrate.yaml
@@ -48,6 +48,10 @@ curation_history:
   action: BACKFILL_PARENT_CHEBI
   changes: set ontology_mapping parent=CHEBI:17053 (stem-substring)
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.743068+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: AMINO_ACID_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 323194-76-9
   data_source: CultureBotHT compounds_to_cas.csv
@@ -57,3 +61,10 @@ chemical_properties:
   inchi: InChI=1S/C4H7NO4.Na.H2O/c5-2(4(8)9)1-3(6)7;;/h2H,1,5H2,(H,6,7)(H,8,9);;1H2/q;+1;/p-1/t2-;;/m0../s1
   pubchem_cid: 23679051
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: AMINO_ACID_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/L-Glutamic_Acid_Monopotassium_Salt_Monohydrate.yaml
+++ b/data/ingredients/mapped/L-Glutamic_Acid_Monopotassium_Salt_Monohydrate.yaml
@@ -54,6 +54,10 @@ curation_history:
   action: BACKFILL_PARENT_CHEBI
   changes: set ontology_mapping parent=CHEBI:16015 (stem-substring)
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.743176+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: AMINO_ACID_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 6382-01-0
   data_source: CultureBotHT compounds_to_cas.csv
@@ -63,3 +67,10 @@ chemical_properties:
   inchi: InChI=1S/C5H9NO4.K.H2O/c6-3(5(9)10)1-2-4(7)8;;/h3H,1-2,6H2,(H,7,8)(H,9,10);;1H2/q;+1;/p-1/t3-;;/m0../s1
   pubchem_cid: 23695977
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: AMINO_ACID_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/L-Histidine_Monohydrochloride_Monohydrate.yaml
+++ b/data/ingredients/mapped/L-Histidine_Monohydrochloride_Monohydrate.yaml
@@ -48,6 +48,10 @@ curation_history:
   action: BACKFILL_PARENT_NCIT
   changes: set ontology_mapping parent=NCIT:C87334 (stem-substring)
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.743227+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: AMINO_ACID_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 5934-29-2
   data_source: CultureBotHT compounds_to_cas.csv
@@ -57,3 +61,10 @@ chemical_properties:
   inchi: InChI=1S/C6H9N3O2.ClH.H2O/c7-5(6(10)11)1-4-2-8-3-9-4;;/h2-3,5H,1,7H2,(H,8,9)(H,10,11);1H;1H2/t5-;;/m0../s1
   pubchem_cid: 165377
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: AMINO_ACID_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/L-Rhamnose_Monohydrate.yaml
+++ b/data/ingredients/mapped/L-Rhamnose_Monohydrate.yaml
@@ -39,6 +39,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.743343+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 10030-85-0
   data_source: CultureBotHT compounds_to_cas.csv
@@ -48,3 +52,10 @@ chemical_properties:
   inchi: InChI=1S/C6H12O5.H2O/c1-3(8)5(10)6(11)4(9)2-7;/h2-6,8-11H,1H3;1H2/t3-,4-,5-,6-;/m0./s1
   pubchem_cid: 20849066
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/L-cysteine_Hcl.yaml
+++ b/data/ingredients/mapped/L-cysteine_Hcl.yaml
@@ -121,6 +121,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.743390+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: AMINO_ACID_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 52-89-1
   data_source: OAK/CHEBI xref
@@ -129,3 +133,10 @@ chemical_properties:
   inchi: InChI=1S/C3H7NO2S.ClH/c4-2(1-7)3(5)6;/h2,7H,1,4H2,(H,5,6);1H/t2-;/m0./s1
   smiles: Cl.N[C@@H](CS)C(=O)O
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: AMINO_ACID_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/L-cysteine_Hcl_X_H2o.yaml
+++ b/data/ingredients/mapped/L-cysteine_Hcl_X_H2o.yaml
@@ -191,6 +191,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.743410+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: AMINO_ACID_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 7048-04-6
   data_source: PubChem (via CHEBI:91248)
@@ -199,3 +203,10 @@ chemical_properties:
   inchi: InChI=1S/C3H7NO2S.ClH.H2O/c4-2(1-7)3(5)6;;/h2,7H,1,4H2,(H,5,6);1H;1H2/t2-;;/m0../s1
   smiles: Cl.N[C@@H](CS)C(=O)O.O
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: AMINO_ACID_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/L-cysteine_Hydrochloride_Monohydrate.yaml
+++ b/data/ingredients/mapped/L-cysteine_Hydrochloride_Monohydrate.yaml
@@ -71,6 +71,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.743541+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: AMINO_ACID_SOURCE (confidence: 0.80)'
 notes: Created from FEBA ontology enrichment workflow. Used in 13 FEBA media formulations.
 chemical_properties:
   cas_rn: 7048-04-6
@@ -80,3 +84,10 @@ chemical_properties:
   inchi: InChI=1S/C3H7NO2S.ClH.H2O/c4-2(1-7)3(5)6;;/h2,7H,1,4H2,(H,5,6);1H;1H2/t2-;;/m0../s1
   smiles: Cl.N[C@@H](CS)C(=O)O.O
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: AMINO_ACID_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/L-cysteine_Zwitterion.yaml
+++ b/data/ingredients/mapped/L-cysteine_Zwitterion.yaml
@@ -42,9 +42,20 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.743430+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: AMINO_ACID_SOURCE (confidence: 0.80)'
 ingredient_type: SINGLE_INGREDIENT
 chemical_properties:
   molecular_formula: C3H7NO2S
   inchi: InChI=1S/C3H7NO2S/c4-2(1-7)3(5)6/h2,7H,1,4H2,(H,5,6)/t2-/m0/s1
   smiles: '[NH3+][C@@H](CS)C(=O)[O-]'
   data_source: CHEBI sqlite (oaklib)
+media_roles:
+- role: AMINO_ACID_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/L-lysine_Hcl.yaml
+++ b/data/ingredients/mapped/L-lysine_Hcl.yaml
@@ -60,6 +60,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.743445+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: AMINO_ACID_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 657-27-2
   data_source: PubChem API
@@ -69,3 +73,10 @@ chemical_properties:
   smiles: Cl.NCCCC[C@H](N)C(=O)O
 kg_microbe_node_id: CHEBI:53633
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: AMINO_ACID_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/L-tyrosine_Disodium_Salt.yaml
+++ b/data/ingredients/mapped/L-tyrosine_Disodium_Salt.yaml
@@ -52,6 +52,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.743564+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: AMINO_ACID_SOURCE (confidence: 0.80)'
 notes: Created from FEBA ontology enrichment workflow. Used in 6 FEBA media formulations.
 chemical_properties:
   cas_rn: 69847-45-6
@@ -61,3 +65,10 @@ chemical_properties:
   inchi: InChI=1S/C9H11NO3.2Na/c10-8(9(12)13)5-6-1-3-7(11)4-2-6;;/h1-4,8,11H,5,10H2,(H,12,13);;/q;2*+1/p-2/t8-;;/m0../s1
   smiles: N[C@@H](Cc1ccc([O-])cc1)C(=O)[O-].[Na+].[Na+]
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: AMINO_ACID_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Lactalbumin_Hydrolysate.yaml
+++ b/data/ingredients/mapped/Lactalbumin_Hydrolysate.yaml
@@ -26,6 +26,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'hydrolysate')
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.743595+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: PROTEIN_SOURCE (confidence: 0.80)'
 notes: Imported from mim-queue (source_id=mediadive.ingredient:2143); no CAS-RN or
   CHEBI/NCIT match. Curator review needed.
 ontology_mapping:
@@ -38,3 +42,10 @@ ontology_mapping:
     source: MICRO via OLS search
     notes: Auto-upgraded from 'UNMAPPED_0420'; match=label-exact
 ingredient_type: UNDEFINED_MIXTURE
+media_roles:
+- role: PROTEIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Lacto-N-fucopentaose_I.yaml
+++ b/data/ingredients/mapped/Lacto-N-fucopentaose_I.yaml
@@ -49,6 +49,10 @@ curation_history:
   action: BACKFILL_PARENT_MESH
   changes: set ontology_mapping parent=mesh:C045442 (label-exact)
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.743631+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 7578-25-8
   data_source: CultureBotHT compounds_to_cas.csv
@@ -58,3 +62,10 @@ chemical_properties:
   inchi: InChI=1S/C32H55NO25/c1-8-16(42)21(47)23(49)30(51-8)58-28-22(48)18(44)12(5-36)54-32(28)56-26-15(33-9(2)39)29(52-13(6-37)19(26)45)57-27-20(46)14(7-38)53-31(24(27)50)55-25(11(41)4-35)17(43)10(40)3-34/h3,8,10-32,35-38,40-50H,4-7H2,1-2H3,(H,33,39)/t8-,10-,11+,12+,13+,14+,15+,16+,17+,18-,19+,20-,21+,22-,23-,24+,25+,26+,27-,28+,29-,30-,31-,32-/m0/s1
   pubchem_cid: 16219579
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Lacto-N-fucopentaose_III.yaml
+++ b/data/ingredients/mapped/Lacto-N-fucopentaose_III.yaml
@@ -49,6 +49,10 @@ curation_history:
   action: BACKFILL_PARENT_MESH
   changes: set ontology_mapping parent=mesh:C434666 (label-exact)
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.743660+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 25541-09-7
   data_source: CultureBotHT compounds_to_cas.csv
@@ -58,3 +62,10 @@ chemical_properties:
   inchi: InChI=1S/C32H55NO25/c1-8-16(42)20(46)22(48)30(51-8)57-27-15(33-9(2)39)29(54-14(7-38)26(27)56-31-23(49)21(47)18(44)12(5-36)52-31)58-28-19(45)13(6-37)53-32(24(28)50)55-25(11(41)4-35)17(43)10(40)3-34/h3,8,10-32,35-38,40-50H,4-7H2,1-2H3,(H,33,39)/t8-,10-,11+,12+,13+,14+,15+,16+,17+,18-,19-,20+,21-,22-,23+,24+,25+,26+,27+,28-,29-,30-,31-,32-/m0/s1
   pubchem_cid: 53477857
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Lacto-N-neotetraose.yaml
+++ b/data/ingredients/mapped/Lacto-N-neotetraose.yaml
@@ -40,6 +40,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.743684+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 13007-32-4
   data_source: CultureBotHT compounds_to_cas.csv
@@ -48,3 +52,10 @@ chemical_properties:
   inchi: InChI=1S/C26H45NO21/c1-6(32)27-11-14(35)20(46-25-18(39)15(36)12(33)7(2-28)43-25)10(5-31)45-24(11)48-22-13(34)8(3-29)44-26(19(22)40)47-21-9(4-30)42-23(41)17(38)16(21)37/h7-26,28-31,33-41H,2-5H2,1H3,(H,27,32)/t7-,8-,9-,10-,11-,12+,13+,14-,15+,16-,17-,18-,19-,20-,21-,22+,23?,24+,25+,26+/m1/s1
   smiles: CC(=O)N[C@H]1[C@H](O[C@H]2[C@@H](O)[C@@H](CO)O[C@@H](O[C@H]3[C@H](O)[C@@H](O)C(O)O[C@@H]3CO)[C@@H]2O)O[C@H](CO)[C@@H](O[C@@H]2O[C@H](CO)[C@H](O)[C@H](O)[C@H]2O)[C@@H]1O
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Lacto-N-tetraose.yaml
+++ b/data/ingredients/mapped/Lacto-N-tetraose.yaml
@@ -48,6 +48,10 @@ curation_history:
   action: BACKFILL_PARENT_CHEBI
   changes: set ontology_mapping parent=CHEBI:30248 (pubchem-xref)
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.743705+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 14116-68-8
   data_source: CultureBotHT compounds_to_cas.csv
@@ -57,3 +61,10 @@ chemical_properties:
   inchi: InChI=1S/C26H45NO21/c1-6(32)27-11-21(47-25-18(39)15(36)12(33)7(2-28)44-25)13(34)8(3-29)43-24(11)48-22-14(35)9(4-30)45-26(19(22)40)46-20-10(5-31)42-23(41)17(38)16(20)37/h7-26,28-31,33-41H,2-5H2,1H3,(H,27,32)/t7-,8-,9-,10-,11-,12+,13-,14+,15+,16-,17-,18-,19-,20-,21-,22+,23?,24+,25+,26+/m1/s1
   pubchem_cid: 440993
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Liver_Digest.yaml
+++ b/data/ingredients/mapped/Liver_Digest.yaml
@@ -22,6 +22,10 @@ curation_history:
   changes: primary UNMAPPED_0430 → MICRO:0001668 via name normalization to 'Liver
     digest'
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.743966+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: PROTEIN_SOURCE (confidence: 0.80)'
 notes: Imported from mim-queue (source_id=mediadive.ingredient:2352); no CAS-RN or
   CHEBI/NCIT match. Curator review needed.
 ontology_mapping:
@@ -34,3 +38,10 @@ ontology_mapping:
     source: MICRO via OLS search (resolve_unmapped)
     notes: Auto-upgraded from UNMAPPED_0430; matched via 'Liver digest' (name normalization);
       label-exact
+media_roles:
+- role: PROTEIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Liver_Extract.yaml
+++ b/data/ingredients/mapped/Liver_Extract.yaml
@@ -27,6 +27,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'extract')
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.743978+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: PROTEIN_SOURCE (confidence: 0.80)'
 notes: 'Imported from CultureBotHT (compounds_to_cas.csv (no CAS-RN)). Used in 3 CultureBot
   media; samples: mGAM, mGAM plus, mGAM_plus. No CAS-RN or CHEBI mapping available;
   curator review needed.'
@@ -40,3 +44,10 @@ ontology_mapping:
     source: MICRO via OLS search
     notes: Auto-upgraded from 'UNMAPPED_0246'; match=label-exact
 ingredient_type: UNDEFINED_MIXTURE
+media_roles:
+- role: PROTEIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Liver_Extract_Concentrate.yaml
+++ b/data/ingredients/mapped/Liver_Extract_Concentrate.yaml
@@ -26,6 +26,10 @@ curation_history:
   action: AUTO_UPGRADE_TO_MICRO
   changes: primary UNMAPPED_0431 → MICRO:0001363 (strategy=stem-match)
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.743996+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: PROTEIN_SOURCE (confidence: 0.80)'
 notes: Imported from mim-queue (source_id=mediadive.ingredient:1599); no CAS-RN or
   CHEBI/NCIT match. Curator review needed.
 ingredient_type: UNDEFINED_MIXTURE
@@ -39,3 +43,10 @@ ontology_mapping:
     source: MICRO via OLS (resolve_unmapped_v2 strategy=stem-match)
     notes: Auto-upgraded from UNMAPPED_0431; matched via 'Liver extract concentrate';
       stem-substring
+media_roles:
+- role: PROTEIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Liver_Extract_Infusion.yaml
+++ b/data/ingredients/mapped/Liver_Extract_Infusion.yaml
@@ -25,6 +25,10 @@ curation_history:
   action: AUTO_UPGRADE_TO_MICRO
   changes: primary UNMAPPED_0105 → MICRO:0001363 (strategy=stem-match)
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.744013+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: PROTEIN_SOURCE (confidence: 0.80)'
 notes: 'CultureMech placeholder_id: 4'
 ingredient_type: UNDEFINED_MIXTURE
 ontology_mapping:
@@ -37,3 +41,10 @@ ontology_mapping:
     source: MICRO via OLS (resolve_unmapped_v2 strategy=stem-match)
     notes: Auto-upgraded from UNMAPPED_0105; matched via 'Liver extract infusion';
       stem-substring
+media_roles:
+- role: PROTEIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/M-inositol.yaml
+++ b/data/ingredients/mapped/M-inositol.yaml
@@ -64,6 +64,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.754037+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: VITAMIN_SOURCE (confidence: 0.80)'
 notes: Created from FEBA ontology enrichment workflow. Used in 21 FEBA media formulations.
 chemical_properties:
   cas_rn: 87-89-8
@@ -73,3 +77,10 @@ chemical_properties:
   inchi: InChI=1S/C6H12O6/c7-1-2(8)4(10)6(12)5(11)3(1)9/h1-12H/t1-,2-,3+,4+,5-,6-
   smiles: O[C@H]1[C@H](O)[C@@H](O)[C@H](O)[C@@H](O)[C@@H]1O
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: VITAMIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/MES_sodium_salt.yaml
+++ b/data/ingredients/mapped/MES_sodium_salt.yaml
@@ -75,6 +75,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.744106+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: BUFFER (confidence: 0.80)'
 notes: Created from FEBA ontology enrichment workflow. Used in 4 FEBA media formulations.
 chemical_properties:
   cas_rn: 71119-23-8
@@ -84,3 +88,10 @@ chemical_properties:
   inchi: InChI=1S/C6H13NO4S.Na/c8-12(9,10)6-3-7-1-4-11-5-2-7;/h1-6H2,(H,8,9,10);/q;+1/p-1
   smiles: O=S(=O)([O-])CCN1CCOCC1.[Na+]
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: BUFFER
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Malt_Extract.yaml
+++ b/data/ingredients/mapped/Malt_Extract.yaml
@@ -67,9 +67,20 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Malt')
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.744207+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 notes: 'CultureMech placeholder_id: 1'
 chemical_properties:
   cas_rn: 8002-48-0
   data_source: CultureBotHT/MicroMediaParam
   retrieval_date: '2026-04-05T17:53:47.284694+00:00'
 ingredient_type: UNDEFINED_MIXTURE
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Maltotriose_Hydrate.yaml
+++ b/data/ingredients/mapped/Maltotriose_Hydrate.yaml
@@ -34,8 +34,19 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: 'set ingredient_type=SINGLE_INGREDIENT (cas: primary (defined chemical))'
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.744316+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 312693-63-3
   data_source: CultureBotHT compounds_to_cas.csv
   retrieval_date: '2026-04-29T06:51:33.117170+00:00'
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Mannan_From_Saccharomyces_Cerevisiae.yaml
+++ b/data/ingredients/mapped/Mannan_From_Saccharomyces_Cerevisiae.yaml
@@ -60,6 +60,10 @@ curation_history:
   previous_status: MAPPED
   new_status: MAPPED
   llm_assisted: true
+- timestamp: '2026-06-03T02:06:01.744385+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 9036-88-8
   data_source: CultureBotHT compounds_to_cas.csv
@@ -69,3 +73,10 @@ chemical_properties:
   inchi: InChI=1S/C24H42O21/c25-1-5-9(29)10(30)15(35)22(40-5)44-19-7(3-27)42-24(17(37)12(19)32)45-20-8(4-28)41-23(16(36)13(20)33)43-18-6(2-26)39-21(38)14(34)11(18)31/h5-38H,1-4H2
   pubchem_cid: 870
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Mannose-6-Phosphate.yaml
+++ b/data/ingredients/mapped/Mannose-6-Phosphate.yaml
@@ -39,9 +39,20 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.744408+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 3672-15-9
   data_source: CultureBotHT compounds_to_cas.csv
   retrieval_date: '2026-04-29T06:34:31.158938+00:00'
   molecular_formula: C6H13O9P
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Meat_Extract.yaml
+++ b/data/ingredients/mapped/Meat_Extract.yaml
@@ -33,4 +33,15 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Meat')
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.744435+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: PROTEIN_SOURCE (confidence: 0.80)'
 ingredient_type: UNDEFINED_MIXTURE
+media_roles:
+- role: PROTEIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Meat_peptone.yaml
+++ b/data/ingredients/mapped/Meat_peptone.yaml
@@ -21,4 +21,15 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Meat')
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.744446+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: PROTEIN_SOURCE (confidence: 0.80)'
 ingredient_type: UNDEFINED_MIXTURE
+media_roles:
+- role: PROTEIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Menadione_Sodium_Bisulfate.yaml
+++ b/data/ingredients/mapped/Menadione_Sodium_Bisulfate.yaml
@@ -40,6 +40,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.744482+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: VITAMIN_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 130-37-0
   data_source: CultureBotHT compounds_to_cas.csv
@@ -48,3 +52,10 @@ chemical_properties:
   inchi: InChI=1S/C11H10O5S.Na/c1-11(17(14,15)16)6-9(12)7-4-2-3-5-8(7)10(11)13;/h2-5H,6H2,1H3,(H,14,15,16);/q;+1/p-1
   smiles: CC1(S(=O)(=O)[O-])CC(=O)c2ccccc2C1=O.[Na+]
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: VITAMIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Myo-inositol.yaml
+++ b/data/ingredients/mapped/Myo-inositol.yaml
@@ -126,6 +126,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.745284+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: VITAMIN_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 87-89-8
   data_source: PubChem API
@@ -135,3 +139,10 @@ chemical_properties:
   smiles: O[C@H]1[C@H](O)[C@@H](O)[C@H](O)[C@@H](O)[C@H]1O
 kg_microbe_node_id: CHEBI:17268
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: VITAMIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Oat_Flour_B-glucan.yaml
+++ b/data/ingredients/mapped/Oat_Flour_B-glucan.yaml
@@ -21,6 +21,10 @@ curation_history:
   action: AUTO_UPGRADE_TO_FOODON
   changes: primary UNMAPPED_0241 → FOODON:03301312 (strategy=stem-match)
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.746657+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 notes: Imported from CultureBotHT (compounds_to_cas.csv (no CAS-RN)). No CAS-RN or
   CHEBI mapping available; curator review needed.
 ontology_mapping:
@@ -32,3 +36,10 @@ ontology_mapping:
   - evidence_type: DATABASE_MATCH
     source: FOODON via OLS (resolve_unmapped_v2 strategy=stem-match)
     notes: Auto-upgraded from UNMAPPED_0241; matched via 'Oat flour B-glucan'; stem-substring
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/P-lacto-N-neo-hexaose.yaml
+++ b/data/ingredients/mapped/P-lacto-N-neo-hexaose.yaml
@@ -40,6 +40,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.746837+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 64309-00-8
   data_source: CultureBotHT compounds_to_cas.csv
@@ -49,3 +53,10 @@ chemical_properties:
   inchi: InChI=1S/C40H68N2O31/c1-9(49)41-17-22(54)30(69-38-27(59)24(56)19(51)11(3-43)64-38)15(7-47)67-36(17)72-33-20(52)12(4-44)65-39(28(33)60)70-31-16(8-48)68-37(18(23(31)55)42-10(2)50)73-34-21(53)13(5-45)66-40(29(34)61)71-32-14(6-46)63-35(62)26(58)25(32)57/h11-40,43-48,51-62H,3-8H2,1-2H3,(H,41,49)(H,42,50)
   pubchem_cid: 72765192
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/PIPES_Sesquisodium_Salt.yaml
+++ b/data/ingredients/mapped/PIPES_Sesquisodium_Salt.yaml
@@ -41,6 +41,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.746851+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: BUFFER (confidence: 0.80)'
 chemical_properties:
   cas_rn: 100037-69-2
   data_source: CultureBotHT compounds_to_cas.csv
@@ -50,3 +54,10 @@ chemical_properties:
   inchi: InChI=1S/2C8H18N2O6S2.3Na/c2*11-17(12,13)7-5-9-1-2-10(4-3-9)6-8-18(14,15)16;;;/h2*1-8H2,(H,11,12,13)(H,14,15,16);;;/q;;3*+1/p-3
   pubchem_cid: 3086462
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: BUFFER
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Palatinose_Hydrate.yaml
+++ b/data/ingredients/mapped/Palatinose_Hydrate.yaml
@@ -40,6 +40,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.746892+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 343336-76-5
   data_source: CultureBotHT compounds_to_cas.csv
@@ -49,3 +53,10 @@ chemical_properties:
   inchi: InChI=1S/C12H22O11.H2O/c13-1-4-6(15)8(17)9(18)11(22-4)21-2-5-7(16)10(19)12(20,3-14)23-5;/h4-11,13-20H,1-3H2;1H2/t4-,5-,6-,7-,8+,9-,10+,11+,12?;/m1./s1
   pubchem_cid: 52994241
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Peptone.yaml
+++ b/data/ingredients/mapped/Peptone.yaml
@@ -21,4 +21,15 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Peptone')
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.747135+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: PROTEIN_SOURCE (confidence: 0.80)'
 ingredient_type: UNDEFINED_MIXTURE
+media_roles:
+- role: PROTEIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Phosphate_Buffer.yaml
+++ b/data/ingredients/mapped/Phosphate_Buffer.yaml
@@ -33,4 +33,15 @@ curation_history:
   changes: set ingredient_type=STOCK_SOLUTION (name matches solution pattern 'Phosphate
     buffer')
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.747415+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: BUFFER (confidence: 0.80)'
 ingredient_type: STOCK_SOLUTION
+media_roles:
+- role: BUFFER
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Phosphate_Buffer_Stock_Solution.yaml
+++ b/data/ingredients/mapped/Phosphate_Buffer_Stock_Solution.yaml
@@ -35,6 +35,10 @@ curation_history:
   previous_status: MAPPED
   new_status: MAPPED
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.747433+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: BUFFER (confidence: 0.80)'
 notes: 'CultureMech placeholder_id: 2 Phosphate buffer stock solution is a preparation
   variant, not identical to the generic phosphate buffer class.'
 ingredient_type: STOCK_SOLUTION
@@ -49,3 +53,10 @@ ontology_mapping:
     notes: Phosphate buffer stock solution is a preparation variant, not identical
       to the generic phosphate buffer class.
 kg_microbe_node_id: kgmicrobe.ingredient:phosphate_buffer_stock_solution
+media_roles:
+- role: BUFFER
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Polypeptone.yaml
+++ b/data/ingredients/mapped/Polypeptone.yaml
@@ -59,4 +59,15 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (FOODON primary (food/biological))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.747805+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: PROTEIN_SOURCE (confidence: 0.80)'
 ingredient_type: UNDEFINED_MIXTURE
+media_roles:
+- role: PROTEIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Potassium_Phosphate_Buffer.yaml
+++ b/data/ingredients/mapped/Potassium_Phosphate_Buffer.yaml
@@ -37,6 +37,10 @@ curation_history:
   previous_status: MAPPED
   new_status: MAPPED
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.748066+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: BUFFER (confidence: 0.80)'
 notes: 'Imported from CultureBotHT (consolidated_media.json (media-only)). Used in
   2 CultureBot media; samples: Mega, TYG. No CAS-RN or CHEBI mapping available; curator
   review needed. Potassium phosphate buffer is a formulation variant, not identical
@@ -53,3 +57,10 @@ ontology_mapping:
     notes: Potassium phosphate buffer is a formulation variant, not identical to the
       generic phosphate buffer class.
 kg_microbe_node_id: kgmicrobe.ingredient:potassium_phosphate_buffer
+media_roles:
+- role: BUFFER
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Proteose_Peptone.yaml
+++ b/data/ingredients/mapped/Proteose_Peptone.yaml
@@ -121,6 +121,10 @@ curation_history:
   previous_status: MAPPED
   new_status: MAPPED
   llm_assisted: true
+- timestamp: '2026-06-03T02:06:01.748330+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: PROTEIN_SOURCE (confidence: 0.80)'
 notes: 'CultureMech placeholder_id: 3; absorbed Peptic digest of animal tissue source
   surface on 2026-05-11.'
 chemical_properties:
@@ -128,3 +132,10 @@ chemical_properties:
   data_source: CultureBotHT compounds_to_cas.csv
   retrieval_date: '2026-04-05T21:48:46.047943+00:00'
 ingredient_type: UNDEFINED_MIXTURE
+media_roles:
+- role: PROTEIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Proteose_Peptone_No_2.yaml
+++ b/data/ingredients/mapped/Proteose_Peptone_No_2.yaml
@@ -21,4 +21,15 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'peptone')
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.748347+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: PROTEIN_SOURCE (confidence: 0.80)'
 ingredient_type: UNDEFINED_MIXTURE
+media_roles:
+- role: PROTEIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Pustulan_B-1-6_Glucan.yaml
+++ b/data/ingredients/mapped/Pustulan_B-1-6_Glucan.yaml
@@ -48,6 +48,10 @@ curation_history:
   action: BACKFILL_PARENT_MESH
   changes: set ontology_mapping parent=mesh:C002076 (label-exact)
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.748478+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 37331-28-5
   data_source: CultureBotHT compounds_to_cas.csv
@@ -57,3 +61,10 @@ chemical_properties:
   inchi: InChI=1S/C20H34O17/c1-5(22)34-17-14(28)11(25)8(4-32-19-16(30)13(27)9(23)6(2-21)36-19)37-20(17)33-3-7-10(24)12(26)15(29)18(31)35-7/h6-21,23-31H,2-4H2,1H3
   pubchem_cid: 163304499
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Sialyllacto-N-tetraose_D.yaml
+++ b/data/ingredients/mapped/Sialyllacto-N-tetraose_D.yaml
@@ -40,6 +40,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.749446+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 100789-83-1
   data_source: CultureBotHT compounds_to_cas.csv
@@ -49,3 +53,10 @@ chemical_properties:
   inchi: InChI=1S/C37H62N2O29/c1-10(46)38-19-12(48)3-37(36(59)60,67-30(19)22(53)14(50)5-41)68-32-24(55)17(8-44)62-35(27(32)58)65-29-18(9-45)63-33(20(25(29)56)39-11(2)47)66-31-23(54)16(7-43)61-34(26(31)57)64-28(15(51)6-42)21(52)13(49)4-40/h4,12-35,41-45,48-58H,3,5-9H2,1-2H3,(H,38,46)(H,39,47)(H,59,60)/t12-,13-,14+,15+,16+,17+,18+,19+,20+,21+,22+,23-,24-,25+,26+,27+,28+,29+,30+,31-,32-,33-,34-,35-,37-/m0/s1
   pubchem_cid: 9963175
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Sn-Glycerol_3-phosphate_Lithium_Salt.yaml
+++ b/data/ingredients/mapped/Sn-Glycerol_3-phosphate_Lithium_Salt.yaml
@@ -47,6 +47,10 @@ curation_history:
   action: BACKFILL_PARENT_CHEBI
   changes: set ontology_mapping parent=CHEBI:15978 (pubchem-xref)
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.749818+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 17989-41-2
   data_source: CultureBotHT compounds_to_cas.csv
@@ -56,3 +60,10 @@ chemical_properties:
   inchi: InChI=1S/C3H9O6P/c4-1-3(5)2-9-10(6,7)8/h3-5H,1-2H2,(H2,6,7,8)/t3-/m1/s1
   pubchem_cid: 439162
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Sn-glycerol_3-phosphate_Bis_Cyclohexylammonium_Salt.yaml
+++ b/data/ingredients/mapped/Sn-glycerol_3-phosphate_Bis_Cyclohexylammonium_Salt.yaml
@@ -49,6 +49,10 @@ curation_history:
   action: BACKFILL_PARENT_CHEBI
   changes: set ontology_mapping parent=CHEBI:15978 (stem-substring)
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.749770+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 29849-82-9
   data_source: CultureBotHT compounds_to_cas.csv
@@ -58,3 +62,10 @@ chemical_properties:
   inchi: InChI=1S/2C6H13N.C3H9O6P/c2*7-6-4-2-1-3-5-6;4-1-3(5)2-9-10(6,7)8/h2*6H,1-5,7H2;3-5H,1-2H2,(H2,6,7,8)/t;;3-/m..1/s1
   pubchem_cid: 16219444
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Sodium_Phosphate_Buffer.yaml
+++ b/data/ingredients/mapped/Sodium_Phosphate_Buffer.yaml
@@ -36,6 +36,10 @@ curation_history:
   previous_status: MAPPED
   new_status: MAPPED
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.750955+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: BUFFER (confidence: 0.80)'
 notes: Imported from mim-queue (source_id=mediadive.ingredient:1753); no CAS-RN or
   CHEBI/NCIT match. Curator review needed. Sodium phosphate buffer is a formulation
   variant, not identical to the generic phosphate buffer class.
@@ -51,3 +55,10 @@ ontology_mapping:
     notes: Sodium phosphate buffer is a formulation variant, not identical to the
       generic phosphate buffer class.
 kg_microbe_node_id: kgmicrobe.ingredient:sodium_phosphate_buffer
+media_roles:
+- role: BUFFER
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Sodium_Potassium_Phosphate_Buffer.yaml
+++ b/data/ingredients/mapped/Sodium_Potassium_Phosphate_Buffer.yaml
@@ -36,6 +36,10 @@ curation_history:
   previous_status: MAPPED
   new_status: MAPPED
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.751074+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: BUFFER (confidence: 0.80)'
 notes: Imported from mim-queue (source_id=mediadive.ingredient:631); no CAS-RN or
   CHEBI/NCIT match. Curator review needed. Sodium potassium phosphate buffer is a
   formulation variant, not identical to the generic phosphate buffer class.
@@ -51,3 +55,10 @@ ontology_mapping:
     notes: Sodium potassium phosphate buffer is a formulation variant, not identical
       to the generic phosphate buffer class.
 kg_microbe_node_id: kgmicrobe.ingredient:sodium_potassium_phosphate_buffer
+media_roles:
+- role: BUFFER
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Soy_Peptone.yaml
+++ b/data/ingredients/mapped/Soy_Peptone.yaml
@@ -66,6 +66,17 @@ curation_history:
   action: MERGED_FROM_DUPLICATES
   changes: Absorbed CHEBI:8150 (Bacto Soytone) — obsolete CHEBI term, Difco soy-peptone
     product. Synonyms unioned, occurrences summed (+47/+47).
+- timestamp: '2026-06-03T02:06:01.751447+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: PROTEIN_SOURCE (confidence: 0.80)'
 ingredient_type: UNDEFINED_MIXTURE
 merged:
 - CHEBI:8150
+media_roles:
+- role: PROTEIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Soya_Peptone.yaml
+++ b/data/ingredients/mapped/Soya_Peptone.yaml
@@ -41,6 +41,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.751461+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: PROTEIN_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 91079-46-8
   data_source: CultureBotHT compounds_to_cas.csv
@@ -50,3 +54,10 @@ chemical_properties:
   inchi: InChI=1S/C44H48O16.C40H40O16.C36H36O16.4C34H24N2O2.C34H32O16/c1-25-15-17-27(3)43(23-25)57-37(49)31(38(50)58-43)13-9-5-7-11-29-33(45)53-41(54-34(29)46)19-21-42(22-20-41)55-35(47)30(36(48)56-42)12-8-6-10-14-32-39(51)59-44(60-40(32)52)24-26(2)16-18-28(44)4;41-29-25(30(42)50-37(49-29)17-9-3-10-18-37)13-5-1-7-15-27-33(45)53-39(54-34(27)46)21-23-40(24-22-39)55-35(47)28(36(48)56-40)16-8-2-6-14-26-31(43)51-38(52-32(26)44)19-11-4-12-20-38;1-5-33(3)45-25(37)21(26(38)46-33)13-9-7-11-15-23-29(41)49-35(50-30(23)42)17-19-36(20-18-35)51-31(43)24(32(44)52-36)16-12-8-10-14-22-27(39)47-34(4,6-2)48-28(22)40;4*37-33-13-11-29(23-31(33)27-7-3-1-4-8-27)35-19-15-25(16-20-35)26-17-21-36(22-18-26)30-12-14-34(38)32(24-30)28-9-5-2-6-10-28;1-31(2)43-23(35)19(24(36)44-31)11-7-5-9-13-21-27(39)47-33(48-28(21)40)15-17-34(18-16-33)49-29(41)22(30(42)50-34)14-10-6-8-12-20-25(37)45-32(3,4)46-26(20)38/h5-14,25-28,49,51H,15-24H2,1-4H3;1-2,5-8,13-16,45,47H,3-4,9-12,17-24H2;7-16,37,39H,5-6,17-20H2,1-4H3;4*1-24H;5-14,39,41H,15-18H2,1-4H3
   pubchem_cid: 167312541
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: PROTEIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Stachyose_Hydrate.yaml
+++ b/data/ingredients/mapped/Stachyose_Hydrate.yaml
@@ -40,6 +40,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.751544+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 54261-98-2
   data_source: CultureBotHT compounds_to_cas.csv
@@ -49,3 +53,10 @@ chemical_properties:
   inchi: InChI=1S/C24H42O21/c25-1-6-10(28)14(32)17(35)21(41-6)39-3-8-11(29)15(33)18(36)22(42-8)40-4-9-12(30)16(34)19(37)23(43-9)45-24(5-27)20(38)13(31)7(2-26)44-24/h6-23,25-38H,1-5H2
   pubchem_cid: 4287569
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Sucrose-6-monophosphate_Dipotassium_Salt.yaml
+++ b/data/ingredients/mapped/Sucrose-6-monophosphate_Dipotassium_Salt.yaml
@@ -40,6 +40,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.751743+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 36064-19-4
   data_source: CultureBotHT compounds_to_cas.csv
@@ -49,3 +53,10 @@ chemical_properties:
   inchi: InChI=1S/C12H23O14P.K/c13-1-4-6(15)8(17)9(18)11(24-4)26-12(3-14)10(19)7(16)5(25-12)2-23-27(20,21)22;/h4-11,13-19H,1-3H2,(H2,20,21,22);
   pubchem_cid: 16219958
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/TAPS_Sodium_Salt.yaml
+++ b/data/ingredients/mapped/TAPS_Sodium_Salt.yaml
@@ -52,6 +52,10 @@ curation_history:
   action: BACKFILL_PARENT_CHEBI
   changes: set ontology_mapping parent=CHEBI:26714 (stem-substring)
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.752095+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: BUFFER (confidence: 0.80)'
 chemical_properties:
   cas_rn: 91000-53-2
   data_source: CultureBotHT compounds_to_cas.csv
@@ -61,3 +65,10 @@ chemical_properties:
   inchi: InChI=1S/C7H17NO6S.Na/c9-4-7(5-10,6-11)8-2-1-3-15(12,13)14;/h8-11H,1-6H2,(H,12,13,14);/q;+1/p-1
   pubchem_cid: 23667519
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: BUFFER
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Tes.yaml
+++ b/data/ingredients/mapped/Tes.yaml
@@ -55,9 +55,20 @@ curation_history:
   previous_status: MAPPED
   new_status: MAPPED
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.752199+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: BUFFER (confidence: 0.80)'
 chemical_properties:
   cas_rn: 7365-44-8
   data_source: PubChem API
   retrieval_date: '2026-04-05T19:54:00.840275+00:00'
 kg_microbe_node_id: CHEBI:39035
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: BUFFER
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Thiamine_Vitamin_Solution.yaml
+++ b/data/ingredients/mapped/Thiamine_Vitamin_Solution.yaml
@@ -35,6 +35,10 @@ curation_history:
   previous_status: MAPPED
   new_status: MAPPED
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.752455+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: VITAMIN_SOURCE (confidence: 0.80)'
 notes: 'CultureMech placeholder_id: 7 Thiamine vitamin solution is a formulation variant,
   not identical to the generic vitamin solution class.'
 ingredient_type: STOCK_SOLUTION
@@ -49,3 +53,10 @@ ontology_mapping:
     notes: Thiamine vitamin solution is a formulation variant, not identical to the
       generic vitamin solution class.
 kg_microbe_node_id: kgmicrobe.ingredient:thiamine_vitamin_solution
+media_roles:
+- role: VITAMIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Thioctic_Acid.yaml
+++ b/data/ingredients/mapped/Thioctic_Acid.yaml
@@ -103,6 +103,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.752469+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: VITAMIN_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 1077-28-7
   data_source: PubChem API
@@ -112,3 +116,10 @@ chemical_properties:
   smiles: O=C(O)CCCC[C@@H]1CCSS1
 kg_microbe_node_id: CHEBI:30314
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: VITAMIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Tricine.yaml
+++ b/data/ingredients/mapped/Tricine.yaml
@@ -35,8 +35,19 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (CHEBI primary)
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.752992+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: BUFFER (confidence: 0.80)'
 chemical_properties:
   cas_rn: 5704-04-1
   data_source: CultureBotHT compounds_to_cas.csv
   retrieval_date: '2026-04-29T06:04:17.380972+00:00'
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: BUFFER
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Tris_Acetate_Stock_Solution.yaml
+++ b/data/ingredients/mapped/Tris_Acetate_Stock_Solution.yaml
@@ -32,6 +32,10 @@ curation_history:
   changes: molecular_formula=C2H4O2.C4H11NO3; inchi=InChI=1S/C4H11NO3.C2H4O2/c5-4(1-6,2-7)3-8;1-2(3)4/;
     smiles=CC(=O)O.NC(CO)(CO)CO
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.753104+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: BUFFER (confidence: 0.80)'
 notes: 'CultureMech placeholder_id: 4'
 ingredient_type: STOCK_SOLUTION
 ontology_mapping:
@@ -49,3 +53,10 @@ chemical_properties:
   inchi: InChI=1S/C4H11NO3.C2H4O2/c5-4(1-6,2-7)3-8;1-2(3)4/h6-8H,1-3,5H2;1H3,(H,3,4)
   smiles: CC(=O)O.NC(CO)(CO)CO
   data_source: CHEBI sqlite (oaklib)
+media_roles:
+- role: BUFFER
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Trypticase.yaml
+++ b/data/ingredients/mapped/Trypticase.yaml
@@ -47,4 +47,15 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (FOODON primary (food/biological))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.753173+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: PROTEIN_SOURCE (confidence: 0.80)'
 ingredient_type: UNDEFINED_MIXTURE
+media_roles:
+- role: PROTEIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Trypticase_Peptone.yaml
+++ b/data/ingredients/mapped/Trypticase_Peptone.yaml
@@ -69,4 +69,15 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'peptone')
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.753188+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: PROTEIN_SOURCE (confidence: 0.80)'
 ingredient_type: UNDEFINED_MIXTURE
+media_roles:
+- role: PROTEIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Tryptone.yaml
+++ b/data/ingredients/mapped/Tryptone.yaml
@@ -122,9 +122,20 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Tryptone')
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.753196+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: PROTEIN_SOURCE (confidence: 0.80)'
 notes: 'CultureMech placeholder_id: 2'
 chemical_properties:
   cas_rn: 84843-69-6
   data_source: CultureBotHT/MicroMediaParam
   retrieval_date: '2026-04-05T17:53:47.219456+00:00'
 ingredient_type: UNDEFINED_MIXTURE
+media_roles:
+- role: PROTEIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Tryptose.yaml
+++ b/data/ingredients/mapped/Tryptose.yaml
@@ -21,6 +21,10 @@ curation_history:
   action: AUTO_UPGRADE_TO_MICRO
   changes: primary UNMAPPED_0559 → MICRO:0000183 via name normalization to 'Tryptose'
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.753204+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: PROTEIN_SOURCE (confidence: 0.80)'
 notes: Imported from mim-queue (source_id=mediadive.ingredient:819); no CAS-RN or
   CHEBI/NCIT match. Curator review needed.
 ontology_mapping:
@@ -33,3 +37,10 @@ ontology_mapping:
     source: MICRO via OLS search (resolve_unmapped)
     notes: Auto-upgraded from UNMAPPED_0559; matched via 'Tryptose' (name normalization);
       label-exact
+media_roles:
+- role: PROTEIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Vitamin_Solution.yaml
+++ b/data/ingredients/mapped/Vitamin_Solution.yaml
@@ -28,6 +28,10 @@ curation_history:
   changes: set ingredient_type=STOCK_SOLUTION (name matches solution pattern 'Vitamin
     solution')
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.753637+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: VITAMIN_SOURCE (confidence: 0.80)'
 notes: Imported from mim-queue (source_id=mediadive.ingredient:154); no CAS-RN or
   CHEBI/NCIT match. Curator review needed.
 ontology_mapping:
@@ -41,3 +45,10 @@ ontology_mapping:
     notes: Auto-upgraded from UNMAPPED_0568; matched via 'Vitamin solution' (name
       normalization); label-exact
 ingredient_type: STOCK_SOLUTION
+media_roles:
+- role: VITAMIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Vitamin_Solution_See_Medium_No_403.yaml
+++ b/data/ingredients/mapped/Vitamin_Solution_See_Medium_No_403.yaml
@@ -41,6 +41,10 @@ curation_history:
   previous_status: MAPPED
   new_status: MAPPED
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.753706+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: VITAMIN_SOURCE (confidence: 0.80)'
 notes: Imported from mim-queue (source_id=mediadive.ingredient:1855); no CAS-RN or
   CHEBI/NCIT match. Curator review needed. Medium-specific vitamin solution is a formulation
   pointer, not identical to the generic vitamin solution class.
@@ -56,3 +60,10 @@ ontology_mapping:
     notes: Medium-specific vitamin solution is a formulation pointer, not identical
       to the generic vitamin solution class.
 kg_microbe_node_id: kgmicrobe.ingredient:vitamin_solution_see_medium_no_403
+media_roles:
+- role: VITAMIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Vitamin_Solution_Thermophilic_Formulation.yaml
+++ b/data/ingredients/mapped/Vitamin_Solution_Thermophilic_Formulation.yaml
@@ -36,6 +36,10 @@ curation_history:
   previous_status: MAPPED
   new_status: MAPPED
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.753675+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: VITAMIN_SOURCE (confidence: 0.80)'
 notes: Imported from communitymech-unmapped (source_id=communitymech.ingredient:Vitamin_solution_(thermophilic_formulation));
   no CAS-RN or CHEBI/NCIT match. Curator review needed. Thermophilic vitamin solution
   is a named formulation, not identical to the generic vitamin solution class.
@@ -51,3 +55,10 @@ ontology_mapping:
     notes: Thermophilic vitamin solution is a named formulation, not identical to
       the generic vitamin solution class.
 kg_microbe_node_id: kgmicrobe.ingredient:vitamin_solution_~28thermophilic_formulation~29
+media_roles:
+- role: VITAMIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Xyloglucan_From_Tamarind.yaml
+++ b/data/ingredients/mapped/Xyloglucan_From_Tamarind.yaml
@@ -34,8 +34,19 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: 'set ingredient_type=SINGLE_INGREDIENT (cas: primary (defined chemical))'
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.753883+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 37294-28-3
   data_source: CultureBotHT compounds_to_cas.csv
   retrieval_date: '2026-04-29T06:51:33.117170+00:00'
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Yeast_Extract.yaml
+++ b/data/ingredients/mapped/Yeast_Extract.yaml
@@ -147,9 +147,20 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Yeast')
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.753916+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: PROTEIN_SOURCE (confidence: 0.80)'
 notes: 'CultureMech placeholder_id: 3'
 chemical_properties:
   cas_rn: 8013-01-2
   data_source: CultureBotHT/MicroMediaParam
   retrieval_date: '2026-04-05T17:53:47.291843+00:00'
 ingredient_type: UNDEFINED_MIXTURE
+media_roles:
+- role: PROTEIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Α-lipoic_Acid.yaml
+++ b/data/ingredients/mapped/Α-lipoic_Acid.yaml
@@ -89,6 +89,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T02:06:01.754161+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: VITAMIN_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 1077-27-6
   data_source: PubChem API (ontology label)
@@ -97,3 +101,10 @@ chemical_properties:
   inchi: InChI=1S/C8H14O2S2/c9-8(10)4-2-1-3-7-5-6-11-12-7/h7H,1-6H2,(H,9,10)/t7-/m0/s1
   smiles: O=C(O)CCCC[C@H]1CCSS1
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: VITAMIN_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/notes/duplicate_identifiers_analysis_2026-05-29.md
+++ b/notes/duplicate_identifiers_analysis_2026-05-29.md
@@ -1,5 +1,23 @@
 # Duplicate `identifier` analysis — 2026-05-29
 
+## Resolution status (updated 2026-06-02)
+- **Stereoisomer mis-maps — RESOLVED (PR #37)** via `scripts/fix_stereoisomer_remaps.py`:
+  `(R)-3-hydroxybutyrate`→CHEBI:10983, `(S)-3-hydroxybutyrate`→CHEBI:11047 (off achiral
+  CHEBI:37054), `L-Carnitine`→CHEBI:16347 (off racemate CHEBI:17126).
+- **Remaining category-3 candidates — reviewed, left as-is (no clean fix):**
+  - *Shared-CAS source variants* — `cas:84082-64-4` (porcine mucin Type II vs III) is the
+    **same chemical substance** at different purity grades → sharing the CAS is correct.
+    `cas:9036-88-8` (carob vs yeast mannan) and `cas:39280-21-2` (soy vs potato
+    rhamnogalacturonan) are genuinely different source materials, but assigning distinct
+    registry IDs needs per-source CAS research (these natural-polymer CAS numbers are
+    themselves ambiguous) — deferred to manual curation.
+  - *Coarse FOODON/MICRO solution terms* — `FOODON:03315719` (Casein peptone / Trypticase
+    / Tryptone), `NCIT:C896` (3 trace-element solutions), `MICRO:0000455`/`MICRO:0001363`
+    (trace-element / liver-extract recipes), `ENVO:00001998` (CR1 Soil vs Soil): these are
+    distinct products/recipes sharing a deliberately-coarse parent term. No distinct
+    ontology term exists for most (e.g. "Zeikus trace element solution"), so the coarse
+    mapping is the best available — they remain documented variant collisions, not errors.
+
 ## TL;DR
 `data/curated/mapped_ingredients.yaml` contains **60 ontology identifiers shared by 2+
 records (143 records total)**. These are **not data corruption** — they are surface-form

--- a/scripts/infer_roles_from_name_lists.py
+++ b/scripts/infer_roles_from_name_lists.py
@@ -43,7 +43,8 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from mediaingredientmech.curation.ingredient_curator import IngredientCurator
 
-# Ordered (role, compiled pattern). First match wins.
+# Ordered (role, include pattern, exclude pattern). First include-match whose
+# exclude pattern does NOT also match wins. Order encodes precedence.
 _ANTIBIOTIC = (
     r"(cillin\b|mycin\b|micin\b|cycline\b|floxacin\b|oxacin\b|^cef|^ceph|penem\b|"
     r"bactam\b|chloramphenicol|rifam|vancomycin|teicoplanin|bacitracin|polymyxin|"
@@ -51,40 +52,102 @@ _ANTIBIOTIC = (
     r"metronidazole|\bnisin\b|novobiocin|fusidic|puromycin|geneticin|hygromycin|"
     r"blasticidin|carbenicillin|cycloheximide|fosfomycin|aztreonam|linezolid|"
     r"daptomycin|tylosin|thiostrepton|actinomycin|antimycin|bleomycin|apramycin|"
-    r"spectinomycin|tetracycline|erythromycin|clindamycin|nourseothricin)"
+    r"spectinomycin|tetracycline|erythromycin|clindamycin|nourseothricin|"
+    r"carbamyl.{0,2}serine)"
 )
 _CHELATOR = (
     r"(\bEDTA\b|ethylenediaminetetraacetic|nitrilotriacetic acid|\bNTA\b|"
     r"\bEGTA\b|\bDTPA\b|desferrioxamine|deferoxamine)"
 )
-# Exclude metal-chelate complexes from CHELATOR (iron/trace sources, not chelators).
+# Metal-chelate complexes are iron/trace sources, not chelators.
 _CHELATE_COMPLEX = r"(Fe|ferric|ferrous|Mg-|Ca-|Zn-|Cu-|Co-|Ni-|sodium ferric)"
 _REDUCING = (
     r"(dithionite|dithiothreitol|\bDTT\b|2-mercaptoethanol|thioglycol|"
     r"\bTCEP\b|sodium sulfide|hydrogen sulfide|ammonium sulfide|\bNa2S\b|"
     r"sodium sulfite|titanium.{0,4}citrate)"
 )
+# Good's buffers + named buffer solutions / Tris.
+_BUFFER = (
+    r"(\bHEPES\b|\bMOPS\b|\bMOPSO\b|\bMES\b|\bPIPES\b|\bTRICINE\b|\bBICINE\b|"
+    r"\bTAPS\b|\bTAPSO\b|\bCAPS\b|\bTES\b|\bEPPS\b|\bHEPPS\b|Bis-Tris|\bTris\b|"
+    r"\bACES\b|buffer\b)"
+)
+# Gelling agents. Restricted to pure agar forms (whole name) + named gels, so
+# agar-containing complete media ("Brucella agar", "Malt Extract Agar") are NOT
+# caught — those are defined media, not a single gelling-agent ingredient.
+_SOLIDIFYING = (
+    r"(agarose|gellan|gelrite|gelzan|phytagel|"
+    r"^(bacto[ -]|noble[ -]|granulated[ -]|purified[ -])?agar([ -]agar)?$)"
+)
+# Protein/nitrogen-rich complex sources. Bare "extract" is avoided (malt extract
+# is a carbon source); only protein-bearing extracts are listed explicitly.
+# "liver" is start-anchored so "Glycogen from bovine liver" (a carbon source) is
+# not caught; complete media (broth/agar) are excluded as defined media.
+_PROTEIN = (
+    r"(peptone|tryptone|tryptose|trypticase|casitone|casamino|casein|"
+    r"hydrolysate|\bdigest\b|yeast extract|beef extract|meat extract|"
+    r"brain heart infusion|\bBHI\b|^liver|gelatin|proteose|lysate|\bbeef\b|"
+    r"baker.?s yeast|tryptic soy)"
+)
+_PROTEIN_EXCL = r"(broth|\bagar\b)"
+# Amino acids: name must START with the (optionally L/D/DL-prefixed) amino acid,
+# so conjugates ("Fructose-asparagine"), acyl-homoserine lactones, polymers and
+# modified residues ("4-benzoyl-L-phenylalanine") are not caught.
+_AMINO_ACID = (
+    r"^(L-|D-|DL-)?(alanine|arginine|asparagine|aspartic acid|aspartate|"
+    r"cysteine|cystine|glutamic acid|glutamate|glutamine|glycine|histidine|"
+    r"isoleucine|leucine|lysine|methionine|phenylalanine|proline|serine|"
+    r"threonine|tryptophan|tyrosine|valine|ornithine|citrulline)\b"
+)
+_AMINO_ACID_EXCL = r"(lactone|\bpoly|peptide|imidazolium|hydroxamate|hydroxamic)"
+_VITAMIN = (
+    r"(\bbiotin\b|thiamine|thiamin\b|riboflavin|niacin|nicotinamide|"
+    r"nicotinic acid|pyridoxine|pyridoxal|pyridoxamine|cobalamin|folic acid|"
+    r"\bfolate\b|folinic|pantothenate|pantothenic|lipoic acid|thioctic|"
+    r"menaquinone|menadione|aminobenzoic|\bPABA\b|inositol|vitamin)"
+)
+# Antivitamins / oxidized derivatives / antagonists / phospholipids that merely
+# contain "inositol" are not vitamin sources.
+_VITAMIN_EXCL = r"(deoxy|N-oxide|\banti|phosphatidyl)"
+# Inorganic salts of nutrient metals, matched by formula prefix (avoids the
+# azide/dithionite/oxidizer false positives of a broad "inorganic salt" rule).
 _MINERAL = (
     r"^(MgSO4|MgCl2|MnSO4|MnCl2|CuSO4|CuCl|FeSO4|FeCl2|FeCl3|CoCl2|CoSO4|"
     r"NiCl2|NiSO4|ZnSO4|ZnCl2|CaCl2|CaSO4|K2SO4|KCl\b|Na2SO4|Na2MoO4|Na2WO4|"
     r"H3BO3|boric acid)"
 )
+# Carbohydrate carbon sources (sugars + polysaccharides).
+_CARBON = (
+    r"(ose\b|oligosaccharide|polysaccharide|dextrin|dextran|starch|glycogen|"
+    r"cellulose|inulin|\bpectin|glucan|mannan|xylan|chitin|chitosan|"
+    r"maltodextrin|glycerol|\bmalt\b|fructo-?oligo|galacto-?oligo|\bFOS\b|\bGOS\b)"
+)
+# Not metabolic carbon-source ingredients despite matching a sugar/polysaccharide
+# token: endotoxin (lipopolysaccharide), glycerol fatty-acid esters (emulsifiers),
+# and complete media ("malt extract agar/broth").
+_CARBON_EXCL = r"(lipopolysaccharide|oleate|stearate|palmitate|broth|\bagar\b)"
 
+# (role, include_rx, exclude_rx | None) in precedence order.
 RULES = [
-    ("SELECTIVE_AGENT", re.compile(_ANTIBIOTIC, re.I)),
-    ("CHELATOR", re.compile(_CHELATOR, re.I)),
-    ("REDUCING_AGENT", re.compile(_REDUCING, re.I)),
-    ("MINERAL", re.compile(_MINERAL, re.I)),
+    ("SELECTIVE_AGENT", re.compile(_ANTIBIOTIC, re.I), None),
+    ("CHELATOR", re.compile(_CHELATOR, re.I), re.compile(_CHELATE_COMPLEX, re.I)),
+    ("REDUCING_AGENT", re.compile(_REDUCING, re.I), None),
+    ("BUFFER", re.compile(_BUFFER, re.I), None),
+    ("SOLIDIFYING_AGENT", re.compile(_SOLIDIFYING, re.I), None),
+    ("PROTEIN_SOURCE", re.compile(_PROTEIN, re.I), re.compile(_PROTEIN_EXCL, re.I)),
+    ("AMINO_ACID_SOURCE", re.compile(_AMINO_ACID, re.I), re.compile(_AMINO_ACID_EXCL, re.I)),
+    ("VITAMIN_SOURCE", re.compile(_VITAMIN, re.I), re.compile(_VITAMIN_EXCL, re.I)),
+    ("MINERAL", re.compile(_MINERAL, re.I), None),
+    ("CARBON_SOURCE", re.compile(_CARBON, re.I), re.compile(_CARBON_EXCL, re.I)),
 ]
-_CHELATE_RX = re.compile(_CHELATE_COMPLEX, re.I)
 
 
 def infer_role(name: str) -> str | None:
-    for role, rx in RULES:
-        if not rx.search(name):
+    for role, include_rx, exclude_rx in RULES:
+        if not include_rx.search(name):
             continue
-        if role == "CHELATOR" and _CHELATE_RX.search(name):
-            return None  # metal-chelate complex: iron/trace source, not a chelator
+        if exclude_rx is not None and exclude_rx.search(name):
+            return None  # matched the category but hit its exclusion guard
         return role
     return None
 

--- a/scripts/infer_roles_from_name_lists.py
+++ b/scripts/infer_roles_from_name_lists.py
@@ -147,7 +147,7 @@ def infer_role(name: str) -> str | None:
         if not include_rx.search(name):
             continue
         if exclude_rx is not None and exclude_rx.search(name):
-            return None  # matched the category but hit its exclusion guard
+            continue  # matched the category but hit its exclusion guard; try later rules
         return role
     return None
 

--- a/tests/test_role_inference.py
+++ b/tests/test_role_inference.py
@@ -119,6 +119,22 @@ def test_chebi_precedence_vitamin_over_nothing():
     ("DL-Dithiothreitol", "REDUCING_AGENT"),
     ("MgSO4 x 7 H2O", "MINERAL"),
     ("CuSO4 x 4 H2O", "MINERAL"),
+    # extended categories
+    ("HEPES", "BUFFER"),
+    ("Phosphate buffer", "BUFFER"),
+    ("Tris Acetate Stock Solution", "BUFFER"),
+    ("Agar", "SOLIDIFYING_AGENT"),
+    ("Peptone", "PROTEIN_SOURCE"),
+    ("Yeast extract", "PROTEIN_SOURCE"),
+    ("Tryptose", "PROTEIN_SOURCE"),        # peptone, not a sugar despite -ose
+    ("Liver extract", "PROTEIN_SOURCE"),
+    ("L-Asparagine monohydrate", "AMINO_ACID_SOURCE"),
+    ("myo-Inositol", "VITAMIN_SOURCE"),
+    ("Calcium D-Pantothenate", "VITAMIN_SOURCE"),
+    ("D-Trehalose dihydrate", "CARBON_SOURCE"),
+    ("Carboxymethyl cellulose", "CARBON_SOURCE"),
+    ("Glycogen from bovine liver", "CARBON_SOURCE"),  # source organ != liver ingredient
+    ("Malt extract", "CARBON_SOURCE"),
 ])
 def test_namelist_positive(name, expected):
     assert namelist.infer_role(name) == expected
@@ -129,9 +145,16 @@ def test_namelist_positive(name, expected):
     "Sodium ferric EDTA",
     "Ferric citrate monohydrate",
     "Citrate",                 # ambiguous -> excluded
-    "L-Cysteine HCl",          # amino acid, not tagged reducing agent
     "Dimethyl sulfide",        # volatile organosulfide, not a reductant additive
-    "D-glucose",               # not in any list
+    # extended-category exclusions (matched a token but guarded out)
+    "Brucella agar",           # agar-containing complete medium, not pure gelling agent
+    "Malt Extract Agar",       # complete medium
+    "Bacto Tryptic Soy Broth", # complete medium
+    "Serine hydroxamate",      # serine analog/inhibitor, not an amino-acid source
+    "L-alpha-Phosphatidylinositol from soybean",  # phospholipid, not a vitamin
+    "4-Deoxypyridoxine",       # antivitamin
+    "Lipopolysaccharide",      # endotoxin, not a carbon source
+    "Glycerol monostearate",   # emulsifier ester, not a carbon source
 ])
 def test_namelist_excluded(name):
     assert namelist.infer_role(name) is None


### PR DESCRIPTION
## Summary
Pushes the two headroom items from PR #37's wrap-up.

### Broaden role coverage 33.2% → 40.2% (+131 roles)
Six high-precision categories added to `infer_roles_from_name_lists.py`, reaching role-less records the CHEBI-ancestry pass can't (including non-CHEBI CAS/MESH/NCIT entries):
- **BUFFER** (15) — Good's buffers + named phosphate/Tris buffers
- **PROTEIN_SOURCE** (36) — peptones, tryptone, casitone, casamino, casein, hydrolysates, yeast/beef/meat extracts, liver, proteose
- **CARBON_SOURCE** (54) — sugars, oligosaccharides, glucans, cellulose, glycerol, malt
- **VITAMIN_SOURCE** (13), **AMINO_ACID_SOURCE** (12), **SOLIDIFYING_AGENT** (1)

Each category has exclusion guards verified against the full candidate list, so precision stays high:
- `Glycogen from bovine liver` → CARBON (not PROTEIN — "liver" is the source organ)
- `Tryptose` → PROTEIN (not a sugar despite `-ose`)
- `Serine hydroxamate` (inhibitor), phosphatidylinositol (phospholipid), `4-Deoxypyridoxine` (antivitamin), lipopolysaccharide, glycerol esters, and complete broth/agar media → **not tagged**

**756 roles / 752 records, 0 validation errors.**

### Duplicate-identifier review finalized
The clear stereoisomer errors were fixed in PR #37. This documents the remaining candidates as reviewed with **no clean fix**:
- shared-CAS: porcine mucin Type II/III is the *same substance* (sharing CAS is correct); carob/yeast mannan and soy/potato rhamnogalacturonan are source variants needing per-case CAS research
- coarse FOODON/MICRO/NCIT solution terms: distinct products with no distinct ontology term available — valid coarse mappings, not errors

## Tests
+21 cases in `test_role_inference.py` pinning the new categories and their FP exclusions.

## Validation
- `validate_strict.py`: **0 errors / 2274 files**
- `validate_roles.py`: **756 roles, 0 errors, 100% cited**
- Full suite: **281 passed** (260 + 21 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)