### PR TITLE
Add StockComponent schema slot — recipe-level decomposition foundation

### DIFF
--- a/docs/stock_components.md
+++ b/docs/stock_components.md
@@ -1,0 +1,49 @@
+# Recipe-level decomposition: `components` / `StockComponent`
+
+## What it is
+`IngredientRecord.components` is a list of `StockComponent` entries that decompose a
+`STOCK_SOLUTION` or `DEFINED_MEDIUM` record into its constituent ingredients. It lets a
+named mixture (e.g. a trace-element or vitamin solution) be resolved to its parts instead
+of staying an opaque `UNMAPPED` mixture.
+
+```yaml
+- identifier: MICRO:0000455
+  preferred_term: WC Trace Elements Solution
+  ingredient_type: STOCK_SOLUTION
+  components:
+    - component_name: FeCl3 x 6 H2O      # required
+      component_id: CHEBI:30808          # optional — omit when unmapped
+      concentration_value: "1.5"         # optional — string preserves source formatting / ranges
+      concentration_unit: G_PER_L        # optional
+      source: "CultureMech:M278"         # provenance — keeps the recipe verifiable
+    - component_name: H3BO3
+      concentration_value: "0.01"
+      concentration_unit: G_PER_L
+```
+
+`StockComponent` fields: `component_name` (**required**), `component_id`, `concentration_value`,
+`concentration_unit`, `source`. The slot is optional and backwards-compatible — records
+without it (i.e. all of them today) validate unchanged.
+
+## Populating it — only from a verified source
+**Do not fabricate recipes.** Populate `components` only from a verifiable source and record
+that source in `component_id`/`source`. Suitable sources:
+- a CultureMech medium that lists the solution's composition (the `solutions[].composition`
+  array — see below),
+- a MediaDive solution definition (by solution ID),
+- a cited publication / DOI.
+
+## Current status (2026-06-09)
+This change adds the **schema + validation + tests + docs foundation** only — no records are
+populated yet, because there is currently **no verifiable in-repo recipe for the
+high-occurrence unmapped stock solutions** (Wolfe's vitamin/mineral mix, `Mc_*`, `P-IV`, …):
+- CultureMech tracks `solutions[]` on media, but of **5314** solution entries only **5** have a
+  non-empty `composition`, and **none of those 5 correspond to a MIM ingredient record**
+  (they are `(see Medium [Mxxx])` references, not MIM records). The target solutions all have
+  empty compositions.
+- `mediadive_cache.sqlite` is a raw HTTP-response cache, not a queryable solution→ingredient
+  table, and the unmapped records carry no MediaDive source_id to key on.
+
+So population awaits a recipe source that maps to these records (a curator-provided recipe,
+or a future CultureMech/MediaDive enrichment that fills `solutions[].composition`). When that
+exists, write `components` from it; the `test_stock_components.py` guards keep the slot honest.

--- a/src/mediaingredientmech/schema/mediaingredientmech.yaml
+++ b/src/mediaingredientmech/schema/mediaingredientmech.yaml
@@ -142,6 +142,16 @@ classes:
           DEFINED_MEDIUM: Complete medium formulation/recipe (R2A agar, LB broth).
           UNDEFINED_MIXTURE: Complex mixture of unknown composition (yeast extract, peptone).
           STOCK_SOLUTION: Pre-mixed solution of defined ingredients.
+      components:
+        range: StockComponent
+        multivalued: true
+        inlined_as_list: true
+        description: >-
+          Recipe-level decomposition for a STOCK_SOLUTION or DEFINED_MEDIUM: the
+          list of component ingredients (with concentration where known). Lets a
+          named mixture (e.g. a trace-element or vitamin solution) be resolved to
+          its constituents. Populate only from a verifiable recipe source; leave
+          empty when the composition is unknown.
       culturemech_medium_name:
         description: >-
           Cross-reference to CultureMech medium name if this is a defined medium.
@@ -469,6 +479,33 @@ classes:
         description: Citations and references supporting this role
       notes:
         description: Additional context about this role assignment
+
+  StockComponent:
+    description: >-
+      One constituent of a stock solution or defined medium recipe — a component
+      ingredient with its concentration. Used in IngredientRecord.components to
+      decompose a named mixture (e.g. a trace-element or vitamin solution) into
+      its parts. Populate only from a verifiable recipe source.
+    attributes:
+      component_name:
+        required: true
+        description: Component ingredient name as listed in the recipe (e.g. "FeCl3 x 6 H2O").
+      component_id:
+        description: >-
+          Identifier of the component when mapped to an ontology/registry term
+          (e.g. CHEBI:..., or a registry CURIE). Omit when the component is
+          unmapped. (No pattern constraint: components may be unmapped.)
+      concentration_value:
+        description: >-
+          Amount/concentration of the component, kept as a string to preserve the
+          source's formatting (e.g. "1.5", "0.1-0.5").
+      concentration_unit:
+        description: Unit for concentration_value (e.g. G_PER_L, MG_PER_L, M, MM, PERCENT).
+      source:
+        description: >-
+          Provenance of this component entry (e.g. a CultureMech medium ID, a
+          MediaDive solution ID, or a publication / DOI). Recording it keeps the
+          recipe verifiable rather than fabricated.
 
 enums:
   MappingStatusEnum:

--- a/tests/test_stock_components.py
+++ b/tests/test_stock_components.py
@@ -1,0 +1,59 @@
+"""Tests for the StockComponent schema slot (recipe-level decomposition).
+
+`IngredientRecord.components` lets a STOCK_SOLUTION / DEFINED_MEDIUM record carry
+its recipe as a list of StockComponent entries. These pin the slot's closed-schema
+behavior so it can't silently regress once recipes start being populated.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from mediaingredientmech.validation.write_validated import validate_ingredient
+
+BASE = {
+    "identifier": "MICRO:0000455",
+    "preferred_term": "Test trace element solution",
+    "mapping_status": "MAPPED",
+    "ingredient_type": "STOCK_SOLUTION",
+    "ontology_mapping": {
+        "ontology_id": "MICRO:0000455",
+        "ontology_label": "x",
+        "ontology_source": "MICRO",
+        "mapping_quality": "CLOSE_MATCH",
+    },
+}
+
+
+def test_record_without_components_valid():
+    # components is optional — existing records (none have it) stay valid.
+    assert validate_ingredient(dict(BASE), target_class="IngredientRecord") == []
+
+
+def test_record_with_components_valid():
+    rec = dict(BASE)
+    rec["components"] = [
+        {
+            "component_name": "FeCl3 x 6 H2O",
+            "component_id": "CHEBI:30808",
+            "concentration_value": "1.5",
+            "concentration_unit": "G_PER_L",
+            "source": "CultureMech:M278",
+        },
+        {"component_name": "H3BO3", "concentration_value": "0.01", "concentration_unit": "G_PER_L"},
+    ]
+    assert validate_ingredient(rec, target_class="IngredientRecord") == []
+
+
+def test_component_name_required():
+    rec = dict(BASE)
+    rec["components"] = [{"concentration_value": "1", "concentration_unit": "G_PER_L"}]
+    assert len(validate_ingredient(rec, target_class="IngredientRecord")) >= 1
+
+
+def test_unknown_component_field_rejected():
+    # closed schema: a typo'd component field must be caught.
+    rec = dict(BASE)
+    rec["components"] = [{"component_name": "X", "concentratoin": "1"}]
+    assert len(validate_ingredient(rec, target_class="IngredientRecord")) >= 1


### PR DESCRIPTION
## Summary
Adds the **schema foundation** for recipe-level decomposition of stock-solution / defined-medium mixtures (the deterministic, no-fabrication part of that feature).

`IngredientRecord.components` — a list of **`StockComponent`** entries:
`component_name` (**required**), `component_id`, `concentration_value`, `concentration_unit`, `source`.
This lets a named mixture (e.g. a trace-element or vitamin solution) be decomposed into its recipe constituents instead of staying an opaque `UNMAPPED` mixture.

- **Optional + backwards-compatible** — every existing record (none use it) still validates; closed-schema `validate_strict` stays 0 errors.
- `tests/test_stock_components.py` pins the slot: valid with/without components, `component_name` required, unknown component field rejected (closed schema).
- `docs/stock_components.md` documents the slot and the "populate only from a verifiable source" rule.

## Why no records are populated yet
There is currently **no verifiable in-repo recipe** for the high-occurrence unmapped stock solutions (Wolfe's vitamin/mineral mix, `Mc_*`, `P-IV`, …): of **5314** CultureMech `solutions[]` entries only **5** carry a non-empty composition, and **none of those 5 correspond to a MIM record**. `mediadive_cache.sqlite` is a raw HTTP cache, and these records carry no MediaDive source_id. Per the agreed approach, this ships the schema + guards as the foundation; population follows when a recipe source that maps to these records is available (curator-provided or a future CultureMech/MediaDive enrichment).

## Validation
- `validate_strict.py`: 0 errors / 2274 files
- Full suite: **314 passed** (+4 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)