### PR TITLE
Add organic-acid carbon-source inference (coverage 40.2% → 43.2%)

### DIFF
--- a/data/ingredients/mapped/2-Hydroxybutyric_Acid_Sodium_Salt.yaml
+++ b/data/ingredients/mapped/2-Hydroxybutyric_Acid_Sodium_Salt.yaml
@@ -48,6 +48,10 @@ curation_history:
   action: BACKFILL_PARENT_CHEBI
   changes: set ontology_mapping parent=CHEBI:1148 (stem-substring)
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.577819+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 5094-24-6
   data_source: CultureBotHT compounds_to_cas.csv
@@ -57,3 +61,10 @@ chemical_properties:
   inchi: InChI=1S/C4H8O3.Na/c1-2-3(5)4(6)7;/h3,5H,2H2,1H3,(H,6,7);/q;+1/p-1
   pubchem_cid: 23663641
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/2-Keto-D-gluconic_Acid_Hemicalcium_Salt_Hydrate.yaml
+++ b/data/ingredients/mapped/2-Keto-D-gluconic_Acid_Hemicalcium_Salt_Hydrate.yaml
@@ -34,8 +34,19 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: 'set ingredient_type=SINGLE_INGREDIENT (cas: primary (defined chemical))'
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.577913+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 1040352-40-6
   data_source: CultureBotHT compounds_to_cas.csv
   retrieval_date: '2026-04-29T06:51:33.117170+00:00'
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/2-Keto-D-gluconic_Acid_Hemicalcium_Salt_Monohydrate.yaml
+++ b/data/ingredients/mapped/2-Keto-D-gluconic_Acid_Hemicalcium_Salt_Monohydrate.yaml
@@ -40,6 +40,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.577991+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 3470-37-9
   data_source: CultureBotHT compounds_to_cas.csv
@@ -49,3 +53,10 @@ chemical_properties:
   inchi: InChI=1S/2C6H10O7.Ca/c2*7-1-2(8)3(9)4(10)5(11)6(12)13;/h2*2-4,7-10H,1H2,(H,12,13);/q;;+2/p-2/t2*2-,3-,4+;/m11./s1
   pubchem_cid: 25113463
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/3-Hydroxypropionate.yaml
+++ b/data/ingredients/mapped/3-Hydroxypropionate.yaml
@@ -38,6 +38,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.578769+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 503-66-2
   data_source: CultureBotHT compounds_to_cas.csv
@@ -46,3 +50,10 @@ chemical_properties:
   inchi: InChI=1S/C3H6O3/c4-2-1-3(5)6/h4H,1-2H2,(H,5,6)/p-1
   smiles: O=C([O-])CCO
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/3-hydroxybutyric_Acid.yaml
+++ b/data/ingredients/mapped/3-hydroxybutyric_Acid.yaml
@@ -38,6 +38,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.579033+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 300-85-6
   data_source: CultureBotHT compounds_to_cas.csv
@@ -46,3 +50,10 @@ chemical_properties:
   inchi: InChI=1S/C4H8O3/c1-3(5)2-4(6)7/h3,5H,2H2,1H3,(H,6,7)
   smiles: CC(O)CC(=O)O
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/4-hydroxybutyric_Acid.yaml
+++ b/data/ingredients/mapped/4-hydroxybutyric_Acid.yaml
@@ -38,6 +38,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.579733+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 591-81-1
   data_source: CultureBotHT compounds_to_cas.csv
@@ -46,3 +50,10 @@ chemical_properties:
   inchi: InChI=1S/C4H8O3/c5-3-1-2-4(6)7/h5H,1-3H2,(H,6,7)
   smiles: O=C(O)CCCO
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/5-Keto-D-Gluconic_Acid_Potassium_Salt.yaml
+++ b/data/ingredients/mapped/5-Keto-D-Gluconic_Acid_Potassium_Salt.yaml
@@ -49,6 +49,10 @@ curation_history:
   action: BACKFILL_PARENT_CHEBI
   changes: set ontology_mapping parent=CHEBI:26218 (stem-substring)
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.580194+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 91446-96-7
   data_source: CultureBotHT compounds_to_cas.csv
@@ -58,3 +62,10 @@ chemical_properties:
   inchi: InChI=1S/C6H10O7.K/c7-1-2(8)3(9)4(10)5(11)6(12)13;/h3-5,7,9-11H,1H2,(H,12,13);/q;+1/p-1/t3-,4+,5-;/m1./s1
   pubchem_cid: 23702137
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/A-Ketoglutaric_Acid_Disodium_Salt_Hydrate.yaml
+++ b/data/ingredients/mapped/A-Ketoglutaric_Acid_Disodium_Salt_Hydrate.yaml
@@ -45,6 +45,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.580608+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 305-72-6
   data_source: CultureBotHT compounds_to_cas.csv
