### PR TITLE
Role QA audit + fix 2 implausible mis-tags + add ENERGY_SOURCE dimension

### DIFF
--- a/data/ingredients/mapped/2-Keto-D-gluconic_Acid_Hemicalcium_Salt_Hydrate.yaml
+++ b/data/ingredients/mapped/2-Keto-D-gluconic_Acid_Hemicalcium_Salt_Hydrate.yaml
@@ -38,6 +38,10 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-04T05:38:59.199997+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 1040352-40-6
   data_source: CultureBotHT compounds_to_cas.csv
@@ -50,3 +54,10 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/2-Keto-D-gluconic_Acid_Hemicalcium_Salt_Monohydrate.yaml
+++ b/data/ingredients/mapped/2-Keto-D-gluconic_Acid_Hemicalcium_Salt_Monohydrate.yaml
@@ -44,6 +44,10 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-04T05:38:59.200328+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 3470-37-9
   data_source: CultureBotHT compounds_to_cas.csv
@@ -60,3 +64,10 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/5-Keto-D-Gluconic_Acid_Potassium_Salt.yaml
+++ b/data/ingredients/mapped/5-Keto-D-Gluconic_Acid_Potassium_Salt.yaml
@@ -53,6 +53,10 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-04T05:38:59.200367+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 91446-96-7
   data_source: CultureBotHT compounds_to_cas.csv
@@ -69,3 +73,10 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/6-O-Acetyl-D-glucose.yaml
+++ b/data/ingredients/mapped/6-O-Acetyl-D-glucose.yaml
@@ -42,6 +42,10 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-04T05:38:59.200375+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 7286-45-5
   data_source: CultureBotHT compounds_to_cas.csv
@@ -57,3 +61,10 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/A-Ketoglutaric_Acid_Disodium_Salt_Hydrate.yaml
+++ b/data/ingredients/mapped/A-Ketoglutaric_Acid_Disodium_Salt_Hydrate.yaml
@@ -49,6 +49,10 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-04T05:38:59.200385+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 305-72-6
   data_source: CultureBotHT compounds_to_cas.csv
@@ -65,3 +69,10 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Acetate.yaml
+++ b/data/ingredients/mapped/Acetate.yaml
@@ -110,6 +110,10 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-04T05:38:59.200392+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 71-50-1
   data_source: PubChem API
@@ -125,3 +129,10 @@ media_roles:
   - reference_type: DATABASE_ENTRY
     reference_text: Imported from CultureMech pipeline
     curator_note: 'Original role text: Carbon Source'
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Acetate_Carbon_Source.yaml
+++ b/data/ingredients/mapped/Acetate_Carbon_Source.yaml
@@ -36,6 +36,10 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-04T05:38:59.200396+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 notes: Imported from communitymech-unmapped (source_id=communitymech.ingredient:Acetate_(carbon_source));
   no CAS-RN or CHEBI/NCIT match. Curator review needed.
 ontology_mapping:
@@ -61,3 +65,10 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Acetic_Acid.yaml
+++ b/data/ingredients/mapped/Acetic_Acid.yaml
@@ -110,6 +110,10 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-04T05:38:59.200400+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 64-19-7
   data_source: PubChem API
@@ -126,3 +130,10 @@ media_roles:
   - reference_type: DATABASE_ENTRY
     reference_text: Imported from CultureMech pipeline
     curator_note: 'Original role text: Carbon Source'
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Alpha-Lactose.yaml
+++ b/data/ingredients/mapped/Alpha-Lactose.yaml
@@ -42,6 +42,10 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-04T05:38:59.200417+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 5989-81-1
   data_source: CultureBotHT compounds_to_cas.csv
@@ -58,4 +62,11 @@ media_roles:
     reference_text: 'Inferred from CHEBI ancestry: subclass/has_role of CHEBI:16646
       (carbohydrate)'
     curator_note: Provisional role inferred from CHEBI is_a/has_role closure; review
+      recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
       recommended.

--- a/data/ingredients/mapped/Alpha-d-glucose.yaml
+++ b/data/ingredients/mapped/Alpha-d-glucose.yaml
@@ -66,6 +66,10 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-04T05:38:59.200422+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 492-62-6
   data_source: PubChem API
@@ -82,4 +86,11 @@ media_roles:
     reference_text: 'Inferred from CHEBI ancestry: subclass/has_role of CHEBI:16646
       (carbohydrate)'
     curator_note: Provisional role inferred from CHEBI is_a/has_role closure; review
+      recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
       recommended.

--- a/data/ingredients/mapped/Alpha-ketoglutaric_Acid.yaml
+++ b/data/ingredients/mapped/Alpha-ketoglutaric_Acid.yaml
@@ -79,6 +79,10 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-04T05:38:59.200426+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 328-50-7
   data_source: PubChem API
@@ -94,3 +98,10 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Arabinose.yaml
+++ b/data/ingredients/mapped/Arabinose.yaml
@@ -78,6 +78,10 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-04T05:38:59.200442+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 226-214-6
   data_source: PubChem API
@@ -91,3 +95,10 @@ media_roles:
   - reference_type: DATABASE_ENTRY
     reference_text: Imported from CultureMech pipeline
     curator_note: 'Original role text: Carbon Source'
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Beta-lactose.yaml
+++ b/data/ingredients/mapped/Beta-lactose.yaml
@@ -75,6 +75,10 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-04T05:38:59.200475+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 notes: Created from FEBA ontology enrichment workflow. Used in 1 FEBA media formulations.
 chemical_properties:
   cas_rn: 5965-66-2
@@ -93,4 +97,11 @@ media_roles:
     reference_text: 'Inferred from CHEBI ancestry: subclass/has_role of CHEBI:16646
       (carbohydrate)'
     curator_note: Provisional role inferred from CHEBI is_a/has_role closure; review
+      recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
       recommended.

--- a/data/ingredients/mapped/Butyric_Acid.yaml
+++ b/data/ingredients/mapped/Butyric_Acid.yaml
@@ -120,6 +120,10 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-04T05:38:59.200486+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 107-92-6
   data_source: PubChem API
@@ -136,3 +140,10 @@ media_roles:
   - reference_type: DATABASE_ENTRY
     reference_text: Imported from CultureMech pipeline
     curator_note: 'Original role text: Carbon Source'
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Cellobiose.yaml
+++ b/data/ingredients/mapped/Cellobiose.yaml
@@ -140,6 +140,10 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-04T05:38:59.200519+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 528-50-7
   data_source: PubChem API
