### PR TITLE
occurrence_statistics audit + backfill; KGX & unmapped-mix assessment

### DIFF
--- a/data/ingredients/mapped/Casein_hydrolysate.yaml
+++ b/data/ingredients/mapped/Casein_hydrolysate.yaml
@@ -25,6 +25,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: PROTEIN_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-08T23:23:58.335244+00:00'
+  curator: audit_occurrence_stats
+  action: CORRECTED
+  changes: 'Backfilled missing occurrence_statistics (0/0): ontology-derived record
+    with no tracked media occurrences.'
 ingredient_type: UNDEFINED_MIXTURE
 media_roles:
 - role: PROTEIN_SOURCE
@@ -33,3 +38,6 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+occurrence_statistics:
+  total_occurrences: 0
+  media_count: 0

--- a/data/ingredients/mapped/Dibenzofuran.yaml
+++ b/data/ingredients/mapped/Dibenzofuran.yaml
@@ -55,9 +55,17 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-08T23:23:58.335565+00:00'
+  curator: audit_occurrence_stats
+  action: CORRECTED
+  changes: 'Backfilled missing occurrence_statistics (0/0): ontology-derived record
+    with no tracked media occurrences.'
 ingredient_type: SINGLE_INGREDIENT
 chemical_properties:
   molecular_formula: C12H8O
   inchi: InChI=1S/C12H8O/c1-3-7-11-9(5-1)10-6-2-4-8-12(10)13-11/h1-8H
   smiles: c1ccc2c(c1)oc1ccccc12
   data_source: CHEBI sqlite (oaklib)
+occurrence_statistics:
+  total_occurrences: 0
+  media_count: 0

--- a/data/ingredients/mapped/Fish_peptone.yaml
+++ b/data/ingredients/mapped/Fish_peptone.yaml
@@ -25,6 +25,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: PROTEIN_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-08T23:23:58.335569+00:00'
+  curator: audit_occurrence_stats
+  action: CORRECTED
+  changes: 'Backfilled missing occurrence_statistics (0/0): ontology-derived record
+    with no tracked media occurrences.'
 ingredient_type: UNDEFINED_MIXTURE
 media_roles:
 - role: PROTEIN_SOURCE
@@ -33,3 +38,6 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+occurrence_statistics:
+  total_occurrences: 0
+  media_count: 0

--- a/data/ingredients/mapped/Fluoranthene.yaml
+++ b/data/ingredients/mapped/Fluoranthene.yaml
@@ -55,9 +55,17 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-08T23:23:58.335571+00:00'
+  curator: audit_occurrence_stats
+  action: CORRECTED
+  changes: 'Backfilled missing occurrence_statistics (0/0): ontology-derived record
+    with no tracked media occurrences.'
 ingredient_type: SINGLE_INGREDIENT
 chemical_properties:
   molecular_formula: C16H10
   inchi: InChI=1S/C16H10/c1-2-8-13-12(7-1)14-9-3-5-11-6-4-10-15(13)16(11)14/h1-10H
   smiles: c1ccc2c(c1)-c1cccc3cccc-2c13
   data_source: CHEBI sqlite (oaklib)
+occurrence_statistics:
+  total_occurrences: 0
+  media_count: 0

--- a/data/ingredients/mapped/Meat_peptone.yaml
+++ b/data/ingredients/mapped/Meat_peptone.yaml
@@ -25,6 +25,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: PROTEIN_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-08T23:23:58.335573+00:00'
+  curator: audit_occurrence_stats
+  action: CORRECTED
+  changes: 'Backfilled missing occurrence_statistics (0/0): ontology-derived record
+    with no tracked media occurrences.'
 ingredient_type: UNDEFINED_MIXTURE
 media_roles:
 - role: PROTEIN_SOURCE
@@ -33,3 +38,6 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+occurrence_statistics:
+  total_occurrences: 0
+  media_count: 0