@@ -54,3 +58,10 @@ chemical_properties:
   inchi: InChI=1S/C5H6O5.2Na/c6-3(5(9)10)1-2-4(7)8;;/h1-2H2,(H,7,8)(H,9,10);;/q;2*+1/p-2
   pubchem_cid: 31040
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Acetate_Carbon_Source.yaml
+++ b/data/ingredients/mapped/Acetate_Carbon_Source.yaml
@@ -32,6 +32,10 @@ curation_history:
   changes: molecular_formula=C2H3O2; inchi=InChI=1S/C2H4O2/c1-2(3)4/h1H3,(H,3,4)/p-1;
     smiles=CC(=O)[O-]
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.580708+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 notes: Imported from communitymech-unmapped (source_id=communitymech.ingredient:Acetate_(carbon_source));
   no CAS-RN or CHEBI/NCIT match. Curator review needed.
 ontology_mapping:
@@ -50,3 +54,10 @@ chemical_properties:
   inchi: InChI=1S/C2H4O2/c1-2(3)4/h1H3,(H,3,4)/p-1
   smiles: CC(=O)[O-]
   data_source: CHEBI sqlite (oaklib)
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Alpha-ketoglutaric_Acid.yaml
+++ b/data/ingredients/mapped/Alpha-ketoglutaric_Acid.yaml
@@ -75,6 +75,10 @@ curation_history:
   previous_status: MAPPED
   new_status: MAPPED
   llm_assisted: true
+- timestamp: '2026-06-03T03:22:14.581179+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 328-50-7
   data_source: PubChem API
@@ -83,3 +87,10 @@ chemical_properties:
   inchi: InChI=1S/C5H6O5/c6-3(5(9)10)1-2-4(7)8/h1-2H2,(H,7,8)(H,9,10)
   smiles: O=C(O)CCC(=O)C(=O)O
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Caproic_Acid.yaml
+++ b/data/ingredients/mapped/Caproic_Acid.yaml
@@ -124,6 +124,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.583304+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 142-62-1
   data_source: PubChem API
@@ -133,3 +137,10 @@ chemical_properties:
   smiles: CCCCCC(=O)O
 kg_microbe_node_id: CHEBI:30776
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Citrate.yaml
+++ b/data/ingredients/mapped/Citrate.yaml
@@ -39,9 +39,20 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.584177+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 ingredient_type: SINGLE_INGREDIENT
 chemical_properties:
   molecular_formula: C6H5O7
   inchi: InChI=1S/C6H8O7/c7-3(8)1-6(13,5(11)12)2-4(9)10/h13H,1-2H2,(H,7,8)(H,9,10)(H,11,12)/p-3
   smiles: O=C([O-])CC(O)(CC(=O)[O-])C(=O)[O-]
   data_source: CHEBI sqlite (oaklib)
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Citric_Acid.yaml
+++ b/data/ingredients/mapped/Citric_Acid.yaml
@@ -96,6 +96,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.584196+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 77-92-9
   data_source: PubChem API
@@ -104,3 +108,10 @@ chemical_properties:
   inchi: InChI=1S/C6H8O7/c7-3(8)1-6(13,5(11)12)2-4(9)10/h13H,1-2H2,(H,7,8)(H,9,10)(H,11,12)
   smiles: O=C(O)CC(O)(CC(=O)O)C(=O)O
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Citric_Acid_X_H2o.yaml
+++ b/data/ingredients/mapped/Citric_Acid_X_H2o.yaml
@@ -59,6 +59,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.584223+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 5949-29-1
   data_source: PubChem (via CHEBI:31404)
@@ -67,3 +71,10 @@ chemical_properties:
   inchi: InChI=1S/C6H8O7.H2O/c7-3(8)1-6(13,5(11)12)2-4(9)10;/h13H,1-2H2,(H,7,8)(H,9,10)(H,11,12);1H2
   smiles: O.O=C(O)CC(O)(CC(=O)O)C(=O)O
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Citric_Acidh2o.yaml
+++ b/data/ingredients/mapped/Citric_Acidh2o.yaml
@@ -26,6 +26,10 @@ curation_history:
   changes: molecular_formula=C6H8O7; inchi=InChI=1S/C6H8O7/c7-3(8)1-6(13,5(11)12)2-4(9)10/h13;
     smiles=O=C(O)CC(O)(CC(=O)O)C(=O)O
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.584268+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 notes: 'CultureMech placeholder_id: 9'
 ontology_mapping:
   ontology_id: CHEBI:30769
@@ -41,3 +45,10 @@ chemical_properties:
   inchi: InChI=1S/C6H8O7/c7-3(8)1-6(13,5(11)12)2-4(9)10/h13H,1-2H2,(H,7,8)(H,9,10)(H,11,12)
   smiles: O=C(O)CC(O)(CC(=O)O)C(=O)O
   data_source: CHEBI sqlite (oaklib)
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/D-_-gluconic_Acid_Gamma-lactone.yaml
+++ b/data/ingredients/mapped/D-_-gluconic_Acid_Gamma-lactone.yaml
@@ -40,6 +40,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.584888+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 90-80-2
   data_source: CultureBotHT compounds_to_cas.csv