@@ -160,3 +164,10 @@ media_roles:
       Simple component'
     curator_note: Widespread use in media formulations (208 occurrences). High confidence
       based on 'Defined component' property.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Citrate.yaml
+++ b/data/ingredients/mapped/Citrate.yaml
@@ -43,6 +43,10 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-04T05:38:59.200538+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 ingredient_type: SINGLE_INGREDIENT
 chemical_properties:
   molecular_formula: C6H5O7
@@ -56,3 +60,10 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Citric_Acid.yaml
+++ b/data/ingredients/mapped/Citric_Acid.yaml
@@ -100,6 +100,10 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-04T05:38:59.200542+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 77-92-9
   data_source: PubChem API
@@ -115,3 +119,10 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Citric_Acid_X_H2o.yaml
+++ b/data/ingredients/mapped/Citric_Acid_X_H2o.yaml
@@ -63,6 +63,10 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-04T05:38:59.200546+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 5949-29-1
   data_source: PubChem (via CHEBI:31404)
@@ -78,3 +82,10 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Citric_Acidh2o.yaml
+++ b/data/ingredients/mapped/Citric_Acidh2o.yaml
@@ -30,6 +30,10 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-04T05:38:59.200559+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 notes: 'CultureMech placeholder_id: 9'
 ontology_mapping:
   ontology_id: CHEBI:30769
@@ -52,3 +56,10 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/D-Maltose_Monohydrate.yaml
+++ b/data/ingredients/mapped/D-Maltose_Monohydrate.yaml
@@ -62,6 +62,10 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-04T05:38:59.200618+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 6363-53-7
   data_source: CultureBotHT compounds_to_cas.csv
@@ -78,3 +82,10 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/D-Ribose.yaml
+++ b/data/ingredients/mapped/D-Ribose.yaml
@@ -41,6 +41,10 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-04T05:38:59.200629+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 50-69-1
   data_source: CultureBotHT compounds_to_cas.csv
@@ -55,4 +59,11 @@ media_roles:
     reference_text: 'Inferred from CHEBI ancestry: subclass/has_role of CHEBI:16646
       (carbohydrate)'
     curator_note: Provisional role inferred from CHEBI is_a/has_role closure; review
+      recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
       recommended.

--- a/data/ingredients/mapped/D-Sucrose.yaml
+++ b/data/ingredients/mapped/D-Sucrose.yaml
@@ -36,6 +36,10 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-04T05:38:59.200634+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 notes: Imported from mim-queue (source_id=mediadive.ingredient:1358); no CAS-RN or
   CHEBI/NCIT match. Curator review needed.
 ontology_mapping:
@@ -63,4 +67,11 @@ media_roles:
     reference_text: 'Inferred from CHEBI ancestry: subclass/has_role of CHEBI:16646
       (carbohydrate)'
     curator_note: Provisional role inferred from CHEBI is_a/has_role closure; review
+      recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
       recommended.

--- a/data/ingredients/mapped/D-_-gluconic_Acid_Gamma-lactone.yaml
+++ b/data/ingredients/mapped/D-_-gluconic_Acid_Gamma-lactone.yaml
@@ -44,6 +44,10 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-04T05:38:59.200592+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 90-80-2
   data_source: CultureBotHT compounds_to_cas.csv
@@ -59,3 +63,10 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/D-arabinose.yaml
+++ b/data/ingredients/mapped/D-arabinose.yaml
@@ -58,6 +58,10 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-04T05:38:59.200639+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 10323-20-3
   data_source: PubChem API
@@ -72,4 +76,11 @@ media_roles:
     reference_text: 'Inferred from CHEBI ancestry: subclass/has_role of CHEBI:16646
       (carbohydrate)'
     curator_note: Provisional role inferred from CHEBI is_a/has_role closure; review
+      recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
       recommended.

--- a/data/ingredients/mapped/D-fructose.yaml
+++ b/data/ingredients/mapped/D-fructose.yaml
@@ -87,6 +87,10 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-04T05:38:59.200645+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 57-48-7
   data_source: CultureBotHT/compounds_to_cas.csv
@@ -100,3 +104,10 @@ media_roles:
   - reference_type: DATABASE_ENTRY
     reference_text: Imported from CultureMech pipeline
     curator_note: 'Original role text: Carbon Source'
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/D-galactose.yaml
+++ b/data/ingredients/mapped/D-galactose.yaml
@@ -86,6 +86,10 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-04T05:38:59.200649+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 59-23-4
   data_source: CultureBotHT/compounds_to_cas.csv
@@ -100,3 +104,10 @@ media_roles:
   - reference_type: DATABASE_ENTRY
     reference_text: Imported from CultureMech pipeline
     curator_note: 'Original role text: Carbon Source'
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/D-glucose.yaml
+++ b/data/ingredients/mapped/D-glucose.yaml
@@ -114,6 +114,10 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-04T05:38:59.200655+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 50-99-7
   data_source: CultureBotHT/compounds_to_cas.csv
@@ -131,3 +135,10 @@ media_roles:
       Organic compound'
     curator_note: Widespread use in media formulations (710 occurrences). High confidence
       based on 'Defined component' property.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/D-mannose.yaml
+++ b/data/ingredients/mapped/D-mannose.yaml
@@ -84,6 +84,10 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-04T05:38:59.200664+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 530-26-7
   data_source: PubChem API
@@ -97,3 +101,10 @@ media_roles:
   - reference_type: DATABASE_ENTRY
     reference_text: Imported from CultureMech pipeline
     curator_note: 'Original role text: Carbon Source'
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/D-trehalose_Dihydrate.yaml
+++ b/data/ingredients/mapped/D-trehalose_Dihydrate.yaml
@@ -56,6 +56,10 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-04T05:38:59.200689+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 notes: Created from FEBA ontology enrichment workflow. Used in 15 FEBA media formulations.
 chemical_properties:
   cas_rn: 6138-23-4
@@ -72,3 +76,10 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/D-xylose.yaml
+++ b/data/ingredients/mapped/D-xylose.yaml
@@ -74,6 +74,10 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-04T05:38:59.200670+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 58-86-6
   data_source: CultureBotHT/compounds_to_cas.csv
@@ -88,3 +92,10 @@ media_roles:
   - reference_type: DATABASE_ENTRY
     reference_text: Imported from CultureMech pipeline
     curator_note: 'Original role text: Carbon Source'
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Deuterated_Glucose.yaml
+++ b/data/ingredients/mapped/Deuterated_Glucose.yaml
@@ -51,6 +51,10 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-04T05:38:59.200698+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 201417-01-8
   data_source: CultureBotHT compounds_to_cas.csv
