### PR TITLE
Add pytest CI workflow — enforce the guard tests on PRs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,40 @@
+name: Tests (pytest)
+
+# Runs the pytest suite (310 tests, fully hermetic — OAK and HTTP are mocked, no
+# network or large ontology DBs needed) so the guard tests added across the role /
+# SSSOM / occurrence-stats work actually fail PRs on regression, instead of only
+# running locally. Complements the data/schema QC workflows (validate-strict,
+# qc-sssom, qc-evidence) which don't run pytest.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install runtime dependencies
+        # --frozen fails if uv.lock is stale (no silent re-resolve in CI). Runtime
+        # deps only; pytest/pytest-cov are layered via `uv run --with` below so the
+        # heavy py>=3.12 dev extras (edison-client / deep-research-client) aren't
+        # pulled for a hermetic unit-test run.
+        run: uv sync --frozen
+
+      - name: Run pytest
+        run: uv run --with pytest --with pytest-cov pytest


### PR DESCRIPTION
## Summary
**No CI workflow ran pytest** — so all **310 tests**, including the guard suites added across this cycle (`test_enum_sync`, `test_role_plausibility`, `test_role_inference`, `test_sssom_currency`, `test_occurrence_stats`), only ran locally and **could not fail a PR on regression**. The data/schema QC workflows (`validate-strict`, `qc-sssom`, `qc-evidence`) don't run pytest.

This adds a `Tests (pytest)` workflow so those guards are actually enforced.

## Approach
- Mirrors the repo's uv setup (`astral-sh/setup-uv`, `uv python install 3.12`, `uv sync --frozen`).
- Runs `uv run --with pytest --with pytest-cov pytest`. The suite is **fully hermetic** — OAK is `MagicMock`ed and HTTP is `@patch`ed, so no network or large ontology DBs are needed — and the heavy `py>=3.12` dev extras (`edison-client` / `deep-research-client`) aren't required, so they're layered via `--with` rather than pulling the full `dev` extra.
- Verified the exact command runs green via uv locally.

## Effect
A change that breaks role plausibility, SSSOM currency, occurrence-stats consistency, enum-sync, or any unit/inference logic now fails CI instead of slipping through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)