@@ -48,3 +52,10 @@ chemical_properties:
   inchi: InChI=1S/C6H10O6/c7-1-2-3(8)4(9)5(10)6(11)12-2/h2-5,7-10H,1H2/t2-,3-,4+,5-/m1/s1
   smiles: O=C1O[C@H](CO)[C@@H](O)[C@H](O)[C@H]1O
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/DL-Isocitric_Acid_Trisodium_Salt_Hydrate.yaml
+++ b/data/ingredients/mapped/DL-Isocitric_Acid_Trisodium_Salt_Hydrate.yaml
@@ -40,6 +40,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.585348+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 1637-73-6
   data_source: CultureBotHT compounds_to_cas.csv
@@ -48,3 +52,10 @@ chemical_properties:
   inchi: InChI=1S/C6H8O7.3Na/c7-3(8)1-2(5(10)11)4(9)6(12)13;;;/h2,4,9H,1H2,(H,7,8)(H,10,11)(H,12,13);;;/q;3*+1/p-3
   smiles: O=C([O-])CC(C(=O)[O-])C(O)C(=O)[O-].[Na+].[Na+].[Na+]
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Disodium_Glutarate.yaml
+++ b/data/ingredients/mapped/Disodium_Glutarate.yaml
@@ -48,6 +48,10 @@ curation_history:
   action: BACKFILL_PARENT_MESH
   changes: set ontology_mapping parent=mesh:C000730144 (stem-substring)
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.586008+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 13521-83-0
   data_source: CultureBotHT compounds_to_cas.csv
@@ -57,3 +61,10 @@ chemical_properties:
   inchi: InChI=1S/C5H8O4.2Na/c6-4(7)2-1-3-5(8)9;;/h1-3H2,(H,6,7)(H,8,9);;/q;2*+1/p-2
   pubchem_cid: 161742
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Dl-mevalonic_Acid.yaml
+++ b/data/ingredients/mapped/Dl-mevalonic_Acid.yaml
@@ -65,6 +65,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.586131+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 150-97-0
   data_source: PubChem API
@@ -72,3 +76,10 @@ chemical_properties:
   molecular_formula: C6H12O4
 kg_microbe_node_id: CHEBI:25351
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Formic_Acid.yaml
+++ b/data/ingredients/mapped/Formic_Acid.yaml
@@ -85,6 +85,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.587313+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 64-18-6
   data_source: PubChem API
@@ -93,3 +97,10 @@ chemical_properties:
   inchi: InChI=1S/CH2O2/c2-1-3/h1H,(H,2,3)
   smiles: '[H]C(=O)O'
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Glutaric_Acid.yaml
+++ b/data/ingredients/mapped/Glutaric_Acid.yaml
@@ -38,6 +38,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.587658+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 110-94-1
   data_source: CultureBotHT compounds_to_cas.csv
@@ -46,3 +50,10 @@ chemical_properties:
   inchi: InChI=1S/C5H8O4/c6-4(7)2-1-3-5(8)9/h1-3H2,(H,6,7)(H,8,9)
   smiles: O=C(O)CCCC(=O)O
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Glycolic_Acid.yaml
+++ b/data/ingredients/mapped/Glycolic_Acid.yaml
@@ -38,6 +38,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.587860+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 79-14-1
   data_source: CultureBotHT compounds_to_cas.csv
@@ -46,3 +50,10 @@ chemical_properties:
   inchi: InChI=1S/C2H4O3/c3-1-2(4)5/h3H,1H2,(H,4,5)
   smiles: O=C(O)CO
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/L-Malic_Acid.yaml
+++ b/data/ingredients/mapped/L-Malic_Acid.yaml
@@ -40,6 +40,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.589450+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 97-67-6
   data_source: CultureBotHT compounds_to_cas.csv
@@ -48,3 +52,10 @@ chemical_properties:
   inchi: InChI=1S/C4H6O5/c5-2(4(8)9)1-3(6)7/h2,5H,1H2,(H,6,7)(H,8,9)/t2-/m0/s1
   smiles: O=C(O)C[C@H](O)C(=O)O
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/L-Malic_Acid_Disodium_Salt_Monohydrate.yaml
+++ b/data/ingredients/mapped/L-Malic_Acid_Disodium_Salt_Monohydrate.yaml
@@ -48,6 +48,10 @@ curation_history:
   action: BACKFILL_PARENT_NCIT
   changes: set ontology_mapping parent=NCIT:C80654 (stem-substring)
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.589506+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 207511-06-6
   data_source: CultureBotHT compounds_to_cas.csv
@@ -57,3 +61,10 @@ chemical_properties:
   inchi: InChI=1S/C4H6O5.Na/c5-2(4(8)9)1-3(6)7;/h2,5H,1H2,(H,6,7)(H,8,9);/q;+1/p-2
   pubchem_cid: 197014
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Lactate.yaml
+++ b/data/ingredients/mapped/Lactate.yaml
@@ -86,6 +86,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.589688+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 113-21-3
   data_source: PubChem API
@@ -94,3 +98,10 @@ chemical_properties:
   inchi: InChI=1S/C3H6O3/c1-2(4)3(5)6/h2,4H,1H3,(H,5,6)/p-1
   smiles: CC(O)C(=O)[O-]
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Levulinic_Acid.yaml
+++ b/data/ingredients/mapped/Levulinic_Acid.yaml
@@ -40,6 +40,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.589856+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 123-76-2
   data_source: CultureBotHT compounds_to_cas.csv