@@ -67,3 +71,10 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Dl-malic_Acid.yaml
+++ b/data/ingredients/mapped/Dl-malic_Acid.yaml
@@ -164,6 +164,10 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-04T05:38:59.200724+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 6915-15-7
   data_source: PubChem API
@@ -180,3 +184,10 @@ media_roles:
   - reference_type: DATABASE_ENTRY
     reference_text: Imported from CultureMech pipeline
     curator_note: 'Original role text: Carbon Source'
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Edta_Acid_Form.yaml
+++ b/data/ingredients/mapped/Edta_Acid_Form.yaml
@@ -56,6 +56,17 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: AMINO_ACID_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-04T05:36:05.608816+00:00'
+  curator: drop_implausible_roles
+  action: CORRECTED
+  changes: 'Removed implausible media_role AMINO_ACID_SOURCE: EDTA is a polyamino-polycarboxylic
+    chelator, not an amino-acid nutrient source; the CHEBI ''amino acid'' ancestry
+    rule over-matched it. After this drop the name-list pass re-tags it CHELATOR.'
+  llm_assisted: false
+- timestamp: '2026-06-04T05:36:15.544101+00:00'
+  curator: infer_roles_from_name_lists
+  action: ANNOTATED
+  changes: 'Added media role: CHELATOR (confidence: 0.80)'
 ingredient_type: SINGLE_INGREDIENT
 chemical_properties:
   molecular_formula: C10H16N2O8
@@ -63,11 +74,9 @@ chemical_properties:
 notes: '2026-05-10 SSSOM SYNONYM_ENRICH review: EDTA (acid form) was corrected from
   CHEBI:42191 EDTA(4-) to CHEBI:4735 ethylenediaminetetraacetic acid.'
 media_roles:
-- role: AMINO_ACID_SOURCE
-  confidence: 0.7
+- role: CHELATOR
+  confidence: 0.8
   evidence:
   - reference_type: COMPUTATIONAL_PREDICTION
-    reference_text: 'Inferred from CHEBI ancestry: subclass/has_role of CHEBI:33709
-      (amino acid)'
-    curator_note: Provisional role inferred from CHEBI is_a/has_role closure; review
-      recommended.
+    reference_text: Inferred from curated media-role name pattern
+    curator_note: Provisional role from a curated name-pattern rule; review recommended.

--- a/data/ingredients/mapped/Formic_Acid.yaml
+++ b/data/ingredients/mapped/Formic_Acid.yaml
@@ -89,6 +89,10 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-04T05:38:59.200769+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 64-18-6
   data_source: PubChem API
@@ -104,3 +108,10 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Fructose-asparagine.yaml
+++ b/data/ingredients/mapped/Fructose-asparagine.yaml
@@ -44,6 +44,10 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-04T05:38:59.200778+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 34393-27-6
   data_source: CultureBotHT compounds_to_cas.csv
@@ -60,3 +64,10 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Fructose.yaml
+++ b/data/ingredients/mapped/Fructose.yaml
@@ -109,6 +109,10 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-04T05:38:59.200782+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 53188-23-1
   data_source: PubChem (via CHEBI:28645)
@@ -122,3 +126,10 @@ media_roles:
   - reference_type: DATABASE_ENTRY
     reference_text: Imported from CultureMech pipeline
     curator_note: 'Original role text: Carbon Source'
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Fumaric_Acid.yaml
+++ b/data/ingredients/mapped/Fumaric_Acid.yaml
@@ -118,6 +118,10 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.90)'
+- timestamp: '2026-06-04T05:38:59.200787+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 110-17-8
   data_source: PubChem API
@@ -134,3 +138,10 @@ media_roles:
   - reference_type: DATABASE_ENTRY
     reference_text: Imported from CultureMech pipeline
     curator_note: 'Original role text: Carbon Source'
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Galactose.yaml
+++ b/data/ingredients/mapped/Galactose.yaml
@@ -73,6 +73,10 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-04T05:38:59.200795+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 200-416-4
   data_source: PubChem API
@@ -87,3 +91,10 @@ media_roles:
   - reference_type: DATABASE_ENTRY
     reference_text: Imported from CultureMech pipeline
     curator_note: 'Original role text: Carbon Source'
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Gluconic_Acid.yaml
+++ b/data/ingredients/mapped/Gluconic_Acid.yaml
@@ -46,6 +46,10 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-04T05:38:59.200811+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 526-95-4
   data_source: PubChem API
@@ -60,4 +64,11 @@ media_roles:
     reference_text: 'Inferred from CHEBI ancestry: subclass/has_role of CHEBI:16646
       (carbohydrate)'
     curator_note: Provisional role inferred from CHEBI is_a/has_role closure; review
+      recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
       recommended.

--- a/data/ingredients/mapped/Glucose.yaml
+++ b/data/ingredients/mapped/Glucose.yaml
@@ -123,6 +123,10 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-04T05:38:59.200814+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 50-99-7
   data_source: CultureBotHT/compounds_to_cas.csv
@@ -140,3 +144,10 @@ media_roles:
       Simple component'
     curator_note: Widespread use in media formulations (1638 occurrences). High confidence
       based on 'Defined component' property.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Glucose_2.yaml
+++ b/data/ingredients/mapped/Glucose_2.yaml
@@ -95,6 +95,10 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-04T05:38:59.200818+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 50-99-7
   data_source: CultureBotHT compounds_to_cas.csv
@@ -111,3 +115,10 @@ media_roles:
   - reference_type: DATABASE_ENTRY
     reference_text: Imported from CultureMech pipeline
     curator_note: 'Original role text: Carbon Source'
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Glycerol.yaml
+++ b/data/ingredients/mapped/Glycerol.yaml
@@ -95,6 +95,10 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-04T05:38:59.200827+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 56-81-5
   data_source: CultureBotHT compounds_to_cas.csv
@@ -114,3 +118,10 @@ media_roles:
       Simple component'
     curator_note: Widespread use in media formulations (208 occurrences). High confidence
       based on 'Defined component' property.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Glycerol_2.yaml
+++ b/data/ingredients/mapped/Glycerol_2.yaml
@@ -129,6 +129,10 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-04T05:38:59.200831+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 56-81-5
   data_source: PubChem API