--- a/data/ingredients/mapped/Mncl2.yaml
+++ b/data/ingredients/mapped/Mncl2.yaml
@@ -88,6 +88,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 0.80)'
+- timestamp: '2026-06-08T23:23:58.335577+00:00'
+  curator: audit_occurrence_stats
+  action: CORRECTED
+  changes: 'Backfilled missing occurrence_statistics (0/0): ontology-derived record
+    with no tracked media occurrences.'
 ingredient_type: SINGLE_INGREDIENT
 chemical_properties:
   molecular_formula: Cl2Mn
@@ -101,3 +106,6 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+occurrence_statistics:
+  total_occurrences: 0
+  media_count: 0

--- a/data/ingredients/mapped/Mncl2_X_2_H2o.yaml
+++ b/data/ingredients/mapped/Mncl2_X_2_H2o.yaml
@@ -66,6 +66,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 0.80)'
+- timestamp: '2026-06-08T23:23:58.335575+00:00'
+  curator: audit_occurrence_stats
+  action: CORRECTED
+  changes: 'Backfilled missing occurrence_statistics (0/0): ontology-derived record
+    with no tracked media occurrences.'
 ingredient_type: SINGLE_INGREDIENT
 chemical_properties:
   molecular_formula: Cl2Mn.2H2O
@@ -79,3 +84,6 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+occurrence_statistics:
+  total_occurrences: 0
+  media_count: 0

--- a/data/ingredients/mapped/Na2b4o7_X_10_H2o.yaml
+++ b/data/ingredients/mapped/Na2b4o7_X_10_H2o.yaml
@@ -74,9 +74,17 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-08T23:23:58.335578+00:00'
+  curator: audit_occurrence_stats
+  action: CORRECTED
+  changes: 'Backfilled missing occurrence_statistics (0/0): ontology-derived record
+    with no tracked media occurrences.'
 ingredient_type: SINGLE_INGREDIENT
 chemical_properties:
   molecular_formula: 10H2O.H4B4O9.2Na
   inchi: InChI=1S/B4H4O9.2Na.10H2O/c5-1-9-3(7)11-2(6)12-4(8,10-1)13-3;;;;;;;;;;;;/h5-8H;;;10*1H2/q-2;2*+1;;;;;;;;;;
   smiles: O.O.O.O.O.O.O.O.O.O.[H]OB1O[B-]2(O[H])OB(O[H])O[B-](O[H])(O1)O2.[Na+].[Na+]
   data_source: CHEBI sqlite (oaklib)
+occurrence_statistics:
+  total_occurrences: 0
+  media_count: 0

--- a/data/ingredients/mapped/Peptone.yaml
+++ b/data/ingredients/mapped/Peptone.yaml
@@ -25,6 +25,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: PROTEIN_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-08T23:23:58.335580+00:00'
+  curator: audit_occurrence_stats
+  action: CORRECTED
+  changes: 'Backfilled missing occurrence_statistics (0/0): ontology-derived record
+    with no tracked media occurrences.'
 ingredient_type: UNDEFINED_MIXTURE
 media_roles:
 - role: PROTEIN_SOURCE
@@ -33,3 +38,6 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+occurrence_statistics:
+  total_occurrences: 0
+  media_count: 0

--- a/data/ingredients/mapped/Proteose_Peptone_No_2.yaml
+++ b/data/ingredients/mapped/Proteose_Peptone_No_2.yaml
@@ -25,6 +25,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: PROTEIN_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-08T23:23:58.335582+00:00'
+  curator: audit_occurrence_stats
+  action: CORRECTED
+  changes: 'Backfilled missing occurrence_statistics (0/0): ontology-derived record
+    with no tracked media occurrences.'
 ingredient_type: UNDEFINED_MIXTURE
 media_roles:
 - role: PROTEIN_SOURCE