@@ -48,3 +52,10 @@ chemical_properties:
   inchi: InChI=1S/C5H8O3/c1-4(6)2-3-5(7)8/h2-3H2,1H3,(H,7,8)
   smiles: CC(=O)CCC(=O)O
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Malate.yaml
+++ b/data/ingredients/mapped/Malate.yaml
@@ -50,9 +50,20 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (CHEBI primary)
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.590086+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 6915-15-7
   data_source: PubChem API
   retrieval_date: '2026-04-05T19:52:51.766654+00:00'
 kg_microbe_node_id: CHEBI:25115
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Malonic_Acid.yaml
+++ b/data/ingredients/mapped/Malonic_Acid.yaml
@@ -38,6 +38,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.590164+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 141-82-2
   data_source: CultureBotHT compounds_to_cas.csv
@@ -46,3 +50,10 @@ chemical_properties:
   inchi: InChI=1S/C3H4O4/c4-2(5)1-3(6)7/h1H2,(H,4,5)(H,6,7)
   smiles: O=C(O)CC(=O)O
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Na-3-hydroxybutyrate.yaml
+++ b/data/ingredients/mapped/Na-3-hydroxybutyrate.yaml
@@ -63,6 +63,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.591801+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 150-83-4
   data_source: PubChem API (preprocessed)
@@ -71,3 +75,10 @@ chemical_properties:
   inchi: InChI=1S/C4H8O3.Na/c1-3(5)2-4(6)7;/h3,5H,2H2,1H3,(H,6,7);/q;+1/p-1
   smiles: CC(O)CC(=O)[O-].[Na+]
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Na-butyrate.yaml
+++ b/data/ingredients/mapped/Na-butyrate.yaml
@@ -149,6 +149,10 @@ curation_history:
   previous_status: MAPPED
   new_status: MAPPED
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.591835+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 156-54-7
   data_source: PubChem API (preprocessed)
@@ -158,3 +162,10 @@ chemical_properties:
   smiles: CCCC(=O)[O-].[Na+]
 kg_microbe_node_id: CHEBI:64103
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Na-caproate.yaml
+++ b/data/ingredients/mapped/Na-caproate.yaml
@@ -91,6 +91,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.591856+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 10051-44-2
   data_source: PubChem API (preprocessed)
@@ -100,3 +104,10 @@ chemical_properties:
   smiles: CCCCCC(=O)[O-].[Na+]
 kg_microbe_node_id: CHEBI:114126
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Na-formate.yaml
+++ b/data/ingredients/mapped/Na-formate.yaml
@@ -141,6 +141,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.591888+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 141-53-7
   data_source: PubChem API (preprocessed)
@@ -150,3 +154,10 @@ chemical_properties:
   smiles: '[H]C(=O)[O-].[Na+]'
 kg_microbe_node_id: CHEBI:62965
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Na2-fumarate.yaml
+++ b/data/ingredients/mapped/Na2-fumarate.yaml
@@ -154,6 +154,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.591976+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 kg_microbe_node_id: CHEBI:115156
 chemical_properties:
   cas_rn: 17013-01-3
@@ -163,3 +167,10 @@ chemical_properties:
   inchi: InChI=1S/C4H4O4.2Na/c5-3(6)1-2-4(7)8;;/h1-2H,(H,5,6)(H,7,8);;/q;2*+1/p-2/b2-1+;;
   smiles: O=C([O-])/C=C/C(=O)[O-].[Na+].[Na+]
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Na2_Alpha-ketoglutarate.yaml
+++ b/data/ingredients/mapped/Na2_Alpha-ketoglutarate.yaml
@@ -93,6 +93,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.592020+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 kg_microbe_node_id: CHEBI:16810
 chemical_properties:
   cas_rn: 64-15-3
@@ -102,3 +106,10 @@ chemical_properties:
   inchi: InChI=1S/C5H6O5/c6-3(5(9)10)1-2-4(7)8/h1-2H2,(H,7,8)(H,9,10)/p-2
   smiles: O=C([O-])CCC(=O)C(=O)[O-]
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Octanoic_Acid.yaml
+++ b/data/ingredients/mapped/Octanoic_Acid.yaml
@@ -41,6 +41,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.592723+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 124-07-2
   data_source: CultureBotHT compounds_to_cas.csv
@@ -49,3 +53,10 @@ chemical_properties:
   inchi: InChI=1S/C8H16O2/c1-2-3-4-5-6-7-8(9)10/h2-7H2,1H3,(H,9,10)
   smiles: CCCCCCCC(=O)O
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Oxaloacetic_Acid.yaml
+++ b/data/ingredients/mapped/Oxaloacetic_Acid.yaml
@@ -41,6 +41,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.592784+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 328-42-7
   data_source: CultureBotHT compounds_to_cas.csv