@@ -145,3 +149,10 @@ media_roles:
   - reference_type: DATABASE_ENTRY
     reference_text: Imported from CultureMech pipeline
     curator_note: 'Original role text: Carbon Source'
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/L-Arabinose.yaml
+++ b/data/ingredients/mapped/L-Arabinose.yaml
@@ -41,6 +41,10 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-04T05:38:59.200894+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 5328-37-0
   data_source: CultureBotHT compounds_to_cas.csv
@@ -55,4 +59,11 @@ media_roles:
     reference_text: 'Inferred from CHEBI ancestry: subclass/has_role of CHEBI:16646
       (carbohydrate)'
     curator_note: Provisional role inferred from CHEBI is_a/has_role closure; review
+      recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
       recommended.

--- a/data/ingredients/mapped/L-Galactose.yaml
+++ b/data/ingredients/mapped/L-Galactose.yaml
@@ -41,6 +41,10 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-04T05:38:59.200901+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 15572-79-9
   data_source: CultureBotHT compounds_to_cas.csv
@@ -55,4 +59,11 @@ media_roles:
     reference_text: 'Inferred from CHEBI ancestry: subclass/has_role of CHEBI:16646
       (carbohydrate)'
     curator_note: Provisional role inferred from CHEBI is_a/has_role closure; review
+      recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
       recommended.

--- a/data/ingredients/mapped/L-Malic_Acid.yaml
+++ b/data/ingredients/mapped/L-Malic_Acid.yaml
@@ -44,6 +44,10 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-04T05:38:59.200907+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 97-67-6
   data_source: CultureBotHT compounds_to_cas.csv
@@ -59,3 +63,10 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/L-Malic_Acid_Disodium_Salt_Monohydrate.yaml
+++ b/data/ingredients/mapped/L-Malic_Acid_Disodium_Salt_Monohydrate.yaml
@@ -52,6 +52,10 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-04T05:38:59.200913+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 207511-06-6
   data_source: CultureBotHT compounds_to_cas.csv
@@ -68,3 +72,10 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/L-Xylose.yaml
+++ b/data/ingredients/mapped/L-Xylose.yaml
@@ -41,6 +41,10 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-04T05:38:59.200919+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 0609-06-3
   data_source: CultureBotHT compounds_to_cas.csv
@@ -55,4 +59,11 @@ media_roles:
     reference_text: 'Inferred from CHEBI ancestry: subclass/has_role of CHEBI:16646
       (carbohydrate)'
     curator_note: Provisional role inferred from CHEBI is_a/has_role closure; review
+      recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
       recommended.

--- a/data/ingredients/mapped/Lactate.yaml
+++ b/data/ingredients/mapped/Lactate.yaml
@@ -90,6 +90,10 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-04T05:38:59.200949+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 113-21-3
   data_source: PubChem API
@@ -105,3 +109,10 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Lactose.yaml
+++ b/data/ingredients/mapped/Lactose.yaml
@@ -148,6 +148,10 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-04T05:38:59.200963+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 63-42-3
   data_source: PubChem (via CHEBI:17716)
@@ -163,3 +167,10 @@ media_roles:
   - reference_type: DATABASE_ENTRY
     reference_text: Imported from CultureMech pipeline
     curator_note: 'Original role text: Carbon Source'
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Malate.yaml
+++ b/data/ingredients/mapped/Malate.yaml
@@ -54,6 +54,10 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-04T05:38:59.200992+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 6915-15-7
   data_source: PubChem API
@@ -67,3 +71,10 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Maltose.yaml
+++ b/data/ingredients/mapped/Maltose.yaml
@@ -144,6 +144,10 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-04T05:38:59.201003+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 69-79-4
   data_source: PubChem (via CHEBI:17306)
@@ -159,3 +163,10 @@ media_roles:
   - reference_type: DATABASE_ENTRY
     reference_text: Imported from CultureMech pipeline
     curator_note: 'Original role text: Carbon Source'
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Maltose_2.yaml
+++ b/data/ingredients/mapped/Maltose_2.yaml
@@ -54,6 +54,10 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-04T05:38:59.201006+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 69-79-4
   data_source: PubChem API
@@ -70,3 +74,10 @@ media_roles:
   - reference_type: DATABASE_ENTRY
     reference_text: Imported from CultureMech pipeline
     curator_note: 'Original role text: Carbon Source'
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Mgso47h2o.yaml
+++ b/data/ingredients/mapped/Mgso47h2o.yaml
@@ -143,6 +143,13 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-04T05:34:41.261481+00:00'
+  curator: drop_implausible_roles
+  action: CORRECTED
+  changes: 'Removed implausible media_role BUFFER: MgSO4 is a magnesium-sulfate mineral
+    salt, not a pH buffer; the BUFFER role came from an erroneous CultureMech source
+    synonym. MINERAL role retained.'
+  llm_assisted: false
 chemical_properties:
   cas_rn: 7487-88-9
   data_source: OAK/CHEBI xref
@@ -153,12 +160,6 @@ chemical_properties:
 kg_microbe_node_id: CHEBI:32599
 ingredient_type: SINGLE_INGREDIENT
 media_roles:
-- role: BUFFER
-  confidence: 1.0
-  evidence:
-  - reference_type: DATABASE_ENTRY
-    reference_text: Imported from CultureMech pipeline
-    curator_note: 'Original role text: Buffer'
 - role: MINERAL
   confidence: 1.0
   evidence:

--- a/data/ingredients/mapped/Na-butyrate.yaml
+++ b/data/ingredients/mapped/Na-butyrate.yaml
@@ -153,6 +153,10 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-04T05:38:59.201073+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 156-54-7
   data_source: PubChem API (preprocessed)
@@ -169,3 +173,10 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Na-formate.yaml
+++ b/data/ingredients/mapped/Na-formate.yaml
@@ -145,6 +145,10 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-04T05:38:59.201079+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 141-53-7
   data_source: PubChem API (preprocessed)
@@ -161,3 +165,10 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Na-l-lactate.yaml
+++ b/data/ingredients/mapped/Na-l-lactate.yaml
@@ -119,6 +119,10 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-04T05:38:59.201084+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 867-56-1
   data_source: PubChem API (preprocessed)
@@ -135,3 +139,10 @@ media_roles:
   - reference_type: DATABASE_ENTRY
     reference_text: Imported from CultureMech pipeline
     curator_note: 'Original role text: Carbon Source'
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Na-propionate.yaml
+++ b/data/ingredients/mapped/Na-propionate.yaml
@@ -128,6 +128,10 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-04T05:38:59.201089+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 137-40-6
   data_source: PubChem API (preprocessed)