@@ -33,3 +38,6 @@ media_roles:
   - reference_type: COMPUTATIONAL_PREDICTION
     reference_text: Inferred from curated media-role name pattern
     curator_note: Provisional role from a curated name-pattern rule; review recommended.
+occurrence_statistics:
+  total_occurrences: 0
+  media_count: 0

--- a/notes/audit_2026-06-08_occstats_kgx_unmapped.md
+++ b/notes/audit_2026-06-08_occstats_kgx_unmapped.md
@@ -1,0 +1,39 @@
+# Audit pass 2026-06-08 — occurrence stats / KGX / high-occurrence unmapped
+
+## 1. occurrence_statistics audit — FIXED
+New `scripts/audit_occurrence_stats.py` (`--check` CI gate / `--fix`). The corpus was
+otherwise consistent (0 REJECTED-with-occurrences, 0 negatives, 0 media_count >
+total_occurrences). The one issue: **10 records had `occurrence_statistics: null`** —
+all ontology-derived (`AUTO_CREATE_FROM_MICRO` / CHEBI) records that were never tracked
+in media counting (peptone variants, MnCl2/borate, two PAHs). Backfilled to `0/0` with a
+`CORRECTED` curation event. `tests/test_occurrence_stats.py` now guards this.
+
+(Note: ~1211 MAPPED records legitimately have 0 occurrences — many CultureBotHT compounds
+are catalogued but unused in any medium. That is expected, not an inconsistency.)
+
+## 2. KGX export refresh — N/A (no export exists)
+There is **no KGX / Biolink edge export in the repo** (grep for biolink/kgx/has_part/
+edges.tsv/nodes.tsv finds only a curie_map mention in `validate_sssom_invariants.py`).
+The earlier memory note referenced a `kgx_export.py` that is not present here (likely a
+CultureMech tool or never committed). "Refresh" is therefore not applicable; building a
+KGX exporter is a new feature, out of scope for this audit pass. The SSSOM set
+(`mappings/ingredient_mappings.sssom.tsv`) is the current machine-readable export and is
+kept current by `reconcile_sssom.py` + its CI gate.
+
+## 3. High-occurrence unmapped mixes — reviewed, correctly unmapped
+The highest-occurrence unmapped records are legitimately unmappable and already correctly
+classified; no clean action exists:
+- **Placeholders** — `Full composition available at source database` (occ 196),
+  `See source for composition` (143): media whose recipe wasn't parsed; correctly
+  `UNDEFINED_MIXTURE`. Not real ingredients (cf. the removed CHEBI:1 artifact) but they
+  carry the "composition unavailable" signal for those media, so retained.
+- **Defined stock solutions** — Wolfe's vitamin/mineral mix + ATCC variants (61/60/46/43),
+  `Mc_*` salt/vitamin mixes, `P-IV Metal Solution`, `MOPS_2M_pH7` (`STOCK_SOLUTION`): multi-
+  component recipes with **no single ontology term** and **no stashed KG source_id**
+  (checked — all NONE), so they cannot be mapped to a chemical ontology or promoted to a
+  `kgmicrobe.solution:` node. Correctly classified.
+- **Defined media** — `ZMB_ALS`, `MoLS4` (`DEFINED_MEDIUM`): complete media, not ingredients.
+- **Undefined mixtures** — `Sea salts`, `Vitamin B`: no single term.
+
+Conclusion: these need recipe-level decomposition (out of scope) to become structured, not
+an ontology mapping. Classifications verified correct; no changes made.