@@ -49,3 +53,10 @@ chemical_properties:
   inchi: InChI=1S/C4H4O5/c5-2(4(8)9)1-3(6)7/h1H2,(H,6,7)(H,8,9)
   smiles: O=C(O)CC(=O)C(=O)O
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Poly_3-hydroxybutyrate.yaml
+++ b/data/ingredients/mapped/Poly_3-hydroxybutyrate.yaml
@@ -68,8 +68,19 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.593734+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 ingredient_type: SINGLE_INGREDIENT
 chemical_properties:
   molecular_formula: (C4H6O2)n
   smiles: '*OC(C)CC(*)=O'
   data_source: CHEBI sqlite (oaklib)
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Poly_3-hydroxybutyric_Acid.yaml
+++ b/data/ingredients/mapped/Poly_3-hydroxybutyric_Acid.yaml
@@ -48,6 +48,10 @@ curation_history:
   action: BACKFILL_PARENT_CHEBI
   changes: set ontology_mapping parent=CHEBI:20067 (stem-substring)
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.593670+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 29435-48-1
   data_source: CultureBotHT compounds_to_cas.csv
@@ -57,3 +61,10 @@ chemical_properties:
   inchi: InChI=1S/C12H20O6/c1-8(14)6-11(15)18-10(3)7-12(16)17-9(2)4-5-13/h5,8-10,14H,4,6-7H2,1-3H3
   pubchem_cid: 71311208
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Pyruvate.yaml
+++ b/data/ingredients/mapped/Pyruvate.yaml
@@ -55,6 +55,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.594610+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 57-60-3
   data_source: PubChem API
@@ -64,3 +68,10 @@ chemical_properties:
   smiles: CC(=O)C(=O)[O-]
 kg_microbe_node_id: CHEBI:15361
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Pyruvic_Acid.yaml
+++ b/data/ingredients/mapped/Pyruvic_Acid.yaml
@@ -93,6 +93,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.594630+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 127-17-3
   data_source: PubChem API
@@ -101,3 +105,10 @@ chemical_properties:
   inchi: InChI=1S/C3H4O3/c1-2(4)3(5)6/h1H3,(H,5,6)
   smiles: CC(=O)C(=O)O
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Quinic_Acid.yaml
+++ b/data/ingredients/mapped/Quinic_Acid.yaml
@@ -49,9 +49,20 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (CHEBI primary)
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.594683+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 7729-33-1
   data_source: PubChem API
   retrieval_date: '2026-04-05T19:53:47.137156+00:00'
 kg_microbe_node_id: CHEBI:26493
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/R-3-hydroxybutyrate.yaml
+++ b/data/ingredients/mapped/R-3-hydroxybutyrate.yaml
@@ -38,6 +38,10 @@ curation_history:
   changes: 'identifier CHEBI:37054 -> CHEBI:10983: enantiomer was sharing an achiral
     CHEBI parent with its mirror image.'
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.576674+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 notes: Imported from CultureBotHT (compounds_to_cas.csv (no CAS-RN)). No CAS-RN or
   CHEBI mapping available; curator review needed.
 ontology_mapping:
@@ -61,3 +65,10 @@ chemical_properties:
   smiles: CC(O)CC(=O)[O-]
   data_source: CHEBI sqlite (oaklib)
 kg_microbe_node_id: CHEBI:10983
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/S-3-hydroxybutyrate.yaml
+++ b/data/ingredients/mapped/S-3-hydroxybutyrate.yaml
@@ -38,6 +38,10 @@ curation_history:
   changes: 'identifier CHEBI:37054 -> CHEBI:11047: enantiomer was sharing an achiral
     CHEBI parent with its mirror image.'
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.577019+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 notes: Imported from CultureBotHT (compounds_to_cas.csv (no CAS-RN)). No CAS-RN or
   CHEBI mapping available; curator review needed.
 ontology_mapping:
@@ -61,3 +65,10 @@ chemical_properties:
   smiles: CC(O)CC(=O)[O-]
   data_source: CHEBI sqlite (oaklib)
 kg_microbe_node_id: CHEBI:11047
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Shikimic_Acid.yaml
+++ b/data/ingredients/mapped/Shikimic_Acid.yaml
@@ -66,6 +66,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.595448+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 notes: Created from FEBA ontology enrichment workflow. Used in 10 FEBA media formulations.
 chemical_properties:
   cas_rn: 138-59-0
@@ -75,3 +79,10 @@ chemical_properties:
   inchi: InChI=1S/C7H10O5/c8-4-1-3(7(11)12)2-5(9)6(4)10/h1,4-6,8-10H,2H2,(H,11,12)/t4-,5-,6-/m1/s1
   smiles: O=C(O)C1=C[C@@H](O)[C@@H](O)[C@H](O)C1
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Sodium_Acetate.yaml
+++ b/data/ingredients/mapped/Sodium_Acetate.yaml
@@ -37,6 +37,10 @@ curation_history:
   changes: molecular_formula=C2H3O2.Na; inchi=InChI=1S/C2H4O2.Na/c1-2(3)4;/h1H3,(H,3,4);/q;+1/p-;
     smiles=CC(=O)[O-].[Na+]
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.595757+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 notes: 'CultureMech placeholder_id: 3'
 chemical_properties:
   cas_rn: 127-09-3