@@ -143,3 +147,10 @@ media_roles:
   - reference_type: DATABASE_ENTRY
     reference_text: Imported from CultureMech pipeline
     curator_note: 'Original role text: Carbon Source'
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Na-pyruvate.yaml
+++ b/data/ingredients/mapped/Na-pyruvate.yaml
@@ -178,6 +178,10 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-04T05:38:59.201093+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 113-24-6
   data_source: PubChem API (preprocessed)
@@ -198,3 +202,10 @@ media_roles:
       Simple component'
     curator_note: Widespread use in media formulations (570 occurrences). High confidence
       based on 'Defined component' property.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Na2-fumarate.yaml
+++ b/data/ingredients/mapped/Na2-fumarate.yaml
@@ -158,6 +158,10 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-04T05:38:59.201102+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 kg_microbe_node_id: CHEBI:115156
 chemical_properties:
   cas_rn: 17013-01-3
@@ -174,3 +178,10 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Na2_Alpha-ketoglutarate.yaml
+++ b/data/ingredients/mapped/Na2_Alpha-ketoglutarate.yaml
@@ -97,6 +97,10 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-04T05:38:59.201108+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 kg_microbe_node_id: CHEBI:16810
 chemical_properties:
   cas_rn: 64-15-3
@@ -113,3 +117,10 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Propionic_Acid.yaml
+++ b/data/ingredients/mapped/Propionic_Acid.yaml
@@ -97,6 +97,10 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-04T05:38:59.201211+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 79-09-4
   data_source: PubChem API
@@ -113,3 +117,10 @@ media_roles:
   - reference_type: DATABASE_ENTRY
     reference_text: Imported from CultureMech pipeline
     curator_note: 'Original role text: Carbon Source'
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Pyruvate.yaml
+++ b/data/ingredients/mapped/Pyruvate.yaml
@@ -59,6 +59,10 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-04T05:38:59.201229+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 57-60-3
   data_source: PubChem API
@@ -75,3 +79,10 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Pyruvic_Acid.yaml
+++ b/data/ingredients/mapped/Pyruvic_Acid.yaml
@@ -97,6 +97,10 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-04T05:38:59.201233+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 127-17-3
   data_source: PubChem API
@@ -112,3 +116,10 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Ribose.yaml
+++ b/data/ingredients/mapped/Ribose.yaml
@@ -58,6 +58,10 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-04T05:38:59.201245+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 200-059-4
   data_source: PubChem API
@@ -72,4 +76,11 @@ media_roles:
     reference_text: 'Inferred from CHEBI ancestry: subclass/has_role of CHEBI:16646
       (carbohydrate)'
     curator_note: Provisional role inferred from CHEBI is_a/has_role closure; review
+      recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
       recommended.

--- a/data/ingredients/mapped/Sodium_Acetate.yaml
+++ b/data/ingredients/mapped/Sodium_Acetate.yaml
@@ -41,6 +41,10 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-04T05:38:59.201274+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 notes: 'CultureMech placeholder_id: 3'
 chemical_properties:
   cas_rn: 127-09-3
@@ -68,3 +72,10 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Sodium_D-Lactate.yaml
+++ b/data/ingredients/mapped/Sodium_D-Lactate.yaml
@@ -44,6 +44,10 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-04T05:38:59.201284+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 920-49-0
   data_source: CultureBotHT compounds_to_cas.csv
@@ -60,3 +64,10 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Sodium_Gluconate.yaml
+++ b/data/ingredients/mapped/Sodium_Gluconate.yaml
@@ -120,6 +120,10 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-04T05:38:59.201291+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 527-07-1
   data_source: CultureBotHT compounds_to_cas.csv
@@ -136,3 +140,10 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Sodium_L-lactate.yaml
+++ b/data/ingredients/mapped/Sodium_L-lactate.yaml
@@ -51,6 +51,10 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-04T05:38:59.201297+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 867-56-1
   data_source: CultureBotHT compounds_to_cas.csv
@@ -64,3 +68,10 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Sodium_Lactate.yaml
+++ b/data/ingredients/mapped/Sodium_Lactate.yaml
@@ -252,6 +252,10 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-04T05:38:59.201302+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 72-17-3
   data_source: OAK/CHEBI xref
@@ -268,3 +272,10 @@ media_roles:
   - reference_type: DATABASE_ENTRY
     reference_text: Imported from CultureMech pipeline
     curator_note: 'Original role text: Carbon Source'
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Sodium_Malate.yaml
+++ b/data/ingredients/mapped/Sodium_Malate.yaml
@@ -190,6 +190,10 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-04T05:38:59.201306+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 138-09-0
   data_source: OAK/CHEBI xref
@@ -206,3 +210,10 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Sodium_Succinate.yaml
+++ b/data/ingredients/mapped/Sodium_Succinate.yaml
@@ -134,6 +134,10 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-04T05:38:59.201319+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 150-90-3
   data_source: OAK/CHEBI xref
@@ -150,3 +154,10 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Sodium_Succinate_Dibasic.yaml
+++ b/data/ingredients/mapped/Sodium_Succinate_Dibasic.yaml
@@ -65,6 +65,10 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-04T05:38:59.201324+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 150-90-3
   data_source: PubChem API
@@ -81,4 +85,11 @@ media_roles:
     reference_text: 'Inferred from CHEBI ancestry: subclass/has_role of CHEBI:16646
       (carbohydrate)'
     curator_note: Provisional role inferred from CHEBI is_a/has_role closure; review
+      recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
       recommended.

--- a/data/ingredients/mapped/Sodium_succinate_dibasic_hexahydrate.yaml
+++ b/data/ingredients/mapped/Sodium_succinate_dibasic_hexahydrate.yaml
@@ -72,6 +72,10 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-04T05:38:59.201331+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 notes: Created from FEBA ontology enrichment workflow. Used in 11 FEBA media formulations.
 chemical_properties:
   cas_rn: 6106-21-4
@@ -88,3 +92,10 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Succinate.yaml
+++ b/data/ingredients/mapped/Succinate.yaml
@@ -70,6 +70,10 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-04T05:38:59.201348+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 56-14-4
   data_source: PubChem API
@@ -83,3 +87,10 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Succinic_Acid.yaml
+++ b/data/ingredients/mapped/Succinic_Acid.yaml
@@ -108,6 +108,10 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-04T05:38:59.201352+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 110-15-6
   data_source: PubChem API
@@ -124,3 +128,10 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Sucrose.yaml
+++ b/data/ingredients/mapped/Sucrose.yaml
@@ -121,6 +121,10 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-04T05:38:59.201357+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 57-50-1
   data_source: PubChem API