--- a/scripts/audit_occurrence_stats.py
+++ b/scripts/audit_occurrence_stats.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Audit (and optionally fix) occurrence_statistics consistency in the curated set.
+
+Checks every record for:
+  MISSING         — occurrence_statistics absent or total_occurrences is null
+  REJECTED_NONZERO — a REJECTED (merged) record still reporting occurrences
+                     (counts should have been transferred to its representative)
+  NEGATIVE        — negative total_occurrences / media_count
+  MEDIA_GT_OCC    — media_count greater than total_occurrences (impossible)
+
+--check (default) prints issues and exits 1 if any (CI gate).
+--fix backfills MISSING records with total_occurrences=0 / media_count=0 (these
+are ontology-derived records that were never tracked in media counting) and records
+a curation event. It does NOT touch the other categories — those need judgement.
+
+Usage:
+    python scripts/audit_occurrence_stats.py
+    python scripts/audit_occurrence_stats.py --fix
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from mediaingredientmech.curate.curation_event import record_curation_event
+from mediaingredientmech.curation.ingredient_curator import IngredientCurator
+
+DATA = Path("data/curated/mapped_ingredients.yaml")
+
+
+def find_issues(records: list[dict]) -> dict[str, list]:
+    issues = {"missing": [], "rejected_nonzero": [], "negative": [], "media_gt_occ": []}
+    for r in records:
+        ident = r.get("identifier")
+        st = r.get("occurrence_statistics")
+        occ = (st or {}).get("total_occurrences")
+        mc = (st or {}).get("media_count")
+        if st is None or occ is None:
+            issues["missing"].append(ident)
+            continue
+        if r.get("mapping_status") == "REJECTED" and occ > 0:
+            issues["rejected_nonzero"].append((ident, occ))
+        if occ < 0 or (mc or 0) < 0:
+            issues["negative"].append((ident, occ, mc))
+        if mc is not None and mc > occ:
+            issues["media_gt_occ"].append((ident, occ, mc))
+    return issues
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fix", action="store_true", help="Backfill MISSING with 0/0")
+    args = parser.parse_args()
+
+    curator = IngredientCurator(data_path=DATA, curator_name="audit_occurrence_stats")
+    curator.load()
+    issues = find_issues(curator.records)
+
+    print("occurrence_statistics audit:")
+    for k in ("missing", "rejected_nonzero", "negative", "media_gt_occ"):
+        print(f"  {k}: {len(issues[k])}", issues[k][:8] if issues[k] else "")
+
+    if not args.fix:
+        total = sum(len(v) for v in issues.values())
+        if total == 0:
+            print("\nOK: occurrence_statistics are consistent.")
+            return 0
+        print(f"\n{total} issue(s). Backfill MISSING with --fix; resolve others by hand.")
+        return 1
+
+    by_ident = {r.get("identifier"): r for r in curator.records}
+    n = 0
+    for ident in issues["missing"]:
+        rec = by_ident[ident]
+        rec["occurrence_statistics"] = {"total_occurrences": 0, "media_count": 0}
+        record_curation_event(
+            rec,
+            curator="audit_occurrence_stats",
+            action="CORRECTED",
+            changes="Backfilled missing occurrence_statistics (0/0): ontology-derived "
+            "record with no tracked media occurrences.",
+        )
+        n += 1
+    curator.save()
+    print(f"\nBackfilled {n} record(s). (Other categories, if any, left for manual review.)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/audit_occurrence_stats.py
+++ b/scripts/audit_occurrence_stats.py
@@ -35,16 +35,21 @@ def find_issues(records: list[dict]) -> dict[str, list]:
     for r in records:
         ident = r.get("identifier")
         st = r.get("occurrence_statistics")
-        occ = (st or {}).get("total_occurrences")
-        mc = (st or {}).get("media_count")
-        if st is None or occ is None:
+        # Treat absent, non-mapping, or partially-populated stats as MISSING; the
+        # later numeric checks then only run when both counts are present.
+        if not isinstance(st, dict):
+            issues["missing"].append(ident)
+            continue
+        occ = st.get("total_occurrences")
+        mc = st.get("media_count")
+        if occ is None or mc is None:
             issues["missing"].append(ident)
             continue
         if r.get("mapping_status") == "REJECTED" and occ > 0:
             issues["rejected_nonzero"].append((ident, occ))
-        if occ < 0 or (mc or 0) < 0:
+        if occ < 0 or mc < 0:
             issues["negative"].append((ident, occ, mc))
-        if mc is not None and mc > occ:
+        if mc > occ:
             issues["media_gt_occ"].append((ident, occ, mc))
     return issues
 
@@ -74,7 +79,13 @@ def main() -> int:
     n = 0
     for ident in issues["missing"]:
         rec = by_ident[ident]
-        rec["occurrence_statistics"] = {"total_occurrences": 0, "media_count": 0}
+        st = rec.get("occurrence_statistics")
+        st = st if isinstance(st, dict) else {}
+        # Preserve any value that is present; only fill the missing count(s).
+        rec["occurrence_statistics"] = {
+            "total_occurrences": st.get("total_occurrences") or 0,
+            "media_count": st.get("media_count") or 0,
+        }
         record_curation_event(
             rec,
             curator="audit_occurrence_stats",

--- a/tests/test_occurrence_stats.py
+++ b/tests/test_occurrence_stats.py
@@ -1,0 +1,34 @@
+"""Guard test: occurrence_statistics stay consistent in the curated collection.
+
+Asserts no record is missing occurrence_statistics, no REJECTED record reports
+occurrences, no negative counts, and media_count never exceeds total_occurrences.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+
+def _load_audit():
+    spec = importlib.util.spec_from_file_location(
+        "audit_occurrence_stats", ROOT / "scripts" / "audit_occurrence_stats.py"
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_occurrence_stats_consistent():
+    audit = _load_audit()
+    data = yaml.safe_load((ROOT / "data" / "curated" / "mapped_ingredients.yaml").read_text())
+    issues = audit.find_issues(data["ingredients"])
+    assert all(len(v) == 0 for v in issues.values()), (
+        "occurrence_statistics inconsistencies found:\n"
+        + "\n".join(f"  {k}: {v}" for k, v in issues.items() if v)
+    )


### PR DESCRIPTION
## Summary
Works through the three audit items. One produced a concrete fix; the other two were investigated and documented (no action warranted).

### 1. occurrence_statistics audit — fixed + guarded
New **`scripts/audit_occurrence_stats.py`** (`--check` CI gate / `--fix`) checks for missing stats, REJECTED-records-still-reporting-occurrences, negatives, and `media_count > total_occurrences`. The corpus was consistent **except 10 records with `occurrence_statistics: null`** — all ontology-derived (`AUTO_CREATE_FROM_MICRO` / CHEBI) records never tracked in media counting (peptone variants, MnCl2/borate, two PAHs). Backfilled to `0/0` with a `CORRECTED` event. **`tests/test_occurrence_stats.py`** guards it.

(~1211 MAPPED records legitimately have 0 occurrences — catalogued CultureBotHT compounds unused in media; expected, not an issue.)

### 2. KGX export refresh — N/A
There is **no KGX/Biolink edge export in the repo** (grep finds only a curie_map mention in the SSSOM validator). Nothing to refresh; building one is a new feature, out of scope. The SSSOM set is the current machine-readable export (kept current by `reconcile_sssom.py` + CI).

### 3. High-occurrence unmapped mixes — reviewed, correctly unmapped
The top unmapped records are placeholders (`See source for composition`), defined stock solutions (Wolfe's / `Mc_*` / `MOPS_2M`; **no ontology term and no KG source_id** — verified), and defined media. All correctly classified (`UNDEFINED_MIXTURE` / `STOCK_SOLUTION` / `DEFINED_MEDIUM`) and legitimately unmapped; mapping would require recipe-level decomposition (out of scope). No changes.

Full assessment: `notes/audit_2026-06-08_occstats_kgx_unmapped.md`.

## Validation
- `validate_strict.py`: 0 errors / 2274 files
- Full suite: **310 passed** (+1 new guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)