@@ -57,3 +61,10 @@ ontology_mapping:
       label-exact
 ingredient_type: SINGLE_INGREDIENT
 kg_microbe_node_id: CHEBI:32954
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Sodium_D-Lactate.yaml
+++ b/data/ingredients/mapped/Sodium_D-Lactate.yaml
@@ -40,6 +40,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.596024+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 920-49-0
   data_source: CultureBotHT compounds_to_cas.csv
@@ -49,3 +53,10 @@ chemical_properties:
   inchi: InChI=1S/C3H6O3.Na/c1-2(4)3(5)6;/h2,4H,1H3,(H,5,6);/q;+1/p-1/t2-;/m1./s1
   pubchem_cid: 23666457
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Sodium_Gluconate.yaml
+++ b/data/ingredients/mapped/Sodium_Gluconate.yaml
@@ -116,6 +116,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.596245+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 527-07-1
   data_source: CultureBotHT compounds_to_cas.csv
@@ -125,3 +129,10 @@ chemical_properties:
   smiles: O=C([O-])[C@H](O)[C@@H](O)[C@H](O)[C@H](O)CO.[Na+]
 kg_microbe_node_id: CHEBI:84997
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Sodium_L-lactate.yaml
+++ b/data/ingredients/mapped/Sodium_L-lactate.yaml
@@ -47,9 +47,20 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (CHEBI primary)
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.596403+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 867-56-1
   data_source: CultureBotHT compounds_to_cas.csv
   retrieval_date: '2026-04-05T21:48:45.780434+00:00'
 kg_microbe_node_id: CHEBI:867561
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Sodium_Malate.yaml
+++ b/data/ingredients/mapped/Sodium_Malate.yaml
@@ -186,6 +186,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.596446+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 138-09-0
   data_source: OAK/CHEBI xref
@@ -195,3 +199,10 @@ chemical_properties:
   smiles: O=C([O-])C[C@H](O)C(=O)[O-].[Na+].[Na+]
 kg_microbe_node_id: CHEBI:91261
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Sodium_Octanoate.yaml
+++ b/data/ingredients/mapped/Sodium_Octanoate.yaml
@@ -68,6 +68,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.596671+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 1984-06-1
   data_source: PubChem API
@@ -77,3 +81,10 @@ chemical_properties:
   smiles: CCCCCCCC(=O)[O-].[Na+]
 kg_microbe_node_id: CHEBI:132100
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Sodium_Succinate.yaml
+++ b/data/ingredients/mapped/Sodium_Succinate.yaml
@@ -130,6 +130,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.596937+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 150-90-3
   data_source: OAK/CHEBI xref
@@ -139,3 +143,10 @@ chemical_properties:
   smiles: O=C([O-])CCC(=O)[O-].[Na+].[Na+]
 kg_microbe_node_id: CHEBI:63675
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Sodium_succinate_dibasic_hexahydrate.yaml
+++ b/data/ingredients/mapped/Sodium_succinate_dibasic_hexahydrate.yaml
@@ -68,6 +68,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.597117+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 notes: Created from FEBA ontology enrichment workflow. Used in 11 FEBA media formulations.
 chemical_properties:
   cas_rn: 6106-21-4
@@ -77,3 +81,10 @@ chemical_properties:
   inchi: InChI=1S/C4H6O4.2Na.6H2O/c5-3(6)1-2-4(7)8;;;;;;;;/h1-2H2,(H,5,6)(H,7,8);;;6*1H2/q;2*+1;;;;;;/p-2
   smiles: O.O.O.O.O.O.O=C([O-])CCC(=O)[O-].[Na+].[Na+]
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Succinate.yaml
+++ b/data/ingredients/mapped/Succinate.yaml
@@ -66,9 +66,20 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (CHEBI primary)
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.597322+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 56-14-4
   data_source: PubChem API
   retrieval_date: '2026-04-05T19:53:57.621764+00:00'
 kg_microbe_node_id: CHEBI:26806
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Succinic_Acid.yaml
+++ b/data/ingredients/mapped/Succinic_Acid.yaml
@@ -104,6 +104,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.597343+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 110-15-6
   data_source: PubChem API
@@ -113,3 +117,10 @@ chemical_properties:
   smiles: O=C(O)CCC(=O)O
 kg_microbe_node_id: CHEBI:15741
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Trans-aconitic_Acid.yaml
+++ b/data/ingredients/mapped/Trans-aconitic_Acid.yaml
@@ -38,6 +38,10 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.598442+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 chemical_properties:
   cas_rn: 4023-65-8
   data_source: CultureBotHT compounds_to_cas.csv
@@ -46,3 +50,10 @@ chemical_properties:
   inchi: InChI=1S/C6H6O6/c7-4(8)1-3(6(11)12)2-5(9)10/h1H,2H2,(H,7,8)(H,9,10)(H,11,12)/b3-1+
   smiles: O=C(O)/C=C(CC(=O)O)C(=O)O
 ingredient_type: SINGLE_INGREDIENT
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Trisodium_Citrate_X_H2O.yaml
+++ b/data/ingredients/mapped/Trisodium_Citrate_X_H2O.yaml
@@ -22,6 +22,10 @@ curation_history:
   changes: primary UNMAPPED_0556 → mesh:C514290 via name normalization to 'Trisodium
     citrate'
   llm_assisted: false