@@ -141,3 +145,10 @@ media_roles:
       Simple component'
     curator_note: Widespread use in media formulations (152 occurrences). High confidence
       based on 'Defined component' property.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Trehalose.yaml
+++ b/data/ingredients/mapped/Trehalose.yaml
@@ -102,6 +102,10 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-04T05:38:59.201386+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 52613-20-4
   data_source: PubChem (via CHEBI:27082)
@@ -117,3 +121,10 @@ media_roles:
   - reference_type: DATABASE_ENTRY
     reference_text: Imported from CultureMech pipeline
     curator_note: 'Original role text: Carbon Source'
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Trisodium_Citrate_X_H2O.yaml
+++ b/data/ingredients/mapped/Trisodium_Citrate_X_H2O.yaml
@@ -26,6 +26,10 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-04T05:38:59.201400+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 notes: Imported from mim-queue (source_id=mediadive.ingredient:1888); no CAS-RN or
   CHEBI/NCIT match. Curator review needed.
 ontology_mapping:
@@ -45,3 +49,10 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/data/ingredients/mapped/Xylose.yaml
+++ b/data/ingredients/mapped/Xylose.yaml
@@ -92,6 +92,10 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-04T05:38:59.201432+00:00'
+  curator: infer_energy_source
+  action: ANNOTATED
+  changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
 chemical_properties:
   cas_rn: 200-400-7
   data_source: PubChem API
@@ -106,3 +110,10 @@ media_roles:
   - reference_type: DATABASE_ENTRY
     reference_text: Imported from CultureMech pipeline
     curator_note: 'Original role text: Carbon Source'
+- role: ENERGY_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: Canonical energy substrate (catabolised for energy)
+    curator_note: Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review
+      recommended.

--- a/scripts/audit_role_plausibility.py
+++ b/scripts/audit_role_plausibility.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Audit media_roles for chemically-implausible assignments.
+
+Most roles come from precise inference (synonym `Role:` text, CHEBI ancestry, or
+curated name lists) and are self-consistent. The exception is roles imported from
+CultureMech `Role:` synonym annotations, which occasionally carry source errors
+(e.g. MgSO4 tagged BUFFER). This flags any assignment whose ingredient name matches
+NONE of the plausible-name tokens for its assigned role — candidates for review.
+
+It is a heuristic flagger for humans, not an auto-fixer. Run after role changes.
+
+Usage:
+    python scripts/audit_role_plausibility.py
+"""
+
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+DATA = Path("data/curated/mapped_ingredients.yaml")
+
+# Per-role plausible-name tokens. Only NARROW-definition roles are audited:
+# their chemistry is specific enough that a name matching none of these tokens is
+# a real red flag. CARBON_SOURCE / MINERAL / SALT / NITROGEN_SOURCE / ENERGY_SOURCE
+# are intentionally NOT audited — they span too many chemical classes (sugars,
+# acids, alcohols, hydrocarbons, amines, polysaccharides, salts, ...) for a
+# name-token rule to be meaningful.
+PLAUSIBLE = {
+    # acetate/citrate/succinate/glycine are legitimate buffer systems.
+    "BUFFER": r"(HEPES|MOPS|MES|PIPES|TRICINE|BICINE|TAPS|CAPS|\bTES\b|EPPS|ACES|"
+              r"\bTris\b|morpholino|piperazine|buffer|bicarbonate|carbonate|"
+              r"phosphate|HCO3|CO3|PO4|citrate|acet(ate|ic)|succin|glycine|"
+              r"glycylglycine|borate|barbital|cacodylate|imidazole|maleate|"
+              r"\bMOPSO\b)",
+    "SOLIDIFYING_AGENT": r"(agar|agarose|gellan|gelrite|gelzan|phytagel|carrageenan|"
+                         r"alginate|gelatin)",
+    "REDUCING_AGENT": r"(sulfide|sulphide|dithionite|dithiothreitol|\bDTT\b|mercapto|"
+                      r"thioglycol|\bTCEP\b|cysteine|sulfite|sulphite|ascorb|"
+                      r"titanium|thiosulf|\bNa2S\b|SO3|S2O3)",
+    "CHELATOR": r"(EDTA|EGTA|DTPA|nitrilotriacetic|\bNTA\b|desferri|deferox|chelat)",
+    "VITAMIN_SOURCE": r"(vitamin|biotin|thiamin|riboflavin|niacin|nicotin|pyridox|"
+                      r"cobalamin|folic|folate|folin|pantothen|lipoic|thioctic|"
+                      r"menaquinone|menadione|aminobenzoic|\bPABA\b|inositol|ascorb|"
+                      r"tocopherol|retinol|calciferol|hemin|haemin|protoporphyrin|"
+                      r"\bFAD\b|\bNAD\b|coenzyme|cobamide|pteroyl)",
+    # standard 20 + common non-proteinogenic amino acids (CHEBI's "amino acid"
+    # class, which the ancestry rule uses, is broader than the proteinogenic set).
+    "AMINO_ACID_SOURCE": r"(alanine|arginine|asparagin|aspart|cysteine|cystine|"
+                         r"glutam|glycine|histidine|isoleucine|leucine|lysine|"
+                         r"methionine|phenylalanine|proline|serine|threonine|"
+                         r"tryptophan|tyrosine|valine|ornithine|citrulline|"
+                         r"amino.*acid|amino.*caproic|aminobutyr|aminovaleric|"
+                         r"aminolevulinic|aminosalicylic|sarcosine|anthranil|"
+                         r"alliin|levodopa|\bdopa\b|homoserine|homocysteine|"
+                         r"canavanine|ergothioneine|aminocyclopropane|carboxylate)",
+    "PROTEIN_SOURCE": r"(peptone|tryptone|tryptose|trypticase|casitone|casamino|"
+                      r"casein|hydrolysate|digest|extract|infusion|\bbeef\b|yeast|"
+                      r"liver|gelatin|proteose|lysate|albumin|mucin|collagen|"
+                      r"protein|brain heart|\bBHI\b)",
+}
+
+
+def find_implausible(data: dict) -> list[tuple[str, str, str, list[str]]]:
+    """Return (role, name, identifier, sources) for assignments whose name matches
+    none of the plausible-name tokens for the assigned (narrow-definition) role."""
+    flagged = []
+    for r in data["ingredients"]:
+        name = r.get("preferred_term", "")
+        for m in r.get("media_roles", []):
+            role = m.get("role")
+            pat = PLAUSIBLE.get(role)
+            if pat and not re.search(pat, name, re.I):
+                srcs = sorted(
+                    {
+                        e.get("source") or e.get("reference_text", "")[:40]
+                        for e in m.get("evidence", [])
+                    }
+                )
+                flagged.append((role, name, r["identifier"], srcs))
+    return flagged
+
+
+def main() -> int:
+    data = yaml.safe_load(DATA.read_text())
+    flagged = find_implausible(data)
+
+    print(f"Audited roles with plausibility rules: {sorted(PLAUSIBLE)}")
+    print(f"Flagged (name matches no plausible token for its role): {len(flagged)}\n")
+    for role, name, ident, srcs in sorted(flagged):
+        print(f"  [{role}] {name!r} ({ident})  <= {srcs}")
+    return 1 if flagged else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/drop_implausible_roles.py
+++ b/scripts/drop_implausible_roles.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Drop specific chemically-implausible media_role assignments (with audit trail).
+
+Some roles were imported from CultureMech `Role:` synonym annotations that carry
+source errors (surfaced by scripts/audit_role_plausibility.py). This removes the
+listed (preferred_term, identifier, role) assignments and records a CORRECTED
+curation_history event. Idempotent: a role already absent is skipped.
+
+Usage:
+    python scripts/drop_implausible_roles.py [--dry-run]
+"""
+
+import argparse
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from mediaingredientmech.curation.ingredient_curator import IngredientCurator
+
+# (preferred_term, identifier, role, reason)
+DROPS = [
+    (
+        "MgSO4·7H2O",
+        "CHEBI:32599",
+        "BUFFER",
+        "MgSO4 is a magnesium-sulfate mineral salt, not a pH buffer; the BUFFER role "
+        "came from an erroneous CultureMech source synonym. MINERAL role retained.",
+    ),
+    (
+        "EDTA (acid form)",
+        "CHEBI:4735",
+        "AMINO_ACID_SOURCE",
+        "EDTA is a polyamino-polycarboxylic chelator, not an amino-acid nutrient "
+        "source; the CHEBI 'amino acid' ancestry rule over-matched it. After this "
+        "drop the name-list pass re-tags it CHELATOR.",
+    ),
+]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    curator = IngredientCurator(
+        data_path=Path("data/curated/mapped_ingredients.yaml"),
+        curator_name="drop_implausible_roles",
+    )
+    curator.load()
+    ts = datetime.now(timezone.utc).isoformat()
+    by_key = {(r.get("preferred_term"), r.get("identifier")): r for r in curator.records}
+
+    n = 0
+    for pt, ident, role, reason in DROPS:
+        record = by_key.get((pt, ident))
+        if record is None:
+            print(f"  SKIP: no record {pt!r} ({ident})")
+            continue
+        roles = record.get("media_roles", [])
+        kept = [m for m in roles if m.get("role") != role]
+        if len(kept) == len(roles):
+            print(f"  SKIP: {pt!r} has no {role} role")
+            continue
+        record["media_roles"] = kept
+        record.setdefault("curation_history", []).append(
+            {
+                "timestamp": ts,
+                "curator": "drop_implausible_roles",
+                "action": "CORRECTED",
+                "changes": f"Removed implausible media_role {role}: {reason}",
+                "llm_assisted": False,
+            }
+        )
+        print(f"  {pt}: dropped {role}")
+        n += 1
+
+    if not args.dry_run:
+        curator.save()
+        print(f"\nSaved; dropped {n} role(s).")
+    else:
+        print(f"\n[dry-run] would drop {n} role(s).")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/drop_implausible_roles.py
+++ b/scripts/drop_implausible_roles.py
@@ -12,11 +12,11 @@ Usage:
 
 import argparse
 import sys
-from datetime import datetime, timezone
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
+from mediaingredientmech.curate.curation_event import record_curation_event
 from mediaingredientmech.curation.ingredient_curator import IngredientCurator
 
 # (preferred_term, identifier, role, reason)
@@ -49,7 +49,6 @@ def main() -> None:
         curator_name="drop_implausible_roles",
     )
     curator.load()
-    ts = datetime.now(timezone.utc).isoformat()
     by_key = {(r.get("preferred_term"), r.get("identifier")): r for r in curator.records}
 
     n = 0
@@ -64,14 +63,11 @@ def main() -> None:
             print(f"  SKIP: {pt!r} has no {role} role")
             continue
         record["media_roles"] = kept
-        record.setdefault("curation_history", []).append(
-            {
-                "timestamp": ts,
-                "curator": "drop_implausible_roles",
-                "action": "CORRECTED",
-                "changes": f"Removed implausible media_role {role}: {reason}",
-                "llm_assisted": False,
-            }
+        record_curation_event(
+            record,
+            curator="drop_implausible_roles",
+            action="CORRECTED",
+            changes=f"Removed implausible media_role {role}: {reason}",
         )
         print(f"  {pt}: dropped {role}")
         n += 1

--- a/scripts/infer_energy_source.py
+++ b/scripts/infer_energy_source.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Add an ENERGY_SOURCE dimension to canonical energy substrates.
+
+media_roles currently carry a single functional axis; most catabolic substrates
+are tagged only CARBON_SOURCE. This adds ENERGY_SOURCE as a SECOND role to the
+textbook fermentable/respirable energy substrates that already hold CARBON_SOURCE
+— glycolytic/TCA organic acids, common fermentable sugars, and ethanol/glycerol.
+
+Deliberately conservative: only substrates microbiologists routinely describe as
+energy sources are included, so ENERGY_SOURCE stays meaningful rather than being
+stamped on every carbon-bearing compound. Records are required to already have a
+CARBON_SOURCE role (so we only add the second axis to confirmed carbon sources).
+Idempotent: a record already carrying ENERGY_SOURCE is skipped.
+
+Usage:
+    python scripts/infer_energy_source.py [--dry-run]
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from mediaingredientmech.curation.ingredient_curator import IngredientCurator
+
+# Canonical energy substrates (word-boundaried). Acids match -ate/-ic forms.
+ENERGY = re.compile(
+    r"\b("
+    # glycolytic / TCA / fermentation acids
+    r"acet(ate|ic)|lact(ate|ic)|pyruv(ate|ic)|succin(ate|ic)|fumar(ate|ic)|"
+    r"mal(ate|ic)|citr(ate|ic)|propion(ate|ic)|butyr(ate|ic)|form(ate|ic)|"
+    r"glucon(ate|ic)|oxoglutar(ate|ic)|ketoglutar(ate|ic)|"
+    # common fermentable sugars
+    r"glucose|fructose|galactose|mannose|sucrose|maltose|lactose|trehalose|"
+    r"cellobiose|xylose|arabinose|ribose|"
+    # alcohols
+    r"ethanol|glycerol"
+    r")\b",
+    re.I,
+)
+# Don't treat non-metabolizable analogs / esters as energy substrates:
+# sugar phosphates, fatty-acid esters, and non-metabolizable glucose analogs
+# (2-deoxyglucose, 3-O-methylglucose — transport tracers, not catabolized).
+ENERGY_EXCL = re.compile(
+    r"(phosphate|oleate|stearate|palmitate|monostearate|deoxy|o-methyl)", re.I
+)
+
+
+def is_energy_substrate(name: str) -> bool:
+    return bool(ENERGY.search(name)) and not ENERGY_EXCL.search(name)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    curator = IngredientCurator(
+        data_path=Path("data/curated/mapped_ingredients.yaml"),
+        curator_name="infer_energy_source",
+    )
+    curator.load()
+
+    added = []
+    for record in curator.records:
+        roles = {m.get("role") for m in record.get("media_roles", [])}
+        if "CARBON_SOURCE" not in roles or "ENERGY_SOURCE" in roles:
+            continue
+        if not is_energy_substrate(record.get("preferred_term", "")):
+            continue
+        added.append(record["preferred_term"])
+        if not args.dry_run:
+            curator.add_media_role(
+                record,
+                role="ENERGY_SOURCE",
+                confidence=0.7,
+                reference_text="Canonical energy substrate (catabolised for energy)",
+                reference_type="COMPUTATIONAL_PREDICTION",
+                curator_note="Provisional ENERGY_SOURCE added alongside CARBON_SOURCE; review recommended.",
+            )
+
+    if not args.dry_run:
+        curator.save()
+
+    print(f"ENERGY_SOURCE added to {len(added)} records" + (" (DRY RUN)" if args.dry_run else ""))
+    for x in sorted(added):
+        print("  ", x)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_role_inference.py
+++ b/tests/test_role_inference.py
@@ -27,6 +27,7 @@ def _load(module_name: str):
 syn = _load("extract_roles_from_synonyms")
 chebi = _load("infer_roles_from_chebi")
 namelist = _load("infer_roles_from_name_lists")
+energy = _load("infer_energy_source")
 
 
 # --- extract_roles_from_synonyms.extract_role_from_synonym -------------------
@@ -147,6 +148,25 @@ def test_chebi_precedence_vitamin_over_nothing():
 ])
 def test_namelist_positive(name, expected):
     assert namelist.infer_role(name) == expected
+
+
+@pytest.mark.parametrize("name", [
+    "D-Glucose", "Sodium acetate", "Sodium L-lactate", "D-Sucrose", "Glycerol",
+    "Pyruvate", "Citric acid", "Fumaric acid",
+])
+def test_energy_substrate_positive(name):
+    assert energy.is_energy_substrate(name) is True
+
+
+@pytest.mark.parametrize("name", [
+    "3-O-methyl-glucose",      # non-metabolizable transport tracer
+    "2-Deoxy-D-glucose",       # non-metabolizable analog
+    "Glucose-6-phosphate",     # phosphorylated, not the plain energy substrate
+    "Sodium oleate",           # fatty-acid, excluded
+    "NaCl",                    # not an energy substrate at all
+])
+def test_energy_substrate_excluded(name):
+    assert energy.is_energy_substrate(name) is False
 
 
 @pytest.mark.parametrize("name", [

--- a/tests/test_role_plausibility.py
+++ b/tests/test_role_plausibility.py
@@ -1,0 +1,34 @@
+"""Guard test: no chemically-implausible media_role assignments in the curated data.
+
+Runs the narrow-definition role plausibility audit (scripts/audit_role_plausibility.py)
+over the curated collection and asserts it finds nothing. Catches regressions like a
+mineral salt tagged BUFFER or a chelator tagged AMINO_ACID_SOURCE.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+
+def _load_audit():
+    spec = importlib.util.spec_from_file_location(
+        "audit_role_plausibility", ROOT / "scripts" / "audit_role_plausibility.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_no_implausible_role_assignments():
+    audit = _load_audit()
+    data = yaml.safe_load((ROOT / "data" / "curated" / "mapped_ingredients.yaml").read_text())
+    flagged = audit.find_implausible(data)
+    assert flagged == [], (
+        "Chemically-implausible media_role assignments found:\n"
+        + "\n".join(f"  [{role}] {name} ({ident}) <- {srcs}" for role, name, ident, srcs in flagged)
+    )


### PR DESCRIPTION
## Summary
Two follow-ups: a quick QA fix that defends the existing roles, and an additive ENERGY_SOURCE dimension.

### 1. Role QA audit + fixes
New `audit_role_plausibility.py` flags `media_role` assignments whose ingredient name matches none of the plausible-name tokens for its **narrow-definition** role (BUFFER/SOLIDIFYING/REDUCING/CHELATOR/VITAMIN/AMINO_ACID/PROTEIN — CARBON/MINERAL span too many chemical classes to audit by name). It surfaced exactly two genuine mis-tags, both fixed:
- **`MgSO4·7H2O`** was tagged `BUFFER` from a bad CultureMech source synonym — MgSO4 is a mineral salt, not a buffer. Dropped (MINERAL retained).
- **`EDTA (acid form)`** was tagged `AMINO_ACID_SOURCE` — the broad CHEBI "amino acid" ancestry rule over-matched this polyamino-carboxylic **chelator**; re-tagged `CHELATOR`.

The other audit flags were all genuine (non-proteinogenic amino acids like GABA/sarcosine/canavanine; acetate-as-buffer; sulfite-as-reductant) — the token lists were completed to recognize them. A new **`test_role_plausibility.py`** asserts the curated data has zero implausible roles, so this can't regress.

### 2. ENERGY_SOURCE dimension
`infer_energy_source.py` adds `ENERGY_SOURCE` as a second role to records already holding `CARBON_SOURCE` that match a tight textbook energy-substrate set (glycolytic/TCA acids, common fermentable sugars, ethanol/glycerol). Non-metabolizable analogs (2-deoxy-/3-O-methyl-glucose), sugar phosphates and fatty-acid esters are excluded so the role stays meaningful. **+78 roles; multi-role records 4 → 81.**

## Validation
- `validate_strict.py`: **0 errors / 2274 files**
- `validate_roles.py`: **889 roles, 0 errors**; plausibility audit: **0 flags**
- Full suite: **308 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)