+- timestamp: '2026-06-03T03:22:14.598734+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
 notes: Imported from mim-queue (source_id=mediadive.ingredient:1888); no CAS-RN or
   CHEBI/NCIT match. Curator review needed.
 ontology_mapping:
@@ -34,3 +38,10 @@ ontology_mapping:
     source: MESH via OLS search (resolve_unmapped)
     notes: Auto-upgraded from UNMAPPED_0556; matched via 'Trisodium citrate' (name
       normalization); label-exact
+media_roles:
+- role: CARBON_SOURCE
+  confidence: 0.8
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/scripts/infer_roles_from_name_lists.py
+++ b/scripts/infer_roles_from_name_lists.py
@@ -127,6 +127,30 @@ _CARBON = (
 # and complete media ("malt extract agar/broth").
 _CARBON_EXCL = r"(lipopolysaccharide|oleate|stearate|palmitate|broth|\bagar\b)"
 
+# Canonical microbial organic-acid carbon sources (TCA / glycolysis / short-chain),
+# as -ate or -ic acid. CHEBI ancestry can't be used here: it classifies the common
+# salt forms (sodium acetate, pyruvate) under "salt", not under carboxylic acid.
+_ORGANIC_ACID = (
+    r"\b(acet(ate|ic)|lact(ate|ic)|pyruv(ate|ic)|succin(ate|ic)|fumar(ate|ic)|"
+    r"mal(ate|ic)|citr(ate|ic)|propion(ate|ic)|butyr(ate|ic)|form(ate|ic)|"
+    r"glucon(ate|ic)|oxoglutar(ate|ic)|ketoglutar(ate|ic)|glutar(ate|ic)|"
+    r"glycol(ate|ic)|glyoxyl(ate|ic)|malon(ate|ic)|oxaloacet(ate|ic)|"
+    r"isocitr(ate|ic)|aconit(ate|ic)|hydroxybutyr(ate|ic)|hydroxypropion(ate|ic)|"
+    r"capro(ate|ic)|octano(ate|ic)|valer(ate|ic)|levulin(ate|ic)|mevalon(ate|ic)|"
+    r"quin(ate|ic)|shikim(ate|ic))\b"
+)
+# Exclude where the acid is a counterion/ester/complex rather than the carbon
+# source: toxic/transition-metal & iron/Mg salts (metal sources), aromatics /
+# polyphenols / indole auxins, esters & ionic liquids, ammonium salts (N source).
+_ORGANIC_ACID_EXCL = (
+    r"(cadmium|thalli|uranyl|\blead\b|mercur|silver|ferric|ferrous|\biron\b|"
+    r"mangan|nickel|cobalt|copper|zinc|alumin|chromium|barium|strontium|gallium|"
+    r"magnesium|\bMg-|"
+    r"indol|phenyl|gallate|epigallo|catechin|imidazolium|rhodinyl|synephrine|"
+    r"cholin|styryl|ursolo|aminopropionitrile|thienyl|\bethyl\b|"
+    r"ammonium|\(NH4\)|NH4-)"
+)
+
 # (role, include_rx, exclude_rx | None) in precedence order.
 RULES = [
     ("SELECTIVE_AGENT", re.compile(_ANTIBIOTIC, re.I), None),
@@ -139,6 +163,7 @@ RULES = [
     ("VITAMIN_SOURCE", re.compile(_VITAMIN, re.I), re.compile(_VITAMIN_EXCL, re.I)),
     ("MINERAL", re.compile(_MINERAL, re.I), None),
     ("CARBON_SOURCE", re.compile(_CARBON, re.I), re.compile(_CARBON_EXCL, re.I)),
+    ("CARBON_SOURCE", re.compile(_ORGANIC_ACID, re.I), re.compile(_ORGANIC_ACID_EXCL, re.I)),
 ]
 
 

--- a/scripts/infer_roles_from_name_lists.py
+++ b/scripts/infer_roles_from_name_lists.py
@@ -12,9 +12,10 @@ Precision choices:
     cef-/-floxacin/-penem/... + explicit names). Antibiotics in a medium are
     selective agents.
   * CHELATOR: only FREE chelators (EDTA / NTA / EGTA / DTPA / desferrioxamine).
-    Metal-chelate complexes (Fe-EDTA, ferric citrate) are excluded — their media
-    role is an iron/trace source, not chelation. Citrate is excluded (ambiguous:
-    carbon source / buffer / chelator).
+    Metal-chelate complexes (Fe-EDTA, ferric citrate) are excluded from CHELATOR —
+    their media role is an iron/trace source, not chelation. Free citrate is not a
+    chelator here; it is inferred as CARBON_SOURCE by the organic-acid rule below
+    (metal-citrate complexes stay excluded via that rule's blocklist).
   * REDUCING_AGENT: specific anaerobic reductants (dithionite, dithiothreitol,
     2-mercaptoethanol, thioglycolate, sodium/hydrogen/ammonium sulfide, TCEP).
     Cysteine and volatile organosulfides are excluded (ambiguous / not reductant

--- a/tests/test_role_inference.py
+++ b/tests/test_role_inference.py
@@ -166,7 +166,6 @@ def test_namelist_positive(name, expected):
     # organic-acid blocklist: acid is a counterion/ester/complex, not the carbon source
     "Cadmium acetate dihydrate",   # toxic metal salt
     "Uranyl acetate",              # toxic metal salt
-    "Ferric citrate monohydrate",  # iron source (metal-citrate complex)
     "ethyl acetate",               # ester/solvent
     "Phenyl acetic acid",          # aromatic acid
     "Indole-3-butyric acid",       # auxin / signaling

--- a/tests/test_role_inference.py
+++ b/tests/test_role_inference.py
@@ -135,6 +135,15 @@ def test_chebi_precedence_vitamin_over_nothing():
     ("Carboxymethyl cellulose", "CARBON_SOURCE"),
     ("Glycogen from bovine liver", "CARBON_SOURCE"),  # source organ != liver ingredient
     ("Malt extract", "CARBON_SOURCE"),
+    # organic-acid carbon sources (curated list + metal/ester/aromatic blocklist)
+    ("Sodium acetate", "CARBON_SOURCE"),
+    ("Pyruvate", "CARBON_SOURCE"),
+    ("Sodium succinate", "CARBON_SOURCE"),
+    ("Citric acid", "CARBON_SOURCE"),
+    ("alpha-ketoglutaric acid", "CARBON_SOURCE"),
+    ("Sodium gluconate", "CARBON_SOURCE"),
+    ("Calcium gluconate", "CARBON_SOURCE"),  # benign counterion kept
+    ("Citrate", "CARBON_SOURCE"),            # carbon source (free citrate, no metal)
 ])
 def test_namelist_positive(name, expected):
     assert namelist.infer_role(name) == expected
@@ -144,7 +153,6 @@ def test_namelist_positive(name, expected):
     "Fe(III)-EDTA",            # metal-chelate complex -> iron source, not chelator
     "Sodium ferric EDTA",
     "Ferric citrate monohydrate",
-    "Citrate",                 # ambiguous -> excluded
     "Dimethyl sulfide",        # volatile organosulfide, not a reductant additive
     # extended-category exclusions (matched a token but guarded out)
     "Brucella agar",           # agar-containing complete medium, not pure gelling agent
@@ -155,6 +163,14 @@ def test_namelist_positive(name, expected):
     "4-Deoxypyridoxine",       # antivitamin
     "Lipopolysaccharide",      # endotoxin, not a carbon source
     "Glycerol monostearate",   # emulsifier ester, not a carbon source
+    # organic-acid blocklist: acid is a counterion/ester/complex, not the carbon source
+    "Cadmium acetate dihydrate",   # toxic metal salt
+    "Uranyl acetate",              # toxic metal salt
+    "Ferric citrate monohydrate",  # iron source (metal-citrate complex)
+    "ethyl acetate",               # ester/solvent
+    "Phenyl acetic acid",          # aromatic acid
+    "Indole-3-butyric acid",       # auxin / signaling
+    "(NH4)2 citrate",              # ammonium salt (nitrogen)
 ])
 def test_namelist_excluded(name):
     assert namelist.infer_role(name) is None


### PR DESCRIPTION
## Summary
Pushes into the role-coverage long tail with a curated organic-acid carbon-source rule.

### Coverage 40.2% → 43.2% (+56 roles)
Adds a canonical organic-acid rule to `infer_roles_from_name_lists.py`: TCA/glycolysis/short-chain acids (acetate, lactate, pyruvate, succinate, fumarate, malate, citrate, propionate, butyrate, formate, gluconate, 2-oxoglutarate, glutarate, glycolate, malonate, caproate, octanoate, hydroxybutyrate, quinate, shikimate, …) as `-ate`/`-ic acid` → **CARBON_SOURCE**.

**Why a curated list, not CHEBI ancestry:** ancestry files the common *salt* forms (sodium acetate, pyruvate) under "salt", not carboxylic acid — so it misses them. **Why a blocklist:** name-matching alone over-tags. A metal/ester/aromatic/ammonium blocklist (verified against the full candidate set) excludes:
- toxic-metal acetates — `Cadmium`/`Thallium`/`Uranyl acetate`
- metal-citrate complexes (iron/Mg sources) — `Ferric citrate`, `Mg-citrate`
- esters / ionic liquids — `ethyl acetate`, imidazolium acetate
- aromatic / indole acids — `Phenyl acetic acid`, `Indole-3-butyric acid`
- ammonium salts (nitrogen) — `(NH4)2 citrate`

All 56 matches are individually-vetted clean carbon sources; oxalate was deliberately left out (borderline chelator). **812 roles / 808 records, 0 validation errors.**

The remaining ~1060 unroled records are the genuine residue — complete named media (correctly unroled), and uncharacterized/ambiguous MESH/NCIT/CAS entries that need true per-record curation rather than pattern rules.

## Tests
+8 cases pinning organic-acid positives and the blocklist exclusions; `Citrate` reclassified excluded→CARBON_SOURCE.

## Validation
- `validate_strict.py`: **0 errors / 2274 files**
- `validate_roles.py`: **812 roles, 0 errors, 100% cited**
- Full suite: **295 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)