### PR TITLE
Canonicalize ontology_label: fix 413 stale CHEBI labels

### DIFF
--- a/data/ingredients/mapped/112-trichloroethane.yaml
+++ b/data/ingredients/mapped/112-trichloroethane.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:36018
 preferred_term: 1,1,2-Trichloroethane
 ontology_mapping:
   ontology_id: CHEBI:36018
-  ontology_label: 1,1,2-Trichloroethane
+  ontology_label: 1,1,2-trichloroethane
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -64,6 +64,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.704902+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''1,1,2-Trichloroethane'' -> ''1,1,2-trichloroethane'':
+    synced to canonical CHEBI label (preferred_term ''1,1,2-Trichloroethane'' unchanged).'
 chemical_properties:
   cas_rn: 79-00-5
   data_source: PubChem API

--- a/data/ingredients/mapped/12-dichloropropane.yaml
+++ b/data/ingredients/mapped/12-dichloropropane.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:142468
 preferred_term: 1,2-Dichloropropane
 ontology_mapping:
   ontology_id: CHEBI:142468
-  ontology_label: 1,2-Dichloropropane
+  ontology_label: 1,2-dichloropropane
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -43,6 +43,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.705123+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''1,2-Dichloropropane'' -> ''1,2-dichloropropane'': synced
+    to canonical CHEBI label (preferred_term ''1,2-Dichloropropane'' unchanged).'
 chemical_properties:
   cas_rn: 78-87-5
   data_source: PubChem API

--- a/data/ingredients/mapped/14-naphthoquinone.yaml
+++ b/data/ingredients/mapped/14-naphthoquinone.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:27418
 preferred_term: 1,4-Naphthoquinone
 ontology_mapping:
   ontology_id: CHEBI:27418
-  ontology_label: 1,4-Naphthoquinone
+  ontology_label: 1,4-naphthoquinone
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -78,6 +78,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.705608+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''1,4-Naphthoquinone'' -> ''1,4-naphthoquinone'': synced
+    to canonical CHEBI label (preferred_term ''1,4-Naphthoquinone'' unchanged).'
 chemical_properties:
   cas_rn: 130-15-4
   data_source: PubChem API

--- a/data/ingredients/mapped/2-furoic_Acid.yaml
+++ b/data/ingredients/mapped/2-furoic_Acid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:30845
 preferred_term: 2-Furoic acid
 ontology_mapping:
   ontology_id: CHEBI:30845
-  ontology_label: 2-Furoic acid
+  ontology_label: 2-furoic acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -81,6 +81,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.707727+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''2-Furoic acid'' -> ''2-furoic acid'': synced to canonical
+    CHEBI label (preferred_term ''2-Furoic acid'' unchanged).'
 chemical_properties:
   cas_rn: 88-14-2
   data_source: PubChem API

--- a/data/ingredients/mapped/2-mercaptoethanesulfonate.yaml
+++ b/data/ingredients/mapped/2-mercaptoethanesulfonate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17905
 preferred_term: 2-Mercaptoethanesulfonate
 ontology_mapping:
   ontology_id: CHEBI:17905
-  ontology_label: 2-Mercaptoethanesulfonate
+  ontology_label: coenzyme M
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -127,6 +127,11 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: COFACTOR_PROVIDER (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.707832+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''2-Mercaptoethanesulfonate'' -> ''coenzyme M'': synced
+    to canonical CHEBI label (preferred_term ''2-Mercaptoethanesulfonate'' unchanged).'
 kg_microbe_node_id: CHEBI:17905
 chemical_properties:
   cas_rn: 3375-50-6

--- a/data/ingredients/mapped/2-mercaptoethanol.yaml
+++ b/data/ingredients/mapped/2-mercaptoethanol.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:41218
 preferred_term: 2-Mercaptoethanol
 ontology_mapping:
   ontology_id: CHEBI:41218
-  ontology_label: 2-Mercaptoethanol
+  ontology_label: mercaptoethanol
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -65,6 +65,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: REDUCING_AGENT (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.707933+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''2-Mercaptoethanol'' -> ''mercaptoethanol'': synced to
+    canonical CHEBI label (preferred_term ''2-Mercaptoethanol'' unchanged).'
 chemical_properties:
   cas_rn: 60-24-2
   data_source: PubChem API

--- a/data/ingredients/mapped/2244688-heptamethylnonane.yaml
+++ b/data/ingredients/mapped/2244688-heptamethylnonane.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:131383
 preferred_term: 2,2,4,4,6,8,8-Heptamethylnonane
 ontology_mapping:
   ontology_id: CHEBI:131383
-  ontology_label: 2,2,4,4,6,8,8-Heptamethylnonane
+  ontology_label: 2,2,4,4,6,8,8-heptamethylnonane
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -62,6 +62,12 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.708720+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''2,2,4,4,6,8,8-Heptamethylnonane'' -> ''2,2,4,4,6,8,8-heptamethylnonane'':
+    synced to canonical CHEBI label (preferred_term ''2,2,4,4,6,8,8-Heptamethylnonane''
+    unchanged).'
 chemical_properties:
   cas_rn: 4390-04-9
   data_source: PubChem API

--- a/data/ingredients/mapped/23-butanediol.yaml
+++ b/data/ingredients/mapped/23-butanediol.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:62064
 preferred_term: 2,3-butanediol
 ontology_mapping:
   ontology_id: CHEBI:62064
-  ontology_label: 2,3-butanediol
+  ontology_label: butane-2,3-diol
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -95,6 +95,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.708820+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''2,3-butanediol'' -> ''butane-2,3-diol'': synced to canonical
+    CHEBI label (preferred_term ''2,3-butanediol'' unchanged).'
 chemical_properties:
   cas_rn: 513-85-9
   data_source: PubChem API

--- a/data/ingredients/mapped/3-hydroxybenzoic_Acid.yaml
+++ b/data/ingredients/mapped/3-hydroxybenzoic_Acid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:30764
 preferred_term: 3-Hydroxybenzoic acid
 ontology_mapping:
   ontology_id: CHEBI:30764
-  ontology_label: 3-Hydroxybenzoic acid
+  ontology_label: 3-hydroxybenzoic acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -64,6 +64,11 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.711016+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''3-Hydroxybenzoic acid'' -> ''3-hydroxybenzoic acid'':
+    synced to canonical CHEBI label (preferred_term ''3-Hydroxybenzoic acid'' unchanged).'
 chemical_properties:
   cas_rn: 99-06-9
   data_source: PubChem API

--- a/data/ingredients/mapped/4-hydroxybenzoic_Acid.yaml
+++ b/data/ingredients/mapped/4-hydroxybenzoic_Acid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:30763
 preferred_term: 4-Hydroxybenzoic acid
 ontology_mapping:
   ontology_id: CHEBI:30763
-  ontology_label: 4-Hydroxybenzoic acid
+  ontology_label: 4-hydroxybenzoic acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -83,6 +83,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.714157+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''4-Hydroxybenzoic acid'' -> ''4-hydroxybenzoic acid'':
+    synced to canonical CHEBI label (preferred_term ''4-Hydroxybenzoic acid'' unchanged).'
 chemical_properties:
   cas_rn: 99-96-7
   data_source: PubChem API

--- a/data/ingredients/mapped/5-aminovaleric_Acid.yaml
+++ b/data/ingredients/mapped/5-aminovaleric_Acid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:15887
 preferred_term: 5-Aminovaleric acid
 ontology_mapping:
   ontology_id: CHEBI:15887
-  ontology_label: 5-Aminovaleric acid
+  ontology_label: 5-aminopentanoic acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -76,6 +76,11 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: AMINO_ACID_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.715800+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''5-Aminovaleric acid'' -> ''5-aminopentanoic acid'': synced
+    to canonical CHEBI label (preferred_term ''5-Aminovaleric acid'' unchanged).'
 chemical_properties:
   cas_rn: 660-88-8
   data_source: PubChem API

--- a/data/ingredients/mapped/Acetate.yaml
+++ b/data/ingredients/mapped/Acetate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:30089
 preferred_term: Acetate
 ontology_mapping:
   ontology_id: CHEBI:30089
-  ontology_label: Acetate
+  ontology_label: acetate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -114,6 +114,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.717506+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Acetate'' -> ''acetate'': synced to canonical CHEBI label
+    (preferred_term ''Acetate'' unchanged).'
 chemical_properties:
   cas_rn: 71-50-1
   data_source: PubChem API

--- a/data/ingredients/mapped/Acetic_Acid.yaml
+++ b/data/ingredients/mapped/Acetic_Acid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:15366
 preferred_term: Acetic acid
 ontology_mapping:
   ontology_id: CHEBI:15366
-  ontology_label: Acetic acid
+  ontology_label: acetic acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -114,6 +114,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.717694+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Acetic acid'' -> ''acetic acid'': synced to canonical
+    CHEBI label (preferred_term ''Acetic acid'' unchanged).'
 chemical_properties:
   cas_rn: 64-19-7
   data_source: PubChem API

--- a/data/ingredients/mapped/Agar.yaml
+++ b/data/ingredients/mapped/Agar.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:2509
 preferred_term: Agar
 ontology_mapping:
   ontology_id: CHEBI:2509
-  ontology_label: Agar
+  ontology_label: agar
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -140,6 +140,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: SOLIDIFYING_AGENT (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.718919+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Agar'' -> ''agar'': synced to canonical CHEBI label (preferred_term
+    ''Agar'' unchanged).'
 chemical_properties:
   cas_rn: 9002-18-0
   data_source: PubChem API

--- a/data/ingredients/mapped/Agarose.yaml
+++ b/data/ingredients/mapped/Agarose.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:2511
 preferred_term: Agarose
 ontology_mapping:
   ontology_id: CHEBI:2511
-  ontology_label: Agarose
+  ontology_label: agarose
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -83,6 +83,11 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.719018+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Agarose'' -> ''agarose'': synced to canonical CHEBI label
+    (preferred_term ''Agarose'' unchanged).'
 chemical_properties:
   cas_rn: 9012-36-6
   data_source: NCI CACTUS Chemical Identifier Resolver

--- a/data/ingredients/mapped/Al2_So43_X_18_H2o.yaml
+++ b/data/ingredients/mapped/Al2_So43_X_18_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:74779
 preferred_term: Al2(SO4)3 x 18 H2O
 ontology_mapping:
   ontology_id: CHEBI:74779
-  ontology_label: Al2(SO4)3 x 18 H2O
+  ontology_label: aluminium sulfate octadecahydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -70,6 +70,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.721632+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Al2(SO4)3 x 18 H2O'' -> ''aluminium sulfate octadecahydrate'':
+    synced to canonical CHEBI label (preferred_term ''Al2(SO4)3 x 18 H2O'' unchanged).'
 chemical_properties:
   cas_rn: 7784-31-8
   data_source: PubChem (via CHEBI:74779)

--- a/data/ingredients/mapped/Alcl3.yaml
+++ b/data/ingredients/mapped/Alcl3.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:30114
 preferred_term: AlCl3
 ontology_mapping:
   ontology_id: CHEBI:30114
-  ontology_label: AlCl3
+  ontology_label: aluminium trichloride
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -85,6 +85,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.721866+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''AlCl3'' -> ''aluminium trichloride'': synced to canonical
+    CHEBI label (preferred_term ''AlCl3'' unchanged).'
 chemical_properties:
   cas_rn: 7446-70-0
   data_source: PubChem (via CHEBI:30114)

--- a/data/ingredients/mapped/Alcl3_X_6_H2o.yaml
+++ b/data/ingredients/mapped/Alcl3_X_6_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:30115
 preferred_term: AlCl3 x 6 H2O
 ontology_mapping:
   ontology_id: CHEBI:30115
-  ontology_label: AlCl3 x 6 H2O
+  ontology_label: aluminium trichloride hexahydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -100,6 +100,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.721969+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''AlCl3 x 6 H2O'' -> ''aluminium trichloride hexahydrate'':
+    synced to canonical CHEBI label (preferred_term ''AlCl3 x 6 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:30115
 chemical_properties:
   cas_rn: 7784-13-6

--- a/data/ingredients/mapped/Alk_So42.yaml
+++ b/data/ingredients/mapped/Alk_So42.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:86463
 preferred_term: AlK(SO4)2
 ontology_mapping:
   ontology_id: CHEBI:86463
-  ontology_label: AlK(SO4)2
+  ontology_label: potassium aluminium sulfate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -122,6 +122,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.722074+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''AlK(SO4)2'' -> ''potassium aluminium sulfate'': synced
+    to canonical CHEBI label (preferred_term ''AlK(SO4)2'' unchanged).'
 chemical_properties:
   cas_rn: 10043-67-1
   data_source: PubChem API

--- a/data/ingredients/mapped/Alk_So42_X_12_H2o.yaml
+++ b/data/ingredients/mapped/Alk_So42_X_12_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:86465
 preferred_term: AlK(SO4)2 x 12 H2O
 ontology_mapping:
   ontology_id: CHEBI:86465
-  ontology_label: AlK(SO4)2 x 12 H2O
+  ontology_label: potassium aluminium sulfate dodecahydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -184,6 +184,12 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.722177+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''AlK(SO4)2 x 12 H2O'' -> ''potassium aluminium sulfate
+    dodecahydrate'': synced to canonical CHEBI label (preferred_term ''AlK(SO4)2 x
+    12 H2O'' unchanged).'
 chemical_properties:
   cas_rn: 7784-24-9
   data_source: PubChem (via CHEBI:86465)

--- a/data/ingredients/mapped/Allantoin.yaml
+++ b/data/ingredients/mapped/Allantoin.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:15676
 preferred_term: Allantoin
 ontology_mapping:
   ontology_id: CHEBI:15676
-  ontology_label: Allantoin
+  ontology_label: allantoin
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -83,6 +83,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: NITROGEN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.722281+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Allantoin'' -> ''allantoin'': synced to canonical CHEBI
+    label (preferred_term ''Allantoin'' unchanged).'
 chemical_properties:
   cas_rn: 97-59-6
   data_source: PubChem API

--- a/data/ingredients/mapped/Alpha-d-glucose.yaml
+++ b/data/ingredients/mapped/Alpha-d-glucose.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17925
 preferred_term: alpha-D-Glucose
 ontology_mapping:
   ontology_id: CHEBI:17925
-  ontology_label: alpha-D-Glucose
+  ontology_label: alpha-D-glucose
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -70,6 +70,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.722854+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''alpha-D-Glucose'' -> ''alpha-D-glucose'': synced to canonical
+    CHEBI label (preferred_term ''alpha-D-Glucose'' unchanged).'
 chemical_properties:
   cas_rn: 492-62-6
   data_source: PubChem API

--- a/data/ingredients/mapped/Alpha-ketoglutaric_Acid.yaml
+++ b/data/ingredients/mapped/Alpha-ketoglutaric_Acid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:30915
 preferred_term: alpha-ketoglutaric acid
 ontology_mapping:
   ontology_id: CHEBI:30915
-  ontology_label: alpha-ketoglutaric acid
+  ontology_label: 2-oxoglutaric acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -83,6 +83,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.722952+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''alpha-ketoglutaric acid'' -> ''2-oxoglutaric acid'':
+    synced to canonical CHEBI label (preferred_term ''alpha-ketoglutaric acid'' unchanged).'
 chemical_properties:
   cas_rn: 328-50-7
   data_source: PubChem API

--- a/data/ingredients/mapped/Ammonium_Acetate.yaml
+++ b/data/ingredients/mapped/Ammonium_Acetate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:62947
 preferred_term: Ammonium acetate
 ontology_mapping:
   ontology_id: CHEBI:62947
-  ontology_label: Ammonium acetate
+  ontology_label: ammonium acetate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -109,6 +109,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: NITROGEN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.723228+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Ammonium acetate'' -> ''ammonium acetate'': synced to
+    canonical CHEBI label (preferred_term ''Ammonium acetate'' unchanged).'
 chemical_properties:
   cas_rn: 631-61-8
   data_source: PubChem API

--- a/data/ingredients/mapped/Amphotericin_B.yaml
+++ b/data/ingredients/mapped/Amphotericin_B.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:2682
 preferred_term: Amphotericin B
 ontology_mapping:
   ontology_id: CHEBI:2682
-  ontology_label: Amphotericin B
+  ontology_label: amphotericin B
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -99,6 +99,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: SELECTIVE_AGENT (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.723794+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Amphotericin B'' -> ''amphotericin B'': synced to canonical
+    CHEBI label (preferred_term ''Amphotericin B'' unchanged).'
 chemical_properties:
   cas_rn: 1397-89-3
   data_source: PubChem API

--- a/data/ingredients/mapped/Ampicillin.yaml
+++ b/data/ingredients/mapped/Ampicillin.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:28971
 preferred_term: Ampicillin
 ontology_mapping:
   ontology_id: CHEBI:28971
-  ontology_label: Ampicillin
+  ontology_label: ampicillin
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -140,6 +140,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: SELECTIVE_AGENT (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.723890+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Ampicillin'' -> ''ampicillin'': synced to canonical CHEBI
+    label (preferred_term ''Ampicillin'' unchanged).'
 chemical_properties:
   cas_rn: 69-53-4
   data_source: PubChem API

--- a/data/ingredients/mapped/Antipyrine.yaml
+++ b/data/ingredients/mapped/Antipyrine.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:31225
 preferred_term: Antipyrine
 ontology_mapping:
   ontology_id: CHEBI:31225
-  ontology_label: Antipyrine
+  ontology_label: antipyrine
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -69,6 +69,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.724902+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Antipyrine'' -> ''antipyrine'': synced to canonical CHEBI
+    label (preferred_term ''Antipyrine'' unchanged).'
 chemical_properties:
   cas_rn: 60-80-0
   data_source: PubChem API

--- a/data/ingredients/mapped/Arabinose.yaml
+++ b/data/ingredients/mapped/Arabinose.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:22599
 preferred_term: Arabinose
 ontology_mapping:
   ontology_id: CHEBI:22599
-  ontology_label: Arabinose
+  ontology_label: arabinose
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -82,6 +82,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.725498+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Arabinose'' -> ''arabinose'': synced to canonical CHEBI
+    label (preferred_term ''Arabinose'' unchanged).'
 chemical_properties:
   cas_rn: 226-214-6
   data_source: PubChem API

--- a/data/ingredients/mapped/Arginine.yaml
+++ b/data/ingredients/mapped/Arginine.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:29016
 preferred_term: Arginine
 ontology_mapping:
   ontology_id: CHEBI:29016
-  ontology_label: Arginine
+  ontology_label: arginine
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -86,6 +86,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: NITROGEN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.725973+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Arginine'' -> ''arginine'': synced to canonical CHEBI
+    label (preferred_term ''Arginine'' unchanged).'
 chemical_properties:
   cas_rn: 74-79-3
   data_source: PubChem API

--- a/data/ingredients/mapped/Arsenate.yaml
+++ b/data/ingredients/mapped/Arsenate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:29125
 preferred_term: Arsenate
 ontology_mapping:
   ontology_id: CHEBI:29125
-  ontology_label: Arsenate
+  ontology_label: arsenate(3-)
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -68,6 +68,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.726440+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Arsenate'' -> ''arsenate(3-)'': synced to canonical CHEBI
+    label (preferred_term ''Arsenate'' unchanged).'
 chemical_properties:
   cas_rn: 15584-04-0
   data_source: PubChem API

--- a/data/ingredients/mapped/Ascorbic_Acid.yaml
+++ b/data/ingredients/mapped/Ascorbic_Acid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:22652
 preferred_term: Ascorbic acid
 ontology_mapping:
   ontology_id: CHEBI:22652
-  ontology_label: Ascorbic acid
+  ontology_label: ascorbic acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -61,6 +61,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: VITAMIN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.726544+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Ascorbic acid'' -> ''ascorbic acid'': synced to canonical
+    CHEBI label (preferred_term ''Ascorbic acid'' unchanged).'
 chemical_properties:
   cas_rn: 50-81-7
   data_source: PubChem API

--- a/data/ingredients/mapped/Asparagine.yaml
+++ b/data/ingredients/mapped/Asparagine.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:22653
 preferred_term: Asparagine
 ontology_mapping:
   ontology_id: CHEBI:22653
-  ontology_label: Asparagine
+  ontology_label: asparagine
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -106,6 +106,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: NITROGEN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.726737+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Asparagine'' -> ''asparagine'': synced to canonical CHEBI
+    label (preferred_term ''Asparagine'' unchanged).'
 chemical_properties:
   cas_rn: 3130-87-8
   data_source: OAK/CHEBI xref (overrode 5794-13-8|70-47-3)

--- a/data/ingredients/mapped/Bacl2.yaml
+++ b/data/ingredients/mapped/Bacl2.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:63317
 preferred_term: BaCl2
 ontology_mapping:
   ontology_id: CHEBI:63317
-  ontology_label: BaCl2
+  ontology_label: barium chloride
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -63,6 +63,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.727739+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''BaCl2'' -> ''barium chloride'': synced to canonical CHEBI
+    label (preferred_term ''BaCl2'' unchanged).'
 chemical_properties:
   cas_rn: 233-788-1
   data_source: PubChem API

--- a/data/ingredients/mapped/Bacl2_X_2_H2o.yaml
+++ b/data/ingredients/mapped/Bacl2_X_2_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:86153
 preferred_term: BaCl2 x 2 H2O
 ontology_mapping:
   ontology_id: CHEBI:86153
-  ontology_label: BaCl2 x 2 H2O
+  ontology_label: barium chloride dihydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -65,6 +65,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.727832+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''BaCl2 x 2 H2O'' -> ''barium chloride dihydrate'': synced
+    to canonical CHEBI label (preferred_term ''BaCl2 x 2 H2O'' unchanged).'
 chemical_properties:
   cas_rn: 10326-27-9
   data_source: PubChem (via CHEBI:86153)

--- a/data/ingredients/mapped/Betaine_X_H2o.yaml
+++ b/data/ingredients/mapped/Betaine_X_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17750
 preferred_term: Betaine x H2O
 ontology_mapping:
   ontology_id: CHEBI:17750
-  ontology_label: Betaine x H2O
+  ontology_label: glycine betaine
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -126,6 +126,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.730447+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Betaine x H2O'' -> ''glycine betaine'': synced to canonical
+    CHEBI label (preferred_term ''Betaine x H2O'' unchanged).'
 chemical_properties:
   cas_rn: 107-43-7
   data_source: OAK/CHEBI xref

--- a/data/ingredients/mapped/Bicine.yaml
+++ b/data/ingredients/mapped/Bicine.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:39065
 preferred_term: Bicine
 ontology_mapping:
   ontology_id: CHEBI:39065
-  ontology_label: Bicine
+  ontology_label: bicine
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -45,6 +45,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: BUFFER (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.730632+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Bicine'' -> ''bicine'': synced to canonical CHEBI label
+    (preferred_term ''Bicine'' unchanged).'
 chemical_properties:
   cas_rn: 150-25-4
   data_source: PubChem API

--- a/data/ingredients/mapped/Bicine_Buffer.yaml
+++ b/data/ingredients/mapped/Bicine_Buffer.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:40957
 preferred_term: BICINE buffer
 ontology_mapping:
   ontology_id: CHEBI:40957
-  ontology_label: BICINE buffer
+  ontology_label: N,N-bis(2-hydroxyethyl)glycine
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -57,6 +57,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: BUFFER (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.730732+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''BICINE buffer'' -> ''N,N-bis(2-hydroxyethyl)glycine'':
+    synced to canonical CHEBI label (preferred_term ''BICINE buffer'' unchanged).'
 chemical_properties:
   cas_rn: 150-25-4
   data_source: PubChem API

--- a/data/ingredients/mapped/Biotin.yaml
+++ b/data/ingredients/mapped/Biotin.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:15956
 preferred_term: Biotin
 ontology_mapping:
   ontology_id: CHEBI:15956
-  ontology_label: Biotin
+  ontology_label: biotin
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -213,6 +213,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: VITAMIN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.731014+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Biotin'' -> ''biotin'': synced to canonical CHEBI label
+    (preferred_term ''Biotin'' unchanged).'
 chemical_properties:
   cas_rn: 58-85-5
   data_source: PubChem API

--- a/data/ingredients/mapped/Bis-tris.yaml
+++ b/data/ingredients/mapped/Bis-tris.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:41250
 preferred_term: Bis-Tris
 ontology_mapping:
   ontology_id: CHEBI:41250
-  ontology_label: Bis-Tris
+  ontology_label: bis-tris
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -77,6 +77,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: BUFFER (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.731205+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Bis-Tris'' -> ''bis-tris'': synced to canonical CHEBI
+    label (preferred_term ''Bis-Tris'' unchanged).'
 chemical_properties:
   cas_rn: 6976-37-0
   data_source: PubChem API

--- a/data/ingredients/mapped/Bromocresol_Purple.yaml
+++ b/data/ingredients/mapped/Bromocresol_Purple.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:86154
 preferred_term: Bromocresol purple
 ontology_mapping:
   ontology_id: CHEBI:86154
-  ontology_label: Bromocresol purple
+  ontology_label: bromocresol purple
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -66,6 +66,11 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: PH_INDICATOR (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.731755+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Bromocresol purple'' -> ''bromocresol purple'': synced
+    to canonical CHEBI label (preferred_term ''Bromocresol purple'' unchanged).'
 chemical_properties:
   cas_rn: 115-40-2
   data_source: PubChem API

--- a/data/ingredients/mapped/Bromothymol_Blue.yaml
+++ b/data/ingredients/mapped/Bromothymol_Blue.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:86155
 preferred_term: Bromothymol blue
 ontology_mapping:
   ontology_id: CHEBI:86155
-  ontology_label: Bromothymol blue
+  ontology_label: bromothymol blue
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -86,6 +86,11 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: PH_INDICATOR (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.731849+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Bromothymol blue'' -> ''bromothymol blue'': synced to
+    canonical CHEBI label (preferred_term ''Bromothymol blue'' unchanged).'
 chemical_properties:
   cas_rn: 76-59-5
   data_source: PubChem API

--- a/data/ingredients/mapped/Butyric_Acid.yaml
+++ b/data/ingredients/mapped/Butyric_Acid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:30772
 preferred_term: Butyric acid
 ontology_mapping:
   ontology_id: CHEBI:30772
-  ontology_label: Butyric acid
+  ontology_label: butyric acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -124,6 +124,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.732223+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Butyric acid'' -> ''butyric acid'': synced to canonical
+    CHEBI label (preferred_term ''Butyric acid'' unchanged).'
 chemical_properties:
   cas_rn: 107-92-6
   data_source: PubChem API

--- a/data/ingredients/mapped/Ca-folinate.yaml
+++ b/data/ingredients/mapped/Ca-folinate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:31340
 preferred_term: Ca-folinate
 ontology_mapping:
   ontology_id: CHEBI:31340
-  ontology_label: Ca-folinate
+  ontology_label: Calcium folinate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -61,6 +61,11 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: VITAMIN_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.732596+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Ca-folinate'' -> ''Calcium folinate'': synced to canonical
+    CHEBI label (preferred_term ''Ca-folinate'' unchanged).'
 chemical_properties:
   cas_rn: 1492-18-8
   data_source: PubChem API (preprocessed)

--- a/data/ingredients/mapped/Ca_No32_X_4_H2o.yaml
+++ b/data/ingredients/mapped/Ca_No32_X_4_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:86159
 preferred_term: Ca(NO3)2 x 4 H2O
 ontology_mapping:
   ontology_id: CHEBI:86159
-  ontology_label: Ca(NO3)2 x 4 H2O
+  ontology_label: calcium nitrate tetrahydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -132,6 +132,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.732873+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Ca(NO3)2 x 4 H2O'' -> ''calcium nitrate tetrahydrate'':
+    synced to canonical CHEBI label (preferred_term ''Ca(NO3)2 x 4 H2O'' unchanged).'
 chemical_properties:
   cas_rn: 13477-34-4
   data_source: PubChem (via CHEBI:86159)

--- a/data/ingredients/mapped/Cacl2.yaml
+++ b/data/ingredients/mapped/Cacl2.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:3312
 preferred_term: CaCl2
 ontology_mapping:
   ontology_id: CHEBI:3312
-  ontology_label: CaCl2
+  ontology_label: calcium dichloride
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -130,6 +130,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.732971+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''CaCl2'' -> ''calcium dichloride'': synced to canonical
+    CHEBI label (preferred_term ''CaCl2'' unchanged).'
 chemical_properties:
   cas_rn: 10043-52-4
   data_source: PubChem API

--- a/data/ingredients/mapped/Cacl2_X_2_H2o.yaml
+++ b/data/ingredients/mapped/Cacl2_X_2_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:86158
 preferred_term: CaCl2 x 2 H2O
 ontology_mapping:
   ontology_id: CHEBI:86158
-  ontology_label: CaCl2 x 2 H2O
+  ontology_label: calcium chloride dihydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -199,6 +199,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.733158+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''CaCl2 x 2 H2O'' -> ''calcium chloride dihydrate'': synced
+    to canonical CHEBI label (preferred_term ''CaCl2 x 2 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:86158
 chemical_properties:
   cas_rn: 10035-04-8

--- a/data/ingredients/mapped/Cacl2_X_6_H2o.yaml
+++ b/data/ingredients/mapped/Cacl2_X_6_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:91243
 preferred_term: CaCl2 x 6 H2O
 ontology_mapping:
   ontology_id: CHEBI:91243
-  ontology_label: CaCl2 x 6 H2O
+  ontology_label: calcium chloride hexahydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -73,6 +73,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.733252+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''CaCl2 x 6 H2O'' -> ''calcium chloride hexahydrate'':
+    synced to canonical CHEBI label (preferred_term ''CaCl2 x 6 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:91243
 chemical_properties:
   cas_rn: 10043-52-4

--- a/data/ingredients/mapped/Cacl2_X_7_H2o.yaml
+++ b/data/ingredients/mapped/Cacl2_X_7_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:3312
 preferred_term: CaCl2 x 7 H2O
 ontology_mapping:
   ontology_id: CHEBI:3312
-  ontology_label: CaCl2 x 7 H2O
+  ontology_label: calcium dichloride
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -78,6 +78,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.733343+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''CaCl2 x 7 H2O'' -> ''calcium dichloride'': synced to
+    canonical CHEBI label (preferred_term ''CaCl2 x 7 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:3312
 chemical_properties:
   cas_rn: 10043-52-4

--- a/data/ingredients/mapped/Caco3.yaml
+++ b/data/ingredients/mapped/Caco3.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:3311
 preferred_term: CaCO3
 ontology_mapping:
   ontology_id: CHEBI:3311
-  ontology_label: CaCO3
+  ontology_label: calcium carbonate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -157,6 +157,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.733439+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''CaCO3'' -> ''calcium carbonate'': synced to canonical
+    CHEBI label (preferred_term ''CaCO3'' unchanged).'
 chemical_properties:
   cas_rn: 471-34-1
   data_source: PubChem API

--- a/data/ingredients/mapped/Cahpo4.yaml
+++ b/data/ingredients/mapped/Cahpo4.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:32596
 preferred_term: CaHPO4
 ontology_mapping:
   ontology_id: CHEBI:32596
-  ontology_label: CaHPO4
+  ontology_label: calcium hydrogenphosphate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -66,6 +66,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.734086+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''CaHPO4'' -> ''calcium hydrogenphosphate'': synced to
+    canonical CHEBI label (preferred_term ''CaHPO4'' unchanged).'
 chemical_properties:
   cas_rn: 7757-93-9
   data_source: PubChem API

--- a/data/ingredients/mapped/Caproic_Acid.yaml
+++ b/data/ingredients/mapped/Caproic_Acid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:30776
 preferred_term: Caproic acid
 ontology_mapping:
   ontology_id: CHEBI:30776
-  ontology_label: Caproic acid
+  ontology_label: hexanoic acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -128,6 +128,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.734799+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Caproic acid'' -> ''hexanoic acid'': synced to canonical
+    CHEBI label (preferred_term ''Caproic acid'' unchanged).'
 chemical_properties:
   cas_rn: 142-62-1
   data_source: PubChem API

--- a/data/ingredients/mapped/Carboxymethyl_Cellulose.yaml
+++ b/data/ingredients/mapped/Carboxymethyl_Cellulose.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:85146
 preferred_term: Carboxymethyl cellulose
 ontology_mapping:
   ontology_id: CHEBI:85146
-  ontology_label: Carboxymethyl cellulose
+  ontology_label: carboxymethylcellulose
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -111,6 +111,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.735527+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Carboxymethyl cellulose'' -> ''carboxymethylcellulose'':
+    synced to canonical CHEBI label (preferred_term ''Carboxymethyl cellulose'' unchanged).'
 kg_microbe_node_id: CHEBI:85146
 chemical_properties:
   cas_rn: 9004-32-4

--- a/data/ingredients/mapped/Caso4.yaml
+++ b/data/ingredients/mapped/Caso4.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:31346
 preferred_term: CaSO4
 ontology_mapping:
   ontology_id: CHEBI:31346
-  ontology_label: CaSO4
+  ontology_label: calcium sulfate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -67,6 +67,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.736381+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''CaSO4'' -> ''calcium sulfate'': synced to canonical CHEBI
+    label (preferred_term ''CaSO4'' unchanged).'
 chemical_properties:
   cas_rn: 7778-18-9
   data_source: PubChem API

--- a/data/ingredients/mapped/Caso4_X_2_H2o.yaml
+++ b/data/ingredients/mapped/Caso4_X_2_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:32583
 preferred_term: CaSO4 x 2 H2O
 ontology_mapping:
   ontology_id: CHEBI:32583
-  ontology_label: CaSO4 x 2 H2O
+  ontology_label: calcium sulfate dihydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -150,6 +150,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.736474+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''CaSO4 x 2 H2O'' -> ''calcium sulfate dihydrate'': synced
+    to canonical CHEBI label (preferred_term ''CaSO4 x 2 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:32583
 chemical_properties:
   cas_rn: 10101-41-4

--- a/data/ingredients/mapped/Caso4_X_7_H2o.yaml
+++ b/data/ingredients/mapped/Caso4_X_7_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:31346
 preferred_term: CaSO4 x 7 H2O
 ontology_mapping:
   ontology_id: CHEBI:31346
-  ontology_label: CaSO4 x 7 H2O
+  ontology_label: calcium sulfate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -63,6 +63,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.736566+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''CaSO4 x 7 H2O'' -> ''calcium sulfate'': synced to canonical
+    CHEBI label (preferred_term ''CaSO4 x 7 H2O'' unchanged).'
 chemical_properties:
   cas_rn: 7778-18-9
   data_source: PubChem (via CHEBI:31346)

--- a/data/ingredients/mapped/Cd_No32_X_4_H2o.yaml
+++ b/data/ingredients/mapped/Cd_No32_X_4_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:86156
 preferred_term: Cd(NO3)2 x 4 H2O
 ontology_mapping:
   ontology_id: CHEBI:86156
-  ontology_label: Cd(NO3)2 x 4 H2O
+  ontology_label: cadmium nitrate tetrahydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -62,6 +62,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.736757+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Cd(NO3)2 x 4 H2O'' -> ''cadmium nitrate tetrahydrate'':
+    synced to canonical CHEBI label (preferred_term ''Cd(NO3)2 x 4 H2O'' unchanged).'
 chemical_properties:
   cas_rn: 10022-68-1
   data_source: PubChem (via CHEBI:86156)

--- a/data/ingredients/mapped/Cecl3.yaml
+++ b/data/ingredients/mapped/Cecl3.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:35458
 preferred_term: CeCl3
 ontology_mapping:
   ontology_id: CHEBI:35458
-  ontology_label: CeCl3
+  ontology_label: cerium trichloride
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -83,6 +83,11 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: TRACE_ELEMENT (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.736851+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''CeCl3'' -> ''cerium trichloride'': synced to canonical
+    CHEBI label (preferred_term ''CeCl3'' unchanged).'
 chemical_properties:
   cas_rn: 7790-86-5
   data_source: PubChem (via CHEBI:35458)

--- a/data/ingredients/mapped/Cecl3_X_7_H2o.yaml
+++ b/data/ingredients/mapped/Cecl3_X_7_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:35458
 preferred_term: CeCl3 x 7 H2O
 ontology_mapping:
   ontology_id: CHEBI:35458
-  ontology_label: CeCl3 x 7 H2O
+  ontology_label: cerium trichloride
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -46,6 +46,11 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: TRACE_ELEMENT (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.736943+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''CeCl3 x 7 H2O'' -> ''cerium trichloride'': synced to
+    canonical CHEBI label (preferred_term ''CeCl3 x 7 H2O'' unchanged).'
 chemical_properties:
   cas_rn: 7790-86-5
   data_source: PubChem (via CHEBI:35458)

--- a/data/ingredients/mapped/Cellobiose.yaml
+++ b/data/ingredients/mapped/Cellobiose.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17057
 preferred_term: Cellobiose
 ontology_mapping:
   ontology_id: CHEBI:17057
-  ontology_label: Cellobiose
+  ontology_label: cellobiose
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -144,6 +144,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.739430+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Cellobiose'' -> ''cellobiose'': synced to canonical CHEBI
+    label (preferred_term ''Cellobiose'' unchanged).'
 chemical_properties:
   cas_rn: 528-50-7
   data_source: PubChem API

--- a/data/ingredients/mapped/Cellulose.yaml
+++ b/data/ingredients/mapped/Cellulose.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:18246
 preferred_term: Cellulose
 ontology_mapping:
   ontology_id: CHEBI:18246
-  ontology_label: Cellulose
+  ontology_label: (1->4)-beta-D-glucan
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -92,6 +92,11 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.739941+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Cellulose'' -> ''(1->4)-beta-D-glucan'': synced to canonical
+    CHEBI label (preferred_term ''Cellulose'' unchanged).'
 chemical_properties:
   cas_rn: 9004-34-6
   data_source: CultureBotHT compounds_to_cas.csv

--- a/data/ingredients/mapped/Charcoal.yaml
+++ b/data/ingredients/mapped/Charcoal.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:91090
 preferred_term: Charcoal
 ontology_mapping:
   ontology_id: CHEBI:91090
-  ontology_label: Charcoal
+  ontology_label: charcoal
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -37,6 +37,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (CHEBI primary)
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.740765+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Charcoal'' -> ''charcoal'': synced to canonical CHEBI
+    label (preferred_term ''Charcoal'' unchanged).'
 chemical_properties:
   cas_rn: 231-153-3
   data_source: PubChem API

--- a/data/ingredients/mapped/Chitosan.yaml
+++ b/data/ingredients/mapped/Chitosan.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:16261
 preferred_term: Chitosan
 ontology_mapping:
   ontology_id: CHEBI:16261
-  ontology_label: Chitosan
+  ontology_label: chitosan
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -78,6 +78,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.741133+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Chitosan'' -> ''chitosan'': synced to canonical CHEBI
+    label (preferred_term ''Chitosan'' unchanged).'
 chemical_properties:
   cas_rn: 9012-76-4
   data_source: CultureBotHT compounds_to_cas.csv

--- a/data/ingredients/mapped/Choline.yaml
+++ b/data/ingredients/mapped/Choline.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:15354
 preferred_term: Choline
 ontology_mapping:
   ontology_id: CHEBI:15354
-  ontology_label: Choline
+  ontology_label: choline
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -72,6 +72,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.741693+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Choline'' -> ''choline'': synced to canonical CHEBI label
+    (preferred_term ''Choline'' unchanged).'
 chemical_properties:
   cas_rn: 62-49-7
   data_source: PubChem API

--- a/data/ingredients/mapped/Citrate.yaml
+++ b/data/ingredients/mapped/Citrate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:16947
 preferred_term: Citrate
 ontology_mapping:
   ontology_id: CHEBI:16947
-  ontology_label: citrate
+  ontology_label: citrate(3-)
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -47,6 +47,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.742872+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''citrate'' -> ''citrate(3-)'': synced to canonical CHEBI
+    label (preferred_term ''Citrate'' unchanged).'
 ingredient_type: SINGLE_INGREDIENT
 chemical_properties:
   molecular_formula: C6H5O7

--- a/data/ingredients/mapped/Citric_Acid.yaml
+++ b/data/ingredients/mapped/Citric_Acid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:30769
 preferred_term: Citric acid
 ontology_mapping:
   ontology_id: CHEBI:30769
-  ontology_label: Citric acid
+  ontology_label: citric acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -104,6 +104,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.742976+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Citric acid'' -> ''citric acid'': synced to canonical
+    CHEBI label (preferred_term ''Citric acid'' unchanged).'
 chemical_properties:
   cas_rn: 77-92-9
   data_source: PubChem API

--- a/data/ingredients/mapped/Citric_Acid_X_H2o.yaml
+++ b/data/ingredients/mapped/Citric_Acid_X_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:31404
 preferred_term: Citric acid x H2O
 ontology_mapping:
   ontology_id: CHEBI:31404
-  ontology_label: Citric acid x H2O
+  ontology_label: Citric acid monohydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -67,6 +67,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.743078+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Citric acid x H2O'' -> ''Citric acid monohydrate'': synced
+    to canonical CHEBI label (preferred_term ''Citric acid x H2O'' unchanged).'
 chemical_properties:
   cas_rn: 5949-29-1
   data_source: PubChem (via CHEBI:31404)

--- a/data/ingredients/mapped/Co_No32.yaml
+++ b/data/ingredients/mapped/Co_No32.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:86209
 preferred_term: Co(NO3)2
 ontology_mapping:
   ontology_id: CHEBI:86209
-  ontology_label: Co(NO3)2
+  ontology_label: cobalt dinitrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -76,6 +76,11 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: TRACE_ELEMENT (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.743650+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Co(NO3)2'' -> ''cobalt dinitrate'': synced to canonical
+    CHEBI label (preferred_term ''Co(NO3)2'' unchanged).'
 chemical_properties:
   cas_rn: 10141-05-6
   data_source: PubChem API

--- a/data/ingredients/mapped/Co_No32_X_6_H2o.yaml
+++ b/data/ingredients/mapped/Co_No32_X_6_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:86214
 preferred_term: Co(NO3)2 x 6 H2O
 ontology_mapping:
   ontology_id: CHEBI:86214
-  ontology_label: Co(NO3)2 x 6 H2O
+  ontology_label: cobalt dinitrate hexahydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -156,6 +156,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.743743+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Co(NO3)2 x 6 H2O'' -> ''cobalt dinitrate hexahydrate'':
+    synced to canonical CHEBI label (preferred_term ''Co(NO3)2 x 6 H2O'' unchanged).'
 chemical_properties:
   cas_rn: 10026-22-9
   data_source: CultureBotHT/compounds_to_cas.csv

--- a/data/ingredients/mapped/Cocl2.yaml
+++ b/data/ingredients/mapped/Cocl2.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:35696
 preferred_term: CoCl2
 ontology_mapping:
   ontology_id: CHEBI:35696
-  ontology_label: CoCl2
+  ontology_label: cobalt dichloride
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -105,6 +105,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.744015+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''CoCl2'' -> ''cobalt dichloride'': synced to canonical
+    CHEBI label (preferred_term ''CoCl2'' unchanged).'
 chemical_properties:
   cas_rn: 7646-79-9
   data_source: PubChem (via CHEBI:35696)

--- a/data/ingredients/mapped/Cocl2_X_2_H2o.yaml
+++ b/data/ingredients/mapped/Cocl2_X_2_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:35696
 preferred_term: CoCl2 x 2 H2O
 ontology_mapping:
   ontology_id: CHEBI:35696
-  ontology_label: CoCl2 x 2 H2O
+  ontology_label: cobalt dichloride
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -77,6 +77,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.744113+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''CoCl2 x 2 H2O'' -> ''cobalt dichloride'': synced to canonical
+    CHEBI label (preferred_term ''CoCl2 x 2 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:35696
 chemical_properties:
   cas_rn: 7646-79-9

--- a/data/ingredients/mapped/Cocl2_X_4_H2o.yaml
+++ b/data/ingredients/mapped/Cocl2_X_4_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:35696
 preferred_term: CoCl2 x 4 H2O
 ontology_mapping:
   ontology_id: CHEBI:35696
-  ontology_label: CoCl2 x 4 H2O
+  ontology_label: cobalt dichloride
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -77,6 +77,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.744219+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''CoCl2 x 4 H2O'' -> ''cobalt dichloride'': synced to canonical
+    CHEBI label (preferred_term ''CoCl2 x 4 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:35696
 chemical_properties:
   cas_rn: 7646-79-9

--- a/data/ingredients/mapped/Cocl2_X_6_H2o.yaml
+++ b/data/ingredients/mapped/Cocl2_X_6_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:35696
 preferred_term: CoCl2 x 6 H2O
 ontology_mapping:
   ontology_id: CHEBI:35696
-  ontology_label: CoCl2 x 6 H2O
+  ontology_label: cobalt dichloride
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -97,6 +97,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.744312+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''CoCl2 x 6 H2O'' -> ''cobalt dichloride'': synced to canonical
+    CHEBI label (preferred_term ''CoCl2 x 6 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:35696
 chemical_properties:
   cas_rn: 7646-79-9

--- a/data/ingredients/mapped/Coenzyme_A.yaml
+++ b/data/ingredients/mapped/Coenzyme_A.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:15346
 preferred_term: Coenzyme A
 ontology_mapping:
   ontology_id: CHEBI:15346
-  ontology_label: Coenzyme A
+  ontology_label: coenzyme A
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -113,6 +113,11 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: COFACTOR_PROVIDER (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.744407+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Coenzyme A'' -> ''coenzyme A'': synced to canonical CHEBI
+    label (preferred_term ''Coenzyme A'' unchanged).'
 kg_microbe_node_id: CHEBI:15346
 chemical_properties:
   cas_rn: 85-61-0

--- a/data/ingredients/mapped/Congo_Red.yaml
+++ b/data/ingredients/mapped/Congo_Red.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:34653
 preferred_term: Congo red
 ontology_mapping:
   ontology_id: CHEBI:34653
-  ontology_label: Congo red
+  ontology_label: Congo Red
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -74,6 +74,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: PH_INDICATOR (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.744774+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Congo red'' -> ''Congo Red'': synced to canonical CHEBI
+    label (preferred_term ''Congo red'' unchanged).'
 chemical_properties:
   cas_rn: 573-58-0
   data_source: PubChem API

--- a/data/ingredients/mapped/Coso4.yaml
+++ b/data/ingredients/mapped/Coso4.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:53470
 preferred_term: CoSO4
 ontology_mapping:
   ontology_id: CHEBI:53470
-  ontology_label: CoSO4
+  ontology_label: cobalt(2+) sulfate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -89,6 +89,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.745274+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''CoSO4'' -> ''cobalt(2+) sulfate'': synced to canonical
+    CHEBI label (preferred_term ''CoSO4'' unchanged).'
 chemical_properties:
   cas_rn: 10124-43-3
   data_source: PubChem API

--- a/data/ingredients/mapped/Coso4_X_7_H2o.yaml
+++ b/data/ingredients/mapped/Coso4_X_7_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:53470
 preferred_term: CoSO4 x 7 H2O
 ontology_mapping:
   ontology_id: CHEBI:53470
-  ontology_label: CoSO4 x 7 H2O
+  ontology_label: cobalt(2+) sulfate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -77,6 +77,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.745368+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''CoSO4 x 7 H2O'' -> ''cobalt(2+) sulfate'': synced to
+    canonical CHEBI label (preferred_term ''CoSO4 x 7 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:53470
 chemical_properties:
   cas_rn: 10124-43-3

--- a/data/ingredients/mapped/Cr2_So43_X_N_H2o.yaml
+++ b/data/ingredients/mapped/Cr2_So43_X_N_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:53471
 preferred_term: Cr2(SO4)3 x n H2O
 ontology_mapping:
   ontology_id: CHEBI:53471
-  ontology_label: Cr2(SO4)3 x n H2O
+  ontology_label: chromium(III) sulfate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -81,6 +81,11 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: TRACE_ELEMENT (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.745680+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Cr2(SO4)3 x n H2O'' -> ''chromium(III) sulfate'': synced
+    to canonical CHEBI label (preferred_term ''Cr2(SO4)3 x n H2O'' unchanged).'
 chemical_properties:
   cas_rn: 10101-53-8
   data_source: PubChem (via CHEBI:53471)

--- a/data/ingredients/mapped/Cr_No33_X_7_H2o.yaml
+++ b/data/ingredients/mapped/Cr_No33_X_7_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:86206
 preferred_term: Cr(NO3)3 x 7 H2O
 ontology_mapping:
   ontology_id: CHEBI:86206
-  ontology_label: Cr(NO3)3 x 7 H2O
+  ontology_label: chromium trinitrate heptahydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -63,6 +63,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.745777+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Cr(NO3)3 x 7 H2O'' -> ''chromium trinitrate heptahydrate'':
+    synced to canonical CHEBI label (preferred_term ''Cr(NO3)3 x 7 H2O'' unchanged).'
 ingredient_type: SINGLE_INGREDIENT
 chemical_properties:
   molecular_formula: Cr.7H2O.3NO3

--- a/data/ingredients/mapped/Creatine.yaml
+++ b/data/ingredients/mapped/Creatine.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:16919
 preferred_term: Creatine
 ontology_mapping:
   ontology_id: CHEBI:16919
-  ontology_label: Creatine
+  ontology_label: creatine
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -94,6 +94,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.745875+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Creatine'' -> ''creatine'': synced to canonical CHEBI
+    label (preferred_term ''Creatine'' unchanged).'
 chemical_properties:
   cas_rn: 57-00-1
   data_source: PubChem API

--- a/data/ingredients/mapped/Creatinine.yaml
+++ b/data/ingredients/mapped/Creatinine.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:16737
 preferred_term: Creatinine
 ontology_mapping:
   ontology_id: CHEBI:16737
-  ontology_label: Creatinine
+  ontology_label: creatinine
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -81,6 +81,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.745970+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Creatinine'' -> ''creatinine'': synced to canonical CHEBI
+    label (preferred_term ''Creatinine'' unchanged).'
 chemical_properties:
   cas_rn: 60-27-5
   data_source: CultureBotHT/compounds_to_cas.csv

--- a/data/ingredients/mapped/Cresol_Red.yaml
+++ b/data/ingredients/mapped/Cresol_Red.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:86218
 preferred_term: Cresol red
 ontology_mapping:
   ontology_id: CHEBI:86218
-  ontology_label: Cresol red
+  ontology_label: cresol red
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -69,6 +69,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.746063+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Cresol red'' -> ''cresol red'': synced to canonical CHEBI
+    label (preferred_term ''Cresol red'' unchanged).'
 chemical_properties:
   cas_rn: 1733-12-6
   data_source: PubChem API

--- a/data/ingredients/mapped/Crotonic_Acid.yaml
+++ b/data/ingredients/mapped/Crotonic_Acid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:41131
 preferred_term: Crotonic acid
 ontology_mapping:
   ontology_id: CHEBI:41131
-  ontology_label: Crotonic acid
+  ontology_label: crotonic acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -114,6 +114,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.746248+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Crotonic acid'' -> ''crotonic acid'': synced to canonical
+    CHEBI label (preferred_term ''Crotonic acid'' unchanged).'
 chemical_properties:
   cas_rn: 107-93-7
   data_source: OAK/CHEBI xref

--- a/data/ingredients/mapped/Cu_No32_X_3_H2o.yaml
+++ b/data/ingredients/mapped/Cu_No32_X_3_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:78036
 preferred_term: Cu(NO3)2 x 3 H2O
 ontology_mapping:
   ontology_id: CHEBI:78036
-  ontology_label: Cu(NO3)2 x 3 H2O
+  ontology_label: copper(II) nitrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -52,6 +52,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.746528+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Cu(NO3)2 x 3 H2O'' -> ''copper(II) nitrate'': synced
+    to canonical CHEBI label (preferred_term ''Cu(NO3)2 x 3 H2O'' unchanged).'
 chemical_properties:
   cas_rn: 10031-43-3
   data_source: CultureBotHT/compounds_to_cas.csv

--- a/data/ingredients/mapped/Cucl.yaml
+++ b/data/ingredients/mapped/Cucl.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:53472
 preferred_term: CuCl
 ontology_mapping:
   ontology_id: CHEBI:53472
-  ontology_label: CuCl
+  ontology_label: copper(I) chloride
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -80,6 +80,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.746621+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''CuCl'' -> ''copper(I) chloride'': synced to canonical
+    CHEBI label (preferred_term ''CuCl'' unchanged).'
 chemical_properties:
   cas_rn: 7758-89-6
   data_source: PubChem API

--- a/data/ingredients/mapped/Cucl2.yaml
+++ b/data/ingredients/mapped/Cucl2.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:49553
 preferred_term: CuCl2
 ontology_mapping:
   ontology_id: CHEBI:49553
-  ontology_label: CuCl2
+  ontology_label: copper(II) chloride
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -132,6 +132,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.746714+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''CuCl2'' -> ''copper(II) chloride'': synced to canonical
+    CHEBI label (preferred_term ''CuCl2'' unchanged).'
 chemical_properties:
   cas_rn: 7447-39-4
   data_source: PubChem (via CHEBI:49553)

--- a/data/ingredients/mapped/Cucl2_X_2_H2o.yaml
+++ b/data/ingredients/mapped/Cucl2_X_2_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:86318
 preferred_term: CuCl2 x 2 H2O
 ontology_mapping:
   ontology_id: CHEBI:86318
-  ontology_label: CuCl2 x 2 H2O
+  ontology_label: copper(II) chloride dihydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -170,6 +170,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.746810+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''CuCl2 x 2 H2O'' -> ''copper(II) chloride dihydrate'':
+    synced to canonical CHEBI label (preferred_term ''CuCl2 x 2 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:86318
 chemical_properties:
   cas_rn: 10125-13-0

--- a/data/ingredients/mapped/Cucl2_X_5_H2o.yaml
+++ b/data/ingredients/mapped/Cucl2_X_5_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:91245
 preferred_term: CuCl2 x 5 H2O
 ontology_mapping:
   ontology_id: CHEBI:91245
-  ontology_label: CuCl2 x 5 H2O
+  ontology_label: copper(II) chloride pentahydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -64,6 +64,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.746911+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''CuCl2 x 5 H2O'' -> ''copper(II) chloride pentahydrate'':
+    synced to canonical CHEBI label (preferred_term ''CuCl2 x 5 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:91245
 ingredient_type: SINGLE_INGREDIENT
 chemical_properties:

--- a/data/ingredients/mapped/Cucl2_X_6_H2o.yaml
+++ b/data/ingredients/mapped/Cucl2_X_6_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:49553
 preferred_term: CuCl2 x 6 H2O
 ontology_mapping:
   ontology_id: CHEBI:49553
-  ontology_label: CuCl2 x 6 H2O
+  ontology_label: copper(II) chloride
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -72,6 +72,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.747013+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''CuCl2 x 6 H2O'' -> ''copper(II) chloride'': synced to
+    canonical CHEBI label (preferred_term ''CuCl2 x 6 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:49553
 chemical_properties:
   cas_rn: 7447-39-4

--- a/data/ingredients/mapped/Cuso4_X_2_H2o.yaml
+++ b/data/ingredients/mapped/Cuso4_X_2_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:23414
 preferred_term: CuSO4 x 2 H2O
 ontology_mapping:
   ontology_id: CHEBI:23414
-  ontology_label: CuSO4 x 2 H2O
+  ontology_label: copper(II) sulfate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -66,6 +66,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.747385+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''CuSO4 x 2 H2O'' -> ''copper(II) sulfate'': synced to
+    canonical CHEBI label (preferred_term ''CuSO4 x 2 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:23414
 chemical_properties:
   cas_rn: 7758-98-7

--- a/data/ingredients/mapped/Cuso4_X_4_H2o.yaml
+++ b/data/ingredients/mapped/Cuso4_X_4_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:23414
 preferred_term: CuSO4 x 4 H2O
 ontology_mapping:
   ontology_id: CHEBI:23414
-  ontology_label: CuSO4 x 4 H2O
+  ontology_label: copper(II) sulfate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -66,6 +66,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.747476+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''CuSO4 x 4 H2O'' -> ''copper(II) sulfate'': synced to
+    canonical CHEBI label (preferred_term ''CuSO4 x 4 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:23414
 chemical_properties:
   cas_rn: 7758-98-7

--- a/data/ingredients/mapped/Cuso4_X_5_H2o.yaml
+++ b/data/ingredients/mapped/Cuso4_X_5_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:31440
 preferred_term: CuSO4 x 5 H2O
 ontology_mapping:
   ontology_id: CHEBI:31440
-  ontology_label: CuSO4 x 5 H2O
+  ontology_label: copper(II) sulfate pentahydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -182,6 +182,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.747569+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''CuSO4 x 5 H2O'' -> ''copper(II) sulfate pentahydrate'':
+    synced to canonical CHEBI label (preferred_term ''CuSO4 x 5 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:31440
 chemical_properties:
   cas_rn: 7758-99-8

--- a/data/ingredients/mapped/Cuso4_X_6_H2o.yaml
+++ b/data/ingredients/mapped/Cuso4_X_6_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:91246
 preferred_term: CuSO4 x 6 H2O
 ontology_mapping:
   ontology_id: CHEBI:91246
-  ontology_label: CuSO4 x 6 H2O
+  ontology_label: copper(II) sulfate hexahydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -60,6 +60,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.747665+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''CuSO4 x 6 H2O'' -> ''copper(II) sulfate hexahydrate'':
+    synced to canonical CHEBI label (preferred_term ''CuSO4 x 6 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:91246
 ingredient_type: SINGLE_INGREDIENT
 chemical_properties:

--- a/data/ingredients/mapped/Cyanocobalamin.yaml
+++ b/data/ingredients/mapped/Cyanocobalamin.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17439
 preferred_term: Cyanocobalamin
 ontology_mapping:
   ontology_id: CHEBI:17439
-  ontology_label: Cyanocobalamin
+  ontology_label: cyanocob(III)alamin
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -155,6 +155,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: VITAMIN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.747763+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Cyanocobalamin'' -> ''cyanocob(III)alamin'': synced to
+    canonical CHEBI label (preferred_term ''Cyanocobalamin'' unchanged).'
 chemical_properties:
   cas_rn: 68-19-9
   data_source: CultureBotHT/compounds_to_cas.csv

--- a/data/ingredients/mapped/Cycloheximid.yaml
+++ b/data/ingredients/mapped/Cycloheximid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:27641
 preferred_term: Cycloheximid
 ontology_mapping:
   ontology_id: CHEBI:27641
-  ontology_label: Cycloheximid
+  ontology_label: cycloheximide
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -108,6 +108,11 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: SELECTIVE_AGENT (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.747856+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Cycloheximid'' -> ''cycloheximide'': synced to canonical
+    CHEBI label (preferred_term ''Cycloheximid'' unchanged).'
 chemical_properties:
   cas_rn: 66-81-9
   data_source: PubChem API

--- a/data/ingredients/mapped/Cyclomaltoheptaose.yaml
+++ b/data/ingredients/mapped/Cyclomaltoheptaose.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:495055
 preferred_term: Cyclomaltoheptaose
 ontology_mapping:
   ontology_id: CHEBI:495055
-  ontology_label: Cyclomaltoheptaose
+  ontology_label: beta-cyclodextrin
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -75,6 +75,11 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.747955+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Cyclomaltoheptaose'' -> ''beta-cyclodextrin'': synced
+    to canonical CHEBI label (preferred_term ''Cyclomaltoheptaose'' unchanged).'
 chemical_properties:
   cas_rn: 7585-39-9
   data_source: PubChem API

--- a/data/ingredients/mapped/Cysteine.yaml
+++ b/data/ingredients/mapped/Cysteine.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:15356
 preferred_term: Cysteine
 ontology_mapping:
   ontology_id: CHEBI:15356
-  ontology_label: Cysteine
+  ontology_label: cysteine
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -132,6 +132,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: NITROGEN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.748148+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Cysteine'' -> ''cysteine'': synced to canonical CHEBI
+    label (preferred_term ''Cysteine'' unchanged).'
 chemical_properties:
   cas_rn: 3374-22-9
   data_source: PubChem (via CHEBI:15356)

--- a/data/ingredients/mapped/D-arabinose.yaml
+++ b/data/ingredients/mapped/D-arabinose.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17108
 preferred_term: D-Arabinose
 ontology_mapping:
   ontology_id: CHEBI:17108
-  ontology_label: D-Arabinose
+  ontology_label: D-arabinose
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -62,6 +62,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.751412+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''D-Arabinose'' -> ''D-arabinose'': synced to canonical
+    CHEBI label (preferred_term ''D-Arabinose'' unchanged).'
 chemical_properties:
   cas_rn: 10323-20-3
   data_source: PubChem API

--- a/data/ingredients/mapped/D-fructose.yaml
+++ b/data/ingredients/mapped/D-fructose.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:15824
 preferred_term: D-Fructose
 ontology_mapping:
   ontology_id: CHEBI:15824
-  ontology_label: D-Fructose
+  ontology_label: D-fructose
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -91,6 +91,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.751601+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''D-Fructose'' -> ''D-fructose'': synced to canonical CHEBI
+    label (preferred_term ''D-Fructose'' unchanged).'
 chemical_properties:
   cas_rn: 57-48-7
   data_source: CultureBotHT/compounds_to_cas.csv

--- a/data/ingredients/mapped/D-galactose.yaml
+++ b/data/ingredients/mapped/D-galactose.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:12936
 preferred_term: D-Galactose
 ontology_mapping:
   ontology_id: CHEBI:12936
-  ontology_label: D-Galactose
+  ontology_label: D-galactose
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -90,6 +90,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.751701+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''D-Galactose'' -> ''D-galactose'': synced to canonical
+    CHEBI label (preferred_term ''D-Galactose'' unchanged).'
 chemical_properties:
   cas_rn: 59-23-4
   data_source: CultureBotHT/compounds_to_cas.csv

--- a/data/ingredients/mapped/D-glucose.yaml
+++ b/data/ingredients/mapped/D-glucose.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17634
 preferred_term: D-Glucose
 ontology_mapping:
   ontology_id: CHEBI:17634
-  ontology_label: D-Glucose
+  ontology_label: D-glucose
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -118,6 +118,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.751890+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''D-Glucose'' -> ''D-glucose'': synced to canonical CHEBI
+    label (preferred_term ''D-Glucose'' unchanged).'
 chemical_properties:
   cas_rn: 50-99-7
   data_source: CultureBotHT/compounds_to_cas.csv

--- a/data/ingredients/mapped/D-mannitol.yaml
+++ b/data/ingredients/mapped/D-mannitol.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:16899
 preferred_term: D-Mannitol
 ontology_mapping:
   ontology_id: CHEBI:16899
-  ontology_label: D-Mannitol
+  ontology_label: D-mannitol
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -84,6 +84,11 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.752171+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''D-Mannitol'' -> ''D-mannitol'': synced to canonical CHEBI
+    label (preferred_term ''D-Mannitol'' unchanged).'
 chemical_properties:
   cas_rn: 69-65-8
   data_source: PubChem API

--- a/data/ingredients/mapped/D-mannose.yaml
+++ b/data/ingredients/mapped/D-mannose.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:16024
 preferred_term: D-Mannose
 ontology_mapping:
   ontology_id: CHEBI:16024
-  ontology_label: D-Mannose
+  ontology_label: D-mannose
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -88,6 +88,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.752273+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''D-Mannose'' -> ''D-mannose'': synced to canonical CHEBI
+    label (preferred_term ''D-Mannose'' unchanged).'
 chemical_properties:
   cas_rn: 530-26-7
   data_source: PubChem API

--- a/data/ingredients/mapped/D-sorbitol.yaml
+++ b/data/ingredients/mapped/D-sorbitol.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17924
 preferred_term: D-Sorbitol
 ontology_mapping:
   ontology_id: CHEBI:17924
-  ontology_label: D-Sorbitol
+  ontology_label: D-glucitol
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -93,6 +93,11 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.752372+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''D-Sorbitol'' -> ''D-glucitol'': synced to canonical CHEBI
+    label (preferred_term ''D-Sorbitol'' unchanged).'
 chemical_properties:
   cas_rn: 50-70-4
   data_source: PubChem API

--- a/data/ingredients/mapped/D-xylose.yaml
+++ b/data/ingredients/mapped/D-xylose.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:65327
 preferred_term: D-Xylose
 ontology_mapping:
   ontology_id: CHEBI:65327
-  ontology_label: D-Xylose
+  ontology_label: D-xylose
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -78,6 +78,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.752564+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''D-Xylose'' -> ''D-xylose'': synced to canonical CHEBI
+    label (preferred_term ''D-Xylose'' unchanged).'
 chemical_properties:
   cas_rn: 58-86-6
   data_source: CultureBotHT/compounds_to_cas.csv

--- a/data/ingredients/mapped/D.yaml
+++ b/data/ingredients/mapped/D.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:29958
 preferred_term: D
 ontology_mapping:
   ontology_id: CHEBI:29958
-  ontology_label: D
+  ontology_label: L-aspartic acid residue
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -65,6 +65,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.752755+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''D'' -> ''L-aspartic acid residue'': synced to canonical
+    CHEBI label (preferred_term ''D'' unchanged).'
 chemical_properties:
   cas_rn: 138-86-3
   data_source: CultureBotHT compounds_to_cas.csv

--- a/data/ingredients/mapped/Dextran.yaml
+++ b/data/ingredients/mapped/Dextran.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:52071
 preferred_term: Dextran
 ontology_mapping:
   ontology_id: CHEBI:52071
-  ontology_label: Dextran
+  ontology_label: dextran
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -80,6 +80,11 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.754999+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Dextran'' -> ''dextran'': synced to canonical CHEBI label
+    (preferred_term ''Dextran'' unchanged).'
 chemical_properties:
   cas_rn: 9004-54-0
   data_source: CultureBotHT compounds_to_cas.csv

--- a/data/ingredients/mapped/Dextrin.yaml
+++ b/data/ingredients/mapped/Dextrin.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:28675
 preferred_term: Dextrin
 ontology_mapping:
   ontology_id: CHEBI:28675
-  ontology_label: Dextrin
+  ontology_label: dextrin
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -69,6 +69,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.755094+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Dextrin'' -> ''dextrin'': synced to canonical CHEBI label
+    (preferred_term ''Dextrin'' unchanged).'
 chemical_properties:
   cas_rn: 9004-53-9
   data_source: PubChem API

--- a/data/ingredients/mapped/Dextrose.yaml
+++ b/data/ingredients/mapped/Dextrose.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:4167
 preferred_term: Dextrose
 ontology_mapping:
   ontology_id: CHEBI:4167
-  ontology_label: Dextrose
+  ontology_label: D-glucopyranose
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -95,6 +95,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.755191+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Dextrose'' -> ''D-glucopyranose'': synced to canonical
+    CHEBI label (preferred_term ''Dextrose'' unchanged).'
 chemical_properties:
   cas_rn: 50-99-7
   data_source: PubChem (via CHEBI:4167)

--- a/data/ingredients/mapped/Dimethyl_Sulfoxide.yaml
+++ b/data/ingredients/mapped/Dimethyl_Sulfoxide.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:28262
 preferred_term: Dimethyl sulfoxide
 ontology_mapping:
   ontology_id: CHEBI:28262
-  ontology_label: Dimethyl sulfoxide
+  ontology_label: dimethyl sulfoxide
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -93,6 +93,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: SALT (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.756679+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Dimethyl sulfoxide'' -> ''dimethyl sulfoxide'': synced
+    to canonical CHEBI label (preferred_term ''Dimethyl sulfoxide'' unchanged).'
 chemical_properties:
   cas_rn: 67-68-5
   data_source: PubChem API

--- a/data/ingredients/mapped/Distilled_Water.yaml
+++ b/data/ingredients/mapped/Distilled_Water.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:15377
 preferred_term: Distilled water
 ontology_mapping:
   ontology_id: CHEBI:15377
-  ontology_label: Distilled water
+  ontology_label: water
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -269,6 +269,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: SALT (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.757483+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Distilled water'' -> ''water'': synced to canonical CHEBI
+    label (preferred_term ''Distilled water'' unchanged).'
 kg_microbe_node_id: CHEBI:15377
 chemical_properties:
   cas_rn: 7732-18-5

--- a/data/ingredients/mapped/Dithionite.yaml
+++ b/data/ingredients/mapped/Dithionite.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:42160
 preferred_term: Dithionite
 ontology_mapping:
   ontology_id: CHEBI:42160
-  ontology_label: Dithionite
+  ontology_label: dithionite(2-)
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -56,6 +56,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: REDUCING_AGENT (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.757581+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Dithionite'' -> ''dithionite(2-)'': synced to canonical
+    CHEBI label (preferred_term ''Dithionite'' unchanged).'
 chemical_properties:
   cas_rn: 14844-07-6
   data_source: PubChem API

--- a/data/ingredients/mapped/Dl-2-methylbutyric_Acid.yaml
+++ b/data/ingredients/mapped/Dl-2-methylbutyric_Acid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:37070
 preferred_term: DL-2-Methylbutyric acid
 ontology_mapping:
   ontology_id: CHEBI:37070
-  ontology_label: DL-2-Methylbutyric acid
+  ontology_label: 2-methylbutyric acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -184,6 +184,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.757679+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''DL-2-Methylbutyric acid'' -> ''2-methylbutyric acid'':
+    synced to canonical CHEBI label (preferred_term ''DL-2-Methylbutyric acid'' unchanged).'
 kg_microbe_node_id: CHEBI:37070
 chemical_properties:
   cas_rn: 116-53-0

--- a/data/ingredients/mapped/Dl-alpha-lipoic_Acid.yaml
+++ b/data/ingredients/mapped/Dl-alpha-lipoic_Acid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:16494
 preferred_term: (DL)-alpha-Lipoic acid
 ontology_mapping:
   ontology_id: CHEBI:16494
-  ontology_label: (DL)-alpha-Lipoic acid
+  ontology_label: lipoic acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -177,6 +177,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: VITAMIN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.757782+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''(DL)-alpha-Lipoic acid'' -> ''lipoic acid'': synced to
+    canonical CHEBI label (preferred_term ''(DL)-alpha-Lipoic acid'' unchanged).'
 kg_microbe_node_id: CHEBI:16494
 chemical_properties:
   cas_rn: 1077-28-7

--- a/data/ingredients/mapped/Dl-aspartic_Acid.yaml
+++ b/data/ingredients/mapped/Dl-aspartic_Acid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:22660
 preferred_term: DL-aspartic acid
 ontology_mapping:
   ontology_id: CHEBI:22660
-  ontology_label: DL-aspartic acid
+  ontology_label: aspartic acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -70,6 +70,11 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: AMINO_ACID_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.757887+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''DL-aspartic acid'' -> ''aspartic acid'': synced to canonical
+    CHEBI label (preferred_term ''DL-aspartic acid'' unchanged).'
 chemical_properties:
   cas_rn: 617-45-8
   data_source: PubChem API

--- a/data/ingredients/mapped/Dl-carnitine.yaml
+++ b/data/ingredients/mapped/Dl-carnitine.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17126
 preferred_term: DL-carnitine
 ontology_mapping:
   ontology_id: CHEBI:17126
-  ontology_label: DL-carnitine
+  ontology_label: carnitine
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -62,6 +62,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.757987+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''DL-carnitine'' -> ''carnitine'': synced to canonical
+    CHEBI label (preferred_term ''DL-carnitine'' unchanged).'
 chemical_properties:
   cas_rn: 406-76-8
   data_source: PubChem (via CHEBI:17126)

--- a/data/ingredients/mapped/Dl-dithiothreitol.yaml
+++ b/data/ingredients/mapped/Dl-dithiothreitol.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:18320
 preferred_term: DL-Dithiothreitol
 ontology_mapping:
   ontology_id: CHEBI:18320
-  ontology_label: DL-Dithiothreitol
+  ontology_label: 1,4-dithiothreitol
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -119,6 +119,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: REDUCING_AGENT (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.758100+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''DL-Dithiothreitol'' -> ''1,4-dithiothreitol'': synced
+    to canonical CHEBI label (preferred_term ''DL-Dithiothreitol'' unchanged).'
 chemical_properties:
   cas_rn: 3483-12-3
   data_source: OAK/CHEBI xref

--- a/data/ingredients/mapped/Dl-histidine.yaml
+++ b/data/ingredients/mapped/Dl-histidine.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:27570
 preferred_term: DL-Histidine
 ontology_mapping:
   ontology_id: CHEBI:27570
-  ontology_label: DL-Histidine
+  ontology_label: histidine
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -66,6 +66,11 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: AMINO_ACID_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.758202+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''DL-Histidine'' -> ''histidine'': synced to canonical
+    CHEBI label (preferred_term ''DL-Histidine'' unchanged).'
 chemical_properties:
   cas_rn: 4998-57-6
   data_source: PubChem API

--- a/data/ingredients/mapped/Dl-malic_Acid.yaml
+++ b/data/ingredients/mapped/Dl-malic_Acid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:6650
 preferred_term: DL-Malic acid
 ontology_mapping:
   ontology_id: CHEBI:6650
-  ontology_label: DL-Malic acid
+  ontology_label: malic acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -168,6 +168,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.758302+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''DL-Malic acid'' -> ''malic acid'': synced to canonical
+    CHEBI label (preferred_term ''DL-Malic acid'' unchanged).'
 chemical_properties:
   cas_rn: 6915-15-7
   data_source: PubChem API

--- a/data/ingredients/mapped/Dl-methionine.yaml
+++ b/data/ingredients/mapped/Dl-methionine.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:16811
 preferred_term: DL-methionine
 ontology_mapping:
   ontology_id: CHEBI:16811
-  ontology_label: DL-Methionine
+  ontology_label: methionine
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -97,6 +97,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: NITROGEN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.758398+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''DL-Methionine'' -> ''methionine'': synced to canonical
+    CHEBI label (preferred_term ''DL-methionine'' unchanged).'
 chemical_properties:
   cas_rn: 59-51-8
   data_source: PubChem API

--- a/data/ingredients/mapped/Edta.yaml
+++ b/data/ingredients/mapped/Edta.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:64755
 preferred_term: EDTA
 ontology_mapping:
   ontology_id: CHEBI:64755
-  ontology_label: EDTA
+  ontology_label: EDTA(2-)
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -75,6 +75,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CHELATOR (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.759866+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''EDTA'' -> ''EDTA(2-)'': synced to canonical CHEBI label
+    (preferred_term ''EDTA'' unchanged).'
 chemical_properties:
   cas_rn: 60-00-4
   data_source: PubChem API

--- a/data/ingredients/mapped/Erythromycin.yaml
+++ b/data/ingredients/mapped/Erythromycin.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:48923
 preferred_term: erythromycin
 ontology_mapping:
   ontology_id: CHEBI:48923
-  ontology_label: Erythromycin
+  ontology_label: erythromycin
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -68,6 +68,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: SELECTIVE_AGENT (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.760523+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Erythromycin'' -> ''erythromycin'': synced to canonical
+    CHEBI label (preferred_term ''erythromycin'' unchanged).'
 chemical_properties:
   cas_rn: 114-07-8
   data_source: PubChem API

--- a/data/ingredients/mapped/Ethanol.yaml
+++ b/data/ingredients/mapped/Ethanol.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:16236
 preferred_term: Ethanol
 ontology_mapping:
   ontology_id: CHEBI:16236
-  ontology_label: Ethanol
+  ontology_label: ethanol
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -168,6 +168,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: SALT (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.761295+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Ethanol'' -> ''ethanol'': synced to canonical CHEBI label
+    (preferred_term ''Ethanol'' unchanged).'
 chemical_properties:
   cas_rn: 64-17-5
   data_source: PubChem API

--- a/data/ingredients/mapped/Ethylene_Glycol.yaml
+++ b/data/ingredients/mapped/Ethylene_Glycol.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:30742
 preferred_term: Ethylene glycol
 ontology_mapping:
   ontology_id: CHEBI:30742
-  ontology_label: Ethylene glycol
+  ontology_label: ethylene glycol
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -77,6 +77,11 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.762168+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Ethylene glycol'' -> ''ethylene glycol'': synced to canonical
+    CHEBI label (preferred_term ''Ethylene glycol'' unchanged).'
 chemical_properties:
   cas_rn: 107-21-1
   data_source: PubChem API

--- a/data/ingredients/mapped/Fatty_Acid_Mixture_See_Medium_No_266.yaml
+++ b/data/ingredients/mapped/Fatty_Acid_Mixture_See_Medium_No_266.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:35366
 preferred_term: Fatty acid mixture (see Medium No. 266)
 ontology_mapping:
   ontology_id: CHEBI:35366
-  ontology_label: Fatty acid mixture (see Medium No. 266)
+  ontology_label: fatty acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -73,6 +73,12 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.762837+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Fatty acid mixture (see Medium No. 266)'' -> ''fatty
+    acid'': synced to canonical CHEBI label (preferred_term ''Fatty acid mixture (see
+    Medium No. 266)'' unchanged).'
 ingredient_type: SINGLE_INGREDIENT
 chemical_properties:
   molecular_formula: CHO2R

--- a/data/ingredients/mapped/Fe2_So43_X_N_H2o.yaml
+++ b/data/ingredients/mapped/Fe2_So43_X_N_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:53438
 preferred_term: Fe2(SO4)3 x n H2O
 ontology_mapping:
   ontology_id: CHEBI:53438
-  ontology_label: Fe2(SO4)3 x n H2O
+  ontology_label: iron(3+) sulfate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -91,6 +91,11 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: TRACE_ELEMENT (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.762941+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Fe2(SO4)3 x n H2O'' -> ''iron(3+) sulfate'': synced to
+    canonical CHEBI label (preferred_term ''Fe2(SO4)3 x n H2O'' unchanged).'
 chemical_properties:
   cas_rn: 10028-22-5
   data_source: PubChem (via CHEBI:53438)

--- a/data/ingredients/mapped/Fe4_Po42.yaml
+++ b/data/ingredients/mapped/Fe4_Po42.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:132767
 preferred_term: Fe4(PO4)2
 ontology_mapping:
   ontology_id: CHEBI:132767
-  ontology_label: Fe4(PO4)2
+  ontology_label: ferric pyrophosphate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -104,6 +104,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.763039+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Fe4(PO4)2'' -> ''ferric pyrophosphate'': synced to canonical
+    CHEBI label (preferred_term ''Fe4(PO4)2'' unchanged).'
 chemical_properties:
   cas_rn: 10058-44-3
   data_source: PubChem (via CHEBI:132767)

--- a/data/ingredients/mapped/Fe_Iii_Citrate.yaml
+++ b/data/ingredients/mapped/Fe_Iii_Citrate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:144421
 preferred_term: Fe(III) citrate
 ontology_mapping:
   ontology_id: CHEBI:144421
-  ontology_label: Fe(III) citrate
+  ontology_label: iron(III) citrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -174,6 +174,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.763230+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Fe(III) citrate'' -> ''iron(III) citrate'': synced to
+    canonical CHEBI label (preferred_term ''Fe(III) citrate'' unchanged).'
 chemical_properties:
   cas_rn: 3522-50-7
   data_source: OAK/CHEBI xref

--- a/data/ingredients/mapped/Fe_Iiipo4_X_4_H2o.yaml
+++ b/data/ingredients/mapped/Fe_Iiipo4_X_4_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:131372
 preferred_term: Fe(III)PO4 x 4 H2O
 ontology_mapping:
   ontology_id: CHEBI:131372
-  ontology_label: Fe(III)PO4 x 4 H2O
+  ontology_label: iron(3+) phosphate tetrahydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -72,6 +72,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.763328+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Fe(III)PO4 x 4 H2O'' -> ''iron(3+) phosphate tetrahydrate'':
+    synced to canonical CHEBI label (preferred_term ''Fe(III)PO4 x 4 H2O'' unchanged).'
 chemical_properties:
   cas_rn: 31096-47-6
   data_source: PubChem (via CHEBI:131372)

--- a/data/ingredients/mapped/Fe_Nh42_So42_X_7_H2o.yaml
+++ b/data/ingredients/mapped/Fe_Nh42_So42_X_7_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:131378
 preferred_term: Fe(NH4)2(SO4)2 x 7 H2O
 ontology_mapping:
   ontology_id: CHEBI:131378
-  ontology_label: Fe(NH4)2(SO4)2 x 7 H2O
+  ontology_label: ferrous ammonium sulfate heptahydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -67,6 +67,12 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: TRACE_ELEMENT (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.763516+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Fe(NH4)2(SO4)2 x 7 H2O'' -> ''ferrous ammonium sulfate
+    heptahydrate'': synced to canonical CHEBI label (preferred_term ''Fe(NH4)2(SO4)2
+    x 7 H2O'' unchanged).'
 ingredient_type: SINGLE_INGREDIENT
 chemical_properties:
   molecular_formula: Fe.7H2O.2H4N.2O4S

--- a/data/ingredients/mapped/Fecl2.yaml
+++ b/data/ingredients/mapped/Fecl2.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:30812
 preferred_term: FeCl2
 ontology_mapping:
   ontology_id: CHEBI:30812
-  ontology_label: FeCl2
+  ontology_label: iron dichloride
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -84,6 +84,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.763609+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''FeCl2'' -> ''iron dichloride'': synced to canonical CHEBI
+    label (preferred_term ''FeCl2'' unchanged).'
 chemical_properties:
   cas_rn: 7758-94-3
   data_source: PubChem (via CHEBI:30812)

--- a/data/ingredients/mapped/Fecl2_X_4_H2o.yaml
+++ b/data/ingredients/mapped/Fecl2_X_4_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:86249
 preferred_term: FeCl2 x 4 H2O
 ontology_mapping:
   ontology_id: CHEBI:86249
-  ontology_label: FeCl2 x 4 H2O
+  ontology_label: iron dichloride tetrahydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -170,6 +170,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.763705+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''FeCl2 x 4 H2O'' -> ''iron dichloride tetrahydrate'':
+    synced to canonical CHEBI label (preferred_term ''FeCl2 x 4 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:86249
 chemical_properties:
   cas_rn: 13478-10-9

--- a/data/ingredients/mapped/Fecl2_X_6_H2o.yaml
+++ b/data/ingredients/mapped/Fecl2_X_6_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:30812
 preferred_term: FeCl2 x 6 H2O
 ontology_mapping:
   ontology_id: CHEBI:30812
-  ontology_label: FeCl2 x 6 H2O
+  ontology_label: iron dichloride
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -62,6 +62,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.763798+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''FeCl2 x 6 H2O'' -> ''iron dichloride'': synced to canonical
+    CHEBI label (preferred_term ''FeCl2 x 6 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:30812
 chemical_properties:
   cas_rn: 7758-94-3

--- a/data/ingredients/mapped/Fecl2_X_7_H2o.yaml
+++ b/data/ingredients/mapped/Fecl2_X_7_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:30812
 preferred_term: FeCl2 x 7 H2O
 ontology_mapping:
   ontology_id: CHEBI:30812
-  ontology_label: FeCl2 x 7 H2O
+  ontology_label: iron dichloride
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -62,6 +62,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.763890+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''FeCl2 x 7 H2O'' -> ''iron dichloride'': synced to canonical
+    CHEBI label (preferred_term ''FeCl2 x 7 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:30812
 chemical_properties:
   cas_rn: 7758-94-3

--- a/data/ingredients/mapped/Fecl3.yaml
+++ b/data/ingredients/mapped/Fecl3.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:30808
 preferred_term: FeCl3
 ontology_mapping:
   ontology_id: CHEBI:30808
-  ontology_label: FeCl3
+  ontology_label: iron trichloride
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -80,6 +80,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.763988+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''FeCl3'' -> ''iron trichloride'': synced to canonical
+    CHEBI label (preferred_term ''FeCl3'' unchanged).'
 chemical_properties:
   cas_rn: 7705-08-0
   data_source: PubChem API

--- a/data/ingredients/mapped/Fecl3_X_4_H2o.yaml
+++ b/data/ingredients/mapped/Fecl3_X_4_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:30808
 preferred_term: FeCl3 x 4 H2O
 ontology_mapping:
   ontology_id: CHEBI:30808
-  ontology_label: FeCl3 x 4 H2O
+  ontology_label: iron trichloride
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -55,6 +55,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.764084+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''FeCl3 x 4 H2O'' -> ''iron trichloride'': synced to canonical
+    CHEBI label (preferred_term ''FeCl3 x 4 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:30808
 chemical_properties:
   cas_rn: 7705-08-0

--- a/data/ingredients/mapped/Ferric_Ammonium_Citrate.yaml
+++ b/data/ingredients/mapped/Ferric_Ammonium_Citrate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:31604
 preferred_term: Ferric ammonium citrate
 ontology_mapping:
   ontology_id: CHEBI:31604
-  ontology_label: Ferric ammonium citrate
+  ontology_label: ferric ammonium citrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -117,6 +117,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: NITROGEN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.764360+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Ferric ammonium citrate'' -> ''ferric ammonium citrate'':
+    synced to canonical CHEBI label (preferred_term ''Ferric ammonium citrate'' unchanged).'
 chemical_properties:
   cas_rn: 1185-57-5
   data_source: CultureBotHT compounds_to_cas.csv

--- a/data/ingredients/mapped/Feso4.yaml
+++ b/data/ingredients/mapped/Feso4.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:75832
 preferred_term: FeSO4
 ontology_mapping:
   ontology_id: CHEBI:75832
-  ontology_label: FeSO4
+  ontology_label: iron(2+) sulfate (anhydrous)
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -129,6 +129,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.764826+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''FeSO4'' -> ''iron(2+) sulfate (anhydrous)'': synced to
+    canonical CHEBI label (preferred_term ''FeSO4'' unchanged).'
 chemical_properties:
   cas_rn: 7720-78-7
   data_source: PubChem API

--- a/data/ingredients/mapped/Feso4_X_5_H2o.yaml
+++ b/data/ingredients/mapped/Feso4_X_5_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:75832
 preferred_term: FeSO4 x 5 H2O
 ontology_mapping:
   ontology_id: CHEBI:75832
-  ontology_label: FeSO4 x 5 H2O
+  ontology_label: iron(2+) sulfate (anhydrous)
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -81,6 +81,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.764919+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''FeSO4 x 5 H2O'' -> ''iron(2+) sulfate (anhydrous)'':
+    synced to canonical CHEBI label (preferred_term ''FeSO4 x 5 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:75832
 chemical_properties:
   cas_rn: 7720-78-7

--- a/data/ingredients/mapped/Feso4_X_6_H2o.yaml
+++ b/data/ingredients/mapped/Feso4_X_6_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:75832
 preferred_term: FeSO4 x 6 H2O
 ontology_mapping:
   ontology_id: CHEBI:75832
-  ontology_label: FeSO4 x 6 H2O
+  ontology_label: iron(2+) sulfate (anhydrous)
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -81,6 +81,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.765015+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''FeSO4 x 6 H2O'' -> ''iron(2+) sulfate (anhydrous)'':
+    synced to canonical CHEBI label (preferred_term ''FeSO4 x 6 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:75832
 chemical_properties:
   cas_rn: 7720-78-7

--- a/data/ingredients/mapped/Feso4_X_7_H2o.yaml
+++ b/data/ingredients/mapped/Feso4_X_7_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:75836
 preferred_term: FeSO4 x 7 H2O
 ontology_mapping:
   ontology_id: CHEBI:75836
-  ontology_label: FeSO4 x 7 H2O
+  ontology_label: iron(2+) sulfate heptahydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -177,6 +177,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.765112+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''FeSO4 x 7 H2O'' -> ''iron(2+) sulfate heptahydrate'':
+    synced to canonical CHEBI label (preferred_term ''FeSO4 x 7 H2O'' unchanged).'
 chemical_properties:
   cas_rn: 7782-63-0
   data_source: PubChem (via CHEBI:75836)

--- a/data/ingredients/mapped/Feso4_X_H2o.yaml
+++ b/data/ingredients/mapped/Feso4_X_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:75834
 preferred_term: FeSO4 x H2O
 ontology_mapping:
   ontology_id: CHEBI:75834
-  ontology_label: FeSO4 x H2O
+  ontology_label: iron(2+) sulfate monohydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -89,6 +89,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.765295+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''FeSO4 x H2O'' -> ''iron(2+) sulfate monohydrate'': synced
+    to canonical CHEBI label (preferred_term ''FeSO4 x H2O'' unchanged).'
 chemical_properties:
   cas_rn: 17375-41-6
   data_source: PubChem (via CHEBI:75834)

--- a/data/ingredients/mapped/Flavin_Adenine_Dinucleotide.yaml
+++ b/data/ingredients/mapped/Flavin_Adenine_Dinucleotide.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:24040
 preferred_term: Flavin adenine dinucleotide
 ontology_mapping:
   ontology_id: CHEBI:24040
-  ontology_label: Flavin adenine dinucleotide
+  ontology_label: flavin adenine dinucleotide
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -38,6 +38,12 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (CHEBI primary)
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.765485+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Flavin adenine dinucleotide'' -> ''flavin adenine dinucleotide'':
+    synced to canonical CHEBI label (preferred_term ''Flavin adenine dinucleotide''
+    unchanged).'
 chemical_properties:
   cas_rn: 146-14-5
   data_source: PubChem API

--- a/data/ingredients/mapped/Folic_Acid.yaml
+++ b/data/ingredients/mapped/Folic_Acid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:27470
 preferred_term: Folic acid
 ontology_mapping:
   ontology_id: CHEBI:27470
-  ontology_label: Folic acid
+  ontology_label: folic acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -169,6 +169,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: VITAMIN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.765867+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Folic acid'' -> ''folic acid'': synced to canonical CHEBI
+    label (preferred_term ''Folic acid'' unchanged).'
 chemical_properties:
   cas_rn: 59-30-3
   data_source: PubChem API

--- a/data/ingredients/mapped/Formic_Acid.yaml
+++ b/data/ingredients/mapped/Formic_Acid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:30751
 preferred_term: Formic acid
 ontology_mapping:
   ontology_id: CHEBI:30751
-  ontology_label: Formic acid
+  ontology_label: formic acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -93,6 +93,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.766242+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Formic acid'' -> ''formic acid'': synced to canonical
+    CHEBI label (preferred_term ''Formic acid'' unchanged).'
 chemical_properties:
   cas_rn: 64-18-6
   data_source: PubChem API

--- a/data/ingredients/mapped/Fucose.yaml
+++ b/data/ingredients/mapped/Fucose.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:33984
 preferred_term: Fucose
 ontology_mapping:
   ontology_id: CHEBI:33984
-  ontology_label: Fucose
+  ontology_label: fucose
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -53,6 +53,11 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.766808+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Fucose'' -> ''fucose'': synced to canonical CHEBI label
+    (preferred_term ''Fucose'' unchanged).'
 chemical_properties:
   cas_rn: 219-452-7
   data_source: PubChem API

--- a/data/ingredients/mapped/Fumaric_Acid.yaml
+++ b/data/ingredients/mapped/Fumaric_Acid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:18012
 preferred_term: Fumaric acid
 ontology_mapping:
   ontology_id: CHEBI:18012
-  ontology_label: Fumaric acid
+  ontology_label: fumaric acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -122,6 +122,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.766907+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Fumaric acid'' -> ''fumaric acid'': synced to canonical
+    CHEBI label (preferred_term ''Fumaric acid'' unchanged).'
 chemical_properties:
   cas_rn: 110-17-8
   data_source: PubChem API

--- a/data/ingredients/mapped/Gamma-aminobutyric_Acid.yaml
+++ b/data/ingredients/mapped/Gamma-aminobutyric_Acid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:16865
 preferred_term: gamma-Aminobutyric acid
 ontology_mapping:
   ontology_id: CHEBI:16865
-  ontology_label: gamma-Aminobutyric acid
+  ontology_label: gamma-aminobutyric acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -94,6 +94,11 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: AMINO_ACID_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.767742+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''gamma-Aminobutyric acid'' -> ''gamma-aminobutyric acid'':
+    synced to canonical CHEBI label (preferred_term ''gamma-Aminobutyric acid'' unchanged).'
 chemical_properties:
   cas_rn: 56-12-2
   data_source: PubChem API

--- a/data/ingredients/mapped/Gelatine.yaml
+++ b/data/ingredients/mapped/Gelatine.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:5291
 preferred_term: Gelatine
 ontology_mapping:
   ontology_id: CHEBI:5291
-  ontology_label: Gelatine
+  ontology_label: gelatin
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -75,6 +75,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: SOLIDIFYING_AGENT (confidence: 0.90)'
+- timestamp: '2026-06-09T05:23:46.767939+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Gelatine'' -> ''gelatin'': synced to canonical CHEBI
+    label (preferred_term ''Gelatine'' unchanged).'
 kg_microbe_node_id: CHEBI:5291
 chemical_properties:
   cas_rn: 9000-70-8

--- a/data/ingredients/mapped/Gelrite.yaml
+++ b/data/ingredients/mapped/Gelrite.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:85248
 preferred_term: Gelrite
 ontology_mapping:
   ontology_id: CHEBI:85248
-  ontology_label: Gelrite
+  ontology_label: gellan gum
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -77,6 +77,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: SOLIDIFYING_AGENT (confidence: 0.90)'
+- timestamp: '2026-06-09T05:23:46.768036+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Gelrite'' -> ''gellan gum'': synced to canonical CHEBI
+    label (preferred_term ''Gelrite'' unchanged).'
 kg_microbe_node_id: CHEBI:85248
 ingredient_type: SINGLE_INGREDIENT
 media_roles:

--- a/data/ingredients/mapped/Gentisic_Acid.yaml
+++ b/data/ingredients/mapped/Gentisic_Acid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17189
 preferred_term: Gentisic acid
 ontology_mapping:
   ontology_id: CHEBI:17189
-  ontology_label: Gentisic acid
+  ontology_label: 2,5-dihydroxybenzoic acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -66,6 +66,11 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.768404+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Gentisic acid'' -> ''2,5-dihydroxybenzoic acid'': synced
+    to canonical CHEBI label (preferred_term ''Gentisic acid'' unchanged).'
 chemical_properties:
   cas_rn: 490-79-9
   data_source: PubChem API

--- a/data/ingredients/mapped/Gluconic_Acid.yaml
+++ b/data/ingredients/mapped/Gluconic_Acid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:24266
 preferred_term: Gluconic acid
 ontology_mapping:
   ontology_id: CHEBI:24266
-  ontology_label: Gluconic acid
+  ontology_label: gluconic acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -50,6 +50,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.768869+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Gluconic acid'' -> ''gluconic acid'': synced to canonical
+    CHEBI label (preferred_term ''Gluconic acid'' unchanged).'
 chemical_properties:
   cas_rn: 526-95-4
   data_source: PubChem API

--- a/data/ingredients/mapped/Glucose.yaml
+++ b/data/ingredients/mapped/Glucose.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17234
 preferred_term: Glucose
 ontology_mapping:
   ontology_id: CHEBI:17234
-  ontology_label: Glucose
+  ontology_label: glucose
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -127,6 +127,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.768965+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Glucose'' -> ''glucose'': synced to canonical CHEBI label
+    (preferred_term ''Glucose'' unchanged).'
 chemical_properties:
   cas_rn: 50-99-7
   data_source: CultureBotHT/compounds_to_cas.csv

--- a/data/ingredients/mapped/Glutamic_Acid.yaml
+++ b/data/ingredients/mapped/Glutamic_Acid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:18237
 preferred_term: Glutamic acid
 ontology_mapping:
   ontology_id: CHEBI:18237
-  ontology_label: Glutamic acid
+  ontology_label: glutamic acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -93,6 +93,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: NITROGEN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.769242+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Glutamic acid'' -> ''glutamic acid'': synced to canonical
+    CHEBI label (preferred_term ''Glutamic acid'' unchanged).'
 chemical_properties:
   cas_rn: 56-86-0
   data_source: PubChem API

--- a/data/ingredients/mapped/Glycerol.yaml
+++ b/data/ingredients/mapped/Glycerol.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17754
 preferred_term: Glycerol
 ontology_mapping:
   ontology_id: CHEBI:17754
-  ontology_label: Glycerol
+  ontology_label: glycerol
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -99,6 +99,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.770007+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Glycerol'' -> ''glycerol'': synced to canonical CHEBI
+    label (preferred_term ''Glycerol'' unchanged).'
 chemical_properties:
   cas_rn: 56-81-5
   data_source: CultureBotHT compounds_to_cas.csv

--- a/data/ingredients/mapped/Glycerol_Mono-oleate.yaml
+++ b/data/ingredients/mapped/Glycerol_Mono-oleate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:75937
 preferred_term: Glycerol mono-oleate
 ontology_mapping:
   ontology_id: CHEBI:75937
-  ontology_label: Glycerol mono-oleate
+  ontology_label: monooleoylglycerol
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -68,6 +68,11 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: SURFACTANT (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.770200+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Glycerol mono-oleate'' -> ''monooleoylglycerol'': synced
+    to canonical CHEBI label (preferred_term ''Glycerol mono-oleate'' unchanged).'
 chemical_properties:
   cas_rn: 129784-87-8
   data_source: PubChem API

--- a/data/ingredients/mapped/Glycine.yaml
+++ b/data/ingredients/mapped/Glycine.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:15428
 preferred_term: Glycine
 ontology_mapping:
   ontology_id: CHEBI:15428
-  ontology_label: Glycine
+  ontology_label: glycine
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -99,6 +99,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: NITROGEN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.770391+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Glycine'' -> ''glycine'': synced to canonical CHEBI label
+    (preferred_term ''Glycine'' unchanged).'
 chemical_properties:
   cas_rn: 56-40-6
   data_source: PubChem API

--- a/data/ingredients/mapped/Glycyl-glycine.yaml
+++ b/data/ingredients/mapped/Glycyl-glycine.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17201
 preferred_term: Glycyl-glycine
 ontology_mapping:
   ontology_id: CHEBI:17201
-  ontology_label: Glycyl-glycine
+  ontology_label: glycylglycine
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -77,6 +77,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: NITROGEN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.770954+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Glycyl-glycine'' -> ''glycylglycine'': synced to canonical
+    CHEBI label (preferred_term ''Glycyl-glycine'' unchanged).'
 chemical_properties:
   cas_rn: 556-50-3
   data_source: PubChem API

--- a/data/ingredients/mapped/H2seo3.yaml
+++ b/data/ingredients/mapped/H2seo3.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:26642
 preferred_term: H2SeO3
 ontology_mapping:
   ontology_id: CHEBI:26642
-  ontology_label: H2SeO3
+  ontology_label: selenous acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -72,6 +72,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.772181+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''H2SeO3'' -> ''selenous acid'': synced to canonical CHEBI
+    label (preferred_term ''H2SeO3'' unchanged).'
 chemical_properties:
   cas_rn: 7783-00-8
   data_source: PubChem (via CHEBI:26642)

--- a/data/ingredients/mapped/H2so4.yaml
+++ b/data/ingredients/mapped/H2so4.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:26836
 preferred_term: H2SO4
 ontology_mapping:
   ontology_id: CHEBI:26836
-  ontology_label: H2SO4
+  ontology_label: sulfuric acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -109,6 +109,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.772280+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''H2SO4'' -> ''sulfuric acid'': synced to canonical CHEBI
+    label (preferred_term ''H2SO4'' unchanged).'
 chemical_properties:
   cas_rn: 7664-93-9
   data_source: PubChem API

--- a/data/ingredients/mapped/H3bo2.yaml
+++ b/data/ingredients/mapped/H3bo2.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:38267
 preferred_term: H3BO2
 ontology_mapping:
   ontology_id: CHEBI:38267
-  ontology_label: H3BO2
+  ontology_label: boronic acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -65,6 +65,11 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: TRACE_ELEMENT (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.772471+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''H3BO2'' -> ''boronic acid'': synced to canonical CHEBI
+    label (preferred_term ''H3BO2'' unchanged).'
 chemical_properties:
   cas_rn: 13780-71-7
   data_source: PubChem (via CHEBI:38267)

--- a/data/ingredients/mapped/H3bo3.yaml
+++ b/data/ingredients/mapped/H3bo3.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:33118
 preferred_term: H3BO3
 ontology_mapping:
   ontology_id: CHEBI:33118
-  ontology_label: H3BO3
+  ontology_label: boric acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -147,6 +147,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.772568+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''H3BO3'' -> ''boric acid'': synced to canonical CHEBI
+    label (preferred_term ''H3BO3'' unchanged).'
 chemical_properties:
   cas_rn: 10043-35-3
   data_source: CultureBotHT compounds_to_cas.csv

--- a/data/ingredients/mapped/Haemin.yaml
+++ b/data/ingredients/mapped/Haemin.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:50385
 preferred_term: Haemin
 ontology_mapping:
   ontology_id: CHEBI:50385
-  ontology_label: Haemin
+  ontology_label: hemin
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -168,6 +168,11 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: COFACTOR_PROVIDER (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.772666+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Haemin'' -> ''hemin'': synced to canonical CHEBI label
+    (preferred_term ''Haemin'' unchanged).'
 chemical_properties:
   cas_rn: 16009-13-5
   data_source: PubChem API

--- a/data/ingredients/mapped/Hcl.yaml
+++ b/data/ingredients/mapped/Hcl.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17883
 preferred_term: HCl
 ontology_mapping:
   ontology_id: CHEBI:17883
-  ontology_label: HCl
+  ontology_label: hydrogen chloride
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -122,6 +122,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: SALT (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.773229+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''HCl'' -> ''hydrogen chloride'': synced to canonical CHEBI
+    label (preferred_term ''HCl'' unchanged).'
 chemical_properties:
   cas_rn: 7647-01-0
   data_source: PubChem API

--- a/data/ingredients/mapped/Heptadecane.yaml
+++ b/data/ingredients/mapped/Heptadecane.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:16148
 preferred_term: Heptadecane
 ontology_mapping:
   ontology_id: CHEBI:16148
-  ontology_label: Heptadecane
+  ontology_label: heptadecane
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -59,6 +59,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.773707+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Heptadecane'' -> ''heptadecane'': synced to canonical
+    CHEBI label (preferred_term ''Heptadecane'' unchanged).'
 chemical_properties:
   cas_rn: 629-78-7
   data_source: PubChem API

--- a/data/ingredients/mapped/Hexachlorocyclo-hexane.yaml
+++ b/data/ingredients/mapped/Hexachlorocyclo-hexane.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:24536
 preferred_term: Hexachlorocyclo-hexane
 ontology_mapping:
   ontology_id: CHEBI:24536
-  ontology_label: Hexachlorocyclo-hexane
+  ontology_label: hexachlorocyclohexane
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -68,6 +68,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.774166+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Hexachlorocyclo-hexane'' -> ''hexachlorocyclohexane'':
+    synced to canonical CHEBI label (preferred_term ''Hexachlorocyclo-hexane'' unchanged).'
 chemical_properties:
   cas_rn: 27154-44-5
   data_source: PubChem (via CHEBI:24536)

--- a/data/ingredients/mapped/Hexadecane.yaml
+++ b/data/ingredients/mapped/Hexadecane.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:45296
 preferred_term: Hexadecane
 ontology_mapping:
   ontology_id: CHEBI:45296
-  ontology_label: Hexadecane
+  ontology_label: hexadecane
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -78,6 +78,11 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.774264+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Hexadecane'' -> ''hexadecane'': synced to canonical CHEBI
+    label (preferred_term ''Hexadecane'' unchanged).'
 chemical_properties:
   cas_rn: 544-76-3
   data_source: PubChem API

--- a/data/ingredients/mapped/Hypoxanthine.yaml
+++ b/data/ingredients/mapped/Hypoxanthine.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17368
 preferred_term: Hypoxanthine
 ontology_mapping:
   ontology_id: CHEBI:17368
-  ontology_label: Hypoxanthine
+  ontology_label: hypoxanthine
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -71,6 +71,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.776308+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Hypoxanthine'' -> ''hypoxanthine'': synced to canonical
+    CHEBI label (preferred_term ''Hypoxanthine'' unchanged).'
 chemical_properties:
   cas_rn: 68-94-0
   data_source: PubChem API

--- a/data/ingredients/mapped/Indigocarmine.yaml
+++ b/data/ingredients/mapped/Indigocarmine.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:31695
 preferred_term: Indigocarmine
 ontology_mapping:
   ontology_id: CHEBI:31695
-  ontology_label: Indigocarmine
+  ontology_label: indigo carmine
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -132,6 +132,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: PH_INDICATOR (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.776614+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Indigocarmine'' -> ''indigo carmine'': synced to canonical
+    CHEBI label (preferred_term ''Indigocarmine'' unchanged).'
 kg_microbe_node_id: CHEBI:31695
 chemical_properties:
   cas_rn: 860-22-0

--- a/data/ingredients/mapped/Indole.yaml
+++ b/data/ingredients/mapped/Indole.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:16881
 preferred_term: Indole
 ontology_mapping:
   ontology_id: CHEBI:16881
-  ontology_label: indole
+  ontology_label: 1H-indole
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -37,6 +37,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.777058+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''indole'' -> ''1H-indole'': synced to canonical CHEBI
+    label (preferred_term ''Indole'' unchanged).'
 ingredient_type: SINGLE_INGREDIENT
 chemical_properties:
   molecular_formula: C8H7N

--- a/data/ingredients/mapped/Inositol.yaml
+++ b/data/ingredients/mapped/Inositol.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:24848
 preferred_term: Inositol
 ontology_mapping:
   ontology_id: CHEBI:24848
-  ontology_label: Inositol
+  ontology_label: inositol
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -55,6 +55,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: VITAMIN_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.777588+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Inositol'' -> ''inositol'': synced to canonical CHEBI
+    label (preferred_term ''Inositol'' unchanged).'
 chemical_properties:
   cas_rn: 87-89-8
   data_source: PubChem API

--- a/data/ingredients/mapped/Inulin.yaml
+++ b/data/ingredients/mapped/Inulin.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:15443
 preferred_term: Inulin
 ontology_mapping:
   ontology_id: CHEBI:15443
-  ontology_label: Inulin
+  ontology_label: inulin
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -63,6 +63,11 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.777716+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Inulin'' -> ''inulin'': synced to canonical CHEBI label
+    (preferred_term ''Inulin'' unchanged).'
 chemical_properties:
   cas_rn: 9005-80-5
   data_source: CultureBotHT compounds_to_cas.csv

--- a/data/ingredients/mapped/Iron.yaml
+++ b/data/ingredients/mapped/Iron.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:18248
 preferred_term: Iron
 ontology_mapping:
   ontology_id: CHEBI:18248
-  ontology_label: Iron
+  ontology_label: iron atom
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -67,6 +67,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.778142+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Iron'' -> ''iron atom'': synced to canonical CHEBI label
+    (preferred_term ''Iron'' unchanged).'
 chemical_properties:
   cas_rn: 7439-89-6
   data_source: PubChem API

--- a/data/ingredients/mapped/Iron_Powder.yaml
+++ b/data/ingredients/mapped/Iron_Powder.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:82664
 preferred_term: Iron powder
 ontology_mapping:
   ontology_id: CHEBI:82664
-  ontology_label: Iron powder
+  ontology_label: iron(0)
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -100,6 +100,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.778255+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Iron powder'' -> ''iron(0)'': synced to canonical CHEBI
+    label (preferred_term ''Iron powder'' unchanged).'
 chemical_properties:
   cas_rn: 7439-89-6
   data_source: PubChem (via CHEBI:82664)

--- a/data/ingredients/mapped/Isobutyric_Acid.yaml
+++ b/data/ingredients/mapped/Isobutyric_Acid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:16135
 preferred_term: Isobutyric acid
 ontology_mapping:
   ontology_id: CHEBI:16135
-  ontology_label: Isobutyric acid
+  ontology_label: isobutyric acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -121,6 +121,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.778550+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Isobutyric acid'' -> ''isobutyric acid'': synced to canonical
+    CHEBI label (preferred_term ''Isobutyric acid'' unchanged).'
 chemical_properties:
   cas_rn: 79-31-2
   data_source: CultureBotHT compounds_to_cas.csv

--- a/data/ingredients/mapped/Isopropyl_Alcohol.yaml
+++ b/data/ingredients/mapped/Isopropyl_Alcohol.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17824
 preferred_term: Isopropyl alcohol
 ontology_mapping:
   ontology_id: CHEBI:17824
-  ontology_label: Isopropyl alcohol
+  ontology_label: propan-2-ol
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -83,6 +83,11 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.778955+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Isopropyl alcohol'' -> ''propan-2-ol'': synced to canonical
+    CHEBI label (preferred_term ''Isopropyl alcohol'' unchanged).'
 chemical_properties:
   cas_rn: 67-63-0
   data_source: PubChem API

--- a/data/ingredients/mapped/Isovaleric_Acid.yaml
+++ b/data/ingredients/mapped/Isovaleric_Acid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:28484
 preferred_term: Isovaleric acid
 ontology_mapping:
   ontology_id: CHEBI:28484
-  ontology_label: Isovaleric acid
+  ontology_label: isovaleric acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -168,6 +168,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.779172+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Isovaleric acid'' -> ''isovaleric acid'': synced to canonical
+    CHEBI label (preferred_term ''Isovaleric acid'' unchanged).'
 chemical_properties:
   cas_rn: 503-74-2
   data_source: CultureBotHT compounds_to_cas.csv

--- a/data/ingredients/mapped/K-acetate.yaml
+++ b/data/ingredients/mapped/K-acetate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:32029
 preferred_term: K-acetate
 ontology_mapping:
   ontology_id: CHEBI:32029
-  ontology_label: K-acetate
+  ontology_label: potassium acetate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -106,6 +106,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.779673+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''K-acetate'' -> ''potassium acetate'': synced to canonical
+    CHEBI label (preferred_term ''K-acetate'' unchanged).'
 chemical_properties:
   cas_rn: 127-08-2
   data_source: PubChem API (preprocessed)

--- a/data/ingredients/mapped/K2co3.yaml
+++ b/data/ingredients/mapped/K2co3.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:131526
 preferred_term: K2CO3
 ontology_mapping:
   ontology_id: CHEBI:131526
-  ontology_label: K2CO3
+  ontology_label: potassium carbonate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -69,6 +69,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.779776+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''K2CO3'' -> ''potassium carbonate'': synced to canonical
+    CHEBI label (preferred_term ''K2CO3'' unchanged).'
 chemical_properties:
   cas_rn: 584-08-7
   data_source: PubChem API

--- a/data/ingredients/mapped/K2hpo4.yaml
+++ b/data/ingredients/mapped/K2hpo4.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:131527
 preferred_term: K2HPO4
 ontology_mapping:
   ontology_id: CHEBI:131527
-  ontology_label: K2HPO4
+  ontology_label: dipotassium hydrogen phosphate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -215,6 +215,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: BUFFER (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.779982+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''K2HPO4'' -> ''dipotassium hydrogen phosphate'': synced
+    to canonical CHEBI label (preferred_term ''K2HPO4'' unchanged).'
 chemical_properties:
   cas_rn: 7758-11-4
   data_source: CultureBotHT compounds_to_cas.csv

--- a/data/ingredients/mapped/K2hpo4_X_3_H2o.yaml
+++ b/data/ingredients/mapped/K2hpo4_X_3_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:131527
 preferred_term: K2HPO4 x 3 H2O
 ontology_mapping:
   ontology_id: CHEBI:131527
-  ontology_label: K2HPO4 x 3 H2O
+  ontology_label: dipotassium hydrogen phosphate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -80,6 +80,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: BUFFER (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.780086+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''K2HPO4 x 3 H2O'' -> ''dipotassium hydrogen phosphate'':
+    synced to canonical CHEBI label (preferred_term ''K2HPO4 x 3 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:131527
 chemical_properties:
   cas_rn: 7758-11-4

--- a/data/ingredients/mapped/K2so4.yaml
+++ b/data/ingredients/mapped/K2so4.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:32036
 preferred_term: K2SO4
 ontology_mapping:
   ontology_id: CHEBI:32036
-  ontology_label: K2SO4
+  ontology_label: potassium sulfate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -108,6 +108,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.780296+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''K2SO4'' -> ''potassium sulfate'': synced to canonical
+    CHEBI label (preferred_term ''K2SO4'' unchanged).'
 chemical_properties:
   cas_rn: 7778-80-5
   data_source: PubChem API

--- a/data/ingredients/mapped/K2so4_X_7_H2o.yaml
+++ b/data/ingredients/mapped/K2so4_X_7_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:32036
 preferred_term: K2SO4 x 7 H2O
 ontology_mapping:
   ontology_id: CHEBI:32036
-  ontology_label: K2SO4 x 7 H2O
+  ontology_label: potassium sulfate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -59,6 +59,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.780393+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''K2SO4 x 7 H2O'' -> ''potassium sulfate'': synced to canonical
+    CHEBI label (preferred_term ''K2SO4 x 7 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:32036
 chemical_properties:
   cas_rn: 7778-80-5

--- a/data/ingredients/mapped/Kanamycin_Sulfate.yaml
+++ b/data/ingredients/mapped/Kanamycin_Sulfate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:6109
 preferred_term: Kanamycin sulfate
 ontology_mapping:
   ontology_id: CHEBI:6109
-  ontology_label: Kanamycin sulfate
+  ontology_label: kanamycin A sulfate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -69,6 +69,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: SELECTIVE_AGENT (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.780586+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Kanamycin sulfate'' -> ''kanamycin A sulfate'': synced
+    to canonical CHEBI label (preferred_term ''Kanamycin sulfate'' unchanged).'
 chemical_properties:
   cas_rn: 25839-94-0
   data_source: CultureBotHT/compounds_to_cas.csv

--- a/data/ingredients/mapped/Kbr.yaml
+++ b/data/ingredients/mapped/Kbr.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:32030
 preferred_term: KBr
 ontology_mapping:
   ontology_id: CHEBI:32030
-  ontology_label: KBr
+  ontology_label: potassium bromide
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -78,6 +78,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.780866+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''KBr'' -> ''potassium bromide'': synced to canonical CHEBI
+    label (preferred_term ''KBr'' unchanged).'
 chemical_properties:
   cas_rn: 7758-02-3
   data_source: PubChem API

--- a/data/ingredients/mapped/Kcl.yaml
+++ b/data/ingredients/mapped/Kcl.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:32588
 preferred_term: KCl
 ontology_mapping:
   ontology_id: CHEBI:32588
-  ontology_label: KCl
+  ontology_label: potassium chloride
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -192,6 +192,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.780968+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''KCl'' -> ''potassium chloride'': synced to canonical
+    CHEBI label (preferred_term ''KCl'' unchanged).'
 chemical_properties:
   cas_rn: 7447-40-7
   data_source: PubChem API

--- a/data/ingredients/mapped/Kf.yaml
+++ b/data/ingredients/mapped/Kf.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:73605
 preferred_term: KF
 ontology_mapping:
   ontology_id: CHEBI:73605
-  ontology_label: KF
+  ontology_label: Lys-Phe
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -68,6 +68,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.781067+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''KF'' -> ''Lys-Phe'': synced to canonical CHEBI label
+    (preferred_term ''KF'' unchanged).'
 kg_microbe_node_id: CHEBI:73605
 chemical_properties:
   cas_rn: 6235-35-4

--- a/data/ingredients/mapped/Kh2po4.yaml
+++ b/data/ingredients/mapped/Kh2po4.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:63036
 preferred_term: KH2PO4
 ontology_mapping:
   ontology_id: CHEBI:63036
-  ontology_label: KH2PO4
+  ontology_label: potassium dihydrogen phosphate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -192,6 +192,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: BUFFER (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.781166+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''KH2PO4'' -> ''potassium dihydrogen phosphate'': synced
+    to canonical CHEBI label (preferred_term ''KH2PO4'' unchanged).'
 chemical_properties:
   cas_rn: 7778-77-0
   data_source: PubChem API

--- a/data/ingredients/mapped/Khco3.yaml
+++ b/data/ingredients/mapped/Khco3.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:81862
 preferred_term: KHCO3
 ontology_mapping:
   ontology_id: CHEBI:81862
-  ontology_label: KHCO3
+  ontology_label: potassium hydrogencarbonate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -81,6 +81,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.781273+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''KHCO3'' -> ''potassium hydrogencarbonate'': synced to
+    canonical CHEBI label (preferred_term ''KHCO3'' unchanged).'
 chemical_properties:
   cas_rn: 298-14-6
   data_source: PubChem API

--- a/data/ingredients/mapped/Kscn.yaml
+++ b/data/ingredients/mapped/Kscn.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:30951
 preferred_term: KSCN
 ontology_mapping:
   ontology_id: CHEBI:30951
-  ontology_label: KSCN
+  ontology_label: potassium thiocyanate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -67,6 +67,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.781740+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''KSCN'' -> ''potassium thiocyanate'': synced to canonical
+    CHEBI label (preferred_term ''KSCN'' unchanged).'
 chemical_properties:
   cas_rn: 333-20-0
   data_source: PubChem API

--- a/data/ingredients/mapped/L-alanine.yaml
+++ b/data/ingredients/mapped/L-alanine.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:16977
 preferred_term: L-Alanine
 ontology_mapping:
   ontology_id: CHEBI:16977
-  ontology_label: L-Alanine
+  ontology_label: L-alanine
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -89,6 +89,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: NITROGEN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.783667+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''L-Alanine'' -> ''L-alanine'': synced to canonical CHEBI
+    label (preferred_term ''L-Alanine'' unchanged).'
 chemical_properties:
   cas_rn: 56-41-7
   data_source: PubChem API

--- a/data/ingredients/mapped/L-arginine.yaml
+++ b/data/ingredients/mapped/L-arginine.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:16467
 preferred_term: L-Arginine
 ontology_mapping:
   ontology_id: CHEBI:16467
-  ontology_label: L-Arginine
+  ontology_label: L-arginine
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -91,6 +91,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: NITROGEN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.783949+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''L-Arginine'' -> ''L-arginine'': synced to canonical CHEBI
+    label (preferred_term ''L-Arginine'' unchanged).'
 chemical_properties:
   cas_rn: 74-79-3
   data_source: PubChem API

--- a/data/ingredients/mapped/L-ascorbic_Acid.yaml
+++ b/data/ingredients/mapped/L-ascorbic_Acid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:29073
 preferred_term: L-Ascorbic acid
 ontology_mapping:
   ontology_id: CHEBI:29073
-  ontology_label: L-Ascorbic acid
+  ontology_label: L-ascorbic acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -116,6 +116,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: VITAMIN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.784137+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''L-Ascorbic acid'' -> ''L-ascorbic acid'': synced to canonical
+    CHEBI label (preferred_term ''L-Ascorbic acid'' unchanged).'
 chemical_properties:
   cas_rn: 50-81-7
   data_source: PubChem API

--- a/data/ingredients/mapped/L-asparagine.yaml
+++ b/data/ingredients/mapped/L-asparagine.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17196
 preferred_term: L-Asparagine
 ontology_mapping:
   ontology_id: CHEBI:17196
-  ontology_label: L-Asparagine
+  ontology_label: L-asparagine
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -123,6 +123,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: NITROGEN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.784234+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''L-Asparagine'' -> ''L-asparagine'': synced to canonical
+    CHEBI label (preferred_term ''L-Asparagine'' unchanged).'
 chemical_properties:
   cas_rn: 70-47-3
   data_source: CultureBotHT compounds_to_cas.csv

--- a/data/ingredients/mapped/L-aspartic_Acid.yaml
+++ b/data/ingredients/mapped/L-aspartic_Acid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17053
 preferred_term: L-Aspartic acid
 ontology_mapping:
   ontology_id: CHEBI:17053
-  ontology_label: L-Aspartic acid
+  ontology_label: L-aspartic acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -70,6 +70,11 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: AMINO_ACID_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.784328+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''L-Aspartic acid'' -> ''L-aspartic acid'': synced to canonical
+    CHEBI label (preferred_term ''L-Aspartic acid'' unchanged).'
 chemical_properties:
   cas_rn: 56-84-8
   data_source: PubChem API

--- a/data/ingredients/mapped/L-cysteine.yaml
+++ b/data/ingredients/mapped/L-cysteine.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17561
 preferred_term: L-Cysteine
 ontology_mapping:
   ontology_id: CHEBI:17561
-  ontology_label: L-Cysteine
+  ontology_label: L-cysteine
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -133,6 +133,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: NITROGEN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.784426+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''L-Cysteine'' -> ''L-cysteine'': synced to canonical CHEBI
+    label (preferred_term ''L-Cysteine'' unchanged).'
 chemical_properties:
   cas_rn: 52-90-4
   data_source: CultureBotHT compounds_to_cas.csv

--- a/data/ingredients/mapped/L-cysteine_Hcl_X_H2o.yaml
+++ b/data/ingredients/mapped/L-cysteine_Hcl_X_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:91248
 preferred_term: L-Cysteine HCl x H2O
 ontology_mapping:
   ontology_id: CHEBI:91248
-  ontology_label: L-Cysteine HCl x H2O
+  ontology_label: L-cysteine hydrochloride hydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -195,6 +195,12 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: AMINO_ACID_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.784615+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''L-Cysteine HCl x H2O'' -> ''L-cysteine hydrochloride
+    hydrate'': synced to canonical CHEBI label (preferred_term ''L-Cysteine HCl x
+    H2O'' unchanged).'
 chemical_properties:
   cas_rn: 7048-04-6
   data_source: PubChem (via CHEBI:91248)

--- a/data/ingredients/mapped/L-cystine.yaml
+++ b/data/ingredients/mapped/L-cystine.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:16283
 preferred_term: L-Cystine
 ontology_mapping:
   ontology_id: CHEBI:16283
-  ontology_label: L-Cystine
+  ontology_label: L-cystine
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -110,6 +110,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: NITROGEN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.784800+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''L-Cystine'' -> ''L-cystine'': synced to canonical CHEBI
+    label (preferred_term ''L-Cystine'' unchanged).'
 chemical_properties:
   cas_rn: 56-89-3
   data_source: PubChem API

--- a/data/ingredients/mapped/L-fucose.yaml
+++ b/data/ingredients/mapped/L-fucose.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:18287
 preferred_term: L-Fucose
 ontology_mapping:
   ontology_id: CHEBI:18287
-  ontology_label: L-Fucose
+  ontology_label: L-fucose
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -71,6 +71,11 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.784896+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''L-Fucose'' -> ''L-fucose'': synced to canonical CHEBI
+    label (preferred_term ''L-Fucose'' unchanged).'
 chemical_properties:
   cas_rn: 2438-80-4
   data_source: CultureBotHT/compounds_to_cas.csv

--- a/data/ingredients/mapped/L-glutamic_Acid.yaml
+++ b/data/ingredients/mapped/L-glutamic_Acid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:16015
 preferred_term: L-Glutamic acid
 ontology_mapping:
   ontology_id: CHEBI:16015
-  ontology_label: L-Glutamic acid
+  ontology_label: L-glutamic acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -114,6 +114,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: NITROGEN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.784990+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''L-Glutamic acid'' -> ''L-glutamic acid'': synced to canonical
+    CHEBI label (preferred_term ''L-Glutamic acid'' unchanged).'
 chemical_properties:
   cas_rn: 56-86-0
   data_source: PubChem API

--- a/data/ingredients/mapped/L-glutamine.yaml
+++ b/data/ingredients/mapped/L-glutamine.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:18050
 preferred_term: L-Glutamine
 ontology_mapping:
   ontology_id: CHEBI:18050
-  ontology_label: L-Glutamine
+  ontology_label: L-glutamine
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -92,6 +92,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: NITROGEN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.785086+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''L-Glutamine'' -> ''L-glutamine'': synced to canonical
+    CHEBI label (preferred_term ''L-Glutamine'' unchanged).'
 chemical_properties:
   cas_rn: 56-85-9
   data_source: PubChem API

--- a/data/ingredients/mapped/L-histidine.yaml
+++ b/data/ingredients/mapped/L-histidine.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:15971
 preferred_term: L-Histidine
 ontology_mapping:
   ontology_id: CHEBI:15971
-  ontology_label: L-Histidine
+  ontology_label: L-histidine
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -143,6 +143,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: NITROGEN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.785181+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''L-Histidine'' -> ''L-histidine'': synced to canonical
+    CHEBI label (preferred_term ''L-Histidine'' unchanged).'
 chemical_properties:
   cas_rn: 71-00-1
   data_source: CultureBotHT compounds_to_cas.csv

--- a/data/ingredients/mapped/L-isoleucine.yaml
+++ b/data/ingredients/mapped/L-isoleucine.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17191
 preferred_term: L-Isoleucine
 ontology_mapping:
   ontology_id: CHEBI:17191
-  ontology_label: L-Isoleucine
+  ontology_label: L-isoleucine
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -75,6 +75,11 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: AMINO_ACID_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.785276+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''L-Isoleucine'' -> ''L-isoleucine'': synced to canonical
+    CHEBI label (preferred_term ''L-Isoleucine'' unchanged).'
 chemical_properties:
   cas_rn: 73-32-5
   data_source: PubChem API

--- a/data/ingredients/mapped/L-leucine.yaml
+++ b/data/ingredients/mapped/L-leucine.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:15603
 preferred_term: L-Leucine
 ontology_mapping:
   ontology_id: CHEBI:15603
-  ontology_label: L-Leucine
+  ontology_label: L-leucine
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -95,6 +95,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: NITROGEN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.785369+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''L-Leucine'' -> ''L-leucine'': synced to canonical CHEBI
+    label (preferred_term ''L-Leucine'' unchanged).'
 chemical_properties:
   cas_rn: 61-90-5
   data_source: PubChem API

--- a/data/ingredients/mapped/L-lysine.yaml
+++ b/data/ingredients/mapped/L-lysine.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:18019
 preferred_term: L-Lysine
 ontology_mapping:
   ontology_id: CHEBI:18019
-  ontology_label: L-Lysine
+  ontology_label: L-lysine
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -88,6 +88,11 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: AMINO_ACID_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.785463+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''L-Lysine'' -> ''L-lysine'': synced to canonical CHEBI
+    label (preferred_term ''L-Lysine'' unchanged).'
 chemical_properties:
   cas_rn: 56-87-1
   data_source: PubChem API

--- a/data/ingredients/mapped/L-methionine.yaml
+++ b/data/ingredients/mapped/L-methionine.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:16643
 preferred_term: L-Methionine
 ontology_mapping:
   ontology_id: CHEBI:16643
-  ontology_label: L-Methionine
+  ontology_label: L-methionine
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -82,6 +82,11 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: AMINO_ACID_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.785649+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''L-Methionine'' -> ''L-methionine'': synced to canonical
+    CHEBI label (preferred_term ''L-Methionine'' unchanged).'
 chemical_properties:
   cas_rn: 63-68-3
   data_source: PubChem API

--- a/data/ingredients/mapped/L-phenylalanine.yaml
+++ b/data/ingredients/mapped/L-phenylalanine.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17295
 preferred_term: L-Phenylalanine
 ontology_mapping:
   ontology_id: CHEBI:17295
-  ontology_label: L-Phenylalanine
+  ontology_label: L-phenylalanine
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -82,6 +82,11 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: AMINO_ACID_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.785743+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''L-Phenylalanine'' -> ''L-phenylalanine'': synced to canonical
+    CHEBI label (preferred_term ''L-Phenylalanine'' unchanged).'
 chemical_properties:
   cas_rn: 63-91-2
   data_source: PubChem API

--- a/data/ingredients/mapped/L-proline.yaml
+++ b/data/ingredients/mapped/L-proline.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17203
 preferred_term: L-Proline
 ontology_mapping:
   ontology_id: CHEBI:17203
-  ontology_label: L-Proline
+  ontology_label: L-proline
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -97,6 +97,11 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: AMINO_ACID_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.785839+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''L-Proline'' -> ''L-proline'': synced to canonical CHEBI
+    label (preferred_term ''L-Proline'' unchanged).'
 chemical_properties:
   cas_rn: 147-85-3
   data_source: PubChem API

--- a/data/ingredients/mapped/L-rhamnose.yaml
+++ b/data/ingredients/mapped/L-rhamnose.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:62345
 preferred_term: L-Rhamnose
 ontology_mapping:
   ontology_id: CHEBI:62345
-  ontology_label: L-Rhamnose
+  ontology_label: L-rhamnose
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -72,6 +72,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.785939+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''L-Rhamnose'' -> ''L-rhamnose'': synced to canonical CHEBI
+    label (preferred_term ''L-Rhamnose'' unchanged).'
 chemical_properties:
   cas_rn: 222-793-4
   data_source: PubChem API

--- a/data/ingredients/mapped/L-serine.yaml
+++ b/data/ingredients/mapped/L-serine.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17115
 preferred_term: L-Serine
 ontology_mapping:
   ontology_id: CHEBI:17115
-  ontology_label: L-Serine
+  ontology_label: L-serine
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -124,6 +124,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: NITROGEN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.786034+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''L-Serine'' -> ''L-serine'': synced to canonical CHEBI
+    label (preferred_term ''L-Serine'' unchanged).'
 chemical_properties:
   cas_rn: 56-45-1
   data_source: CultureBotHT compounds_to_cas.csv

--- a/data/ingredients/mapped/L-threonine.yaml
+++ b/data/ingredients/mapped/L-threonine.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:16857
 preferred_term: L-Threonine
 ontology_mapping:
   ontology_id: CHEBI:16857
-  ontology_label: L-Threonine
+  ontology_label: L-threonine
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -82,6 +82,11 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: AMINO_ACID_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.786126+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''L-Threonine'' -> ''L-threonine'': synced to canonical
+    CHEBI label (preferred_term ''L-Threonine'' unchanged).'
 chemical_properties:
   cas_rn: 72-19-5
   data_source: PubChem API

--- a/data/ingredients/mapped/L-tryptophan.yaml
+++ b/data/ingredients/mapped/L-tryptophan.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:16828
 preferred_term: L-Tryptophan
 ontology_mapping:
   ontology_id: CHEBI:16828
-  ontology_label: L-Tryptophan
+  ontology_label: L-tryptophan
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -95,6 +95,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: NITROGEN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.786222+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''L-Tryptophan'' -> ''L-tryptophan'': synced to canonical
+    CHEBI label (preferred_term ''L-Tryptophan'' unchanged).'
 chemical_properties:
   cas_rn: 73-22-3
   data_source: PubChem API

--- a/data/ingredients/mapped/L-tyrosine.yaml
+++ b/data/ingredients/mapped/L-tyrosine.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17895
 preferred_term: L-Tyrosine
 ontology_mapping:
   ontology_id: CHEBI:17895
-  ontology_label: L-Tyrosine
+  ontology_label: L-tyrosine
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -85,6 +85,11 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: AMINO_ACID_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.786325+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''L-Tyrosine'' -> ''L-tyrosine'': synced to canonical CHEBI
+    label (preferred_term ''L-Tyrosine'' unchanged).'
 chemical_properties:
   cas_rn: 60-18-4
   data_source: PubChem API

--- a/data/ingredients/mapped/L-valine.yaml
+++ b/data/ingredients/mapped/L-valine.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:16414
 preferred_term: L-Valine
 ontology_mapping:
   ontology_id: CHEBI:16414
-  ontology_label: L-Valine
+  ontology_label: L-valine
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -85,6 +85,11 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: AMINO_ACID_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.786421+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''L-Valine'' -> ''L-valine'': synced to canonical CHEBI
+    label (preferred_term ''L-Valine'' unchanged).'
 chemical_properties:
   cas_rn: 72-18-4
   data_source: PubChem API

--- a/data/ingredients/mapped/L_-tartaric_Acid.yaml
+++ b/data/ingredients/mapped/L_-tartaric_Acid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:15671
 preferred_term: L(+)-Tartaric acid
 ontology_mapping:
   ontology_id: CHEBI:15671
-  ontology_label: L(+)-Tartaric acid
+  ontology_label: L-tartaric acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -97,6 +97,11 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.786613+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''L(+)-Tartaric acid'' -> ''L-tartaric acid'': synced to
+    canonical CHEBI label (preferred_term ''L(+)-Tartaric acid'' unchanged).'
 chemical_properties:
   cas_rn: 87-69-4
   data_source: PubChem API

--- a/data/ingredients/mapped/Lactate.yaml
+++ b/data/ingredients/mapped/Lactate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:24996
 preferred_term: Lactate
 ontology_mapping:
   ontology_id: CHEBI:24996
-  ontology_label: Lactate
+  ontology_label: lactate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -94,6 +94,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.787276+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Lactate'' -> ''lactate'': synced to canonical CHEBI label
+    (preferred_term ''Lactate'' unchanged).'
 chemical_properties:
   cas_rn: 113-21-3
   data_source: PubChem API

--- a/data/ingredients/mapped/Lactose.yaml
+++ b/data/ingredients/mapped/Lactose.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17716
 preferred_term: Lactose
 ontology_mapping:
   ontology_id: CHEBI:17716
-  ontology_label: Lactose
+  ontology_label: lactose
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -152,6 +152,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.787743+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Lactose'' -> ''lactose'': synced to canonical CHEBI label
+    (preferred_term ''Lactose'' unchanged).'
 chemical_properties:
   cas_rn: 63-42-3
   data_source: PubChem (via CHEBI:17716)

--- a/data/ingredients/mapped/M-xylene.yaml
+++ b/data/ingredients/mapped/M-xylene.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:28488
 preferred_term: m-Xylene
 ontology_mapping:
   ontology_id: CHEBI:28488
-  ontology_label: m-Xylene
+  ontology_label: m-xylene
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -78,6 +78,11 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.790870+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''m-Xylene'' -> ''m-xylene'': synced to canonical CHEBI
+    label (preferred_term ''m-Xylene'' unchanged).'
 chemical_properties:
   cas_rn: 108-38-3
   data_source: PubChem API

--- a/data/ingredients/mapped/Magnesium_Acetate.yaml
+++ b/data/ingredients/mapped/Magnesium_Acetate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:62964
 preferred_term: Magnesium acetate
 ontology_mapping:
   ontology_id: CHEBI:62964
-  ontology_label: Magnesium acetate
+  ontology_label: magnesium acetate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -77,6 +77,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.791158+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Magnesium acetate'' -> ''magnesium acetate'': synced
+    to canonical CHEBI label (preferred_term ''Magnesium acetate'' unchanged).'
 chemical_properties:
   cas_rn: 142-72-3
   data_source: PubChem API

--- a/data/ingredients/mapped/Magnesium_Sulfate.yaml
+++ b/data/ingredients/mapped/Magnesium_Sulfate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:32599
 preferred_term: Magnesium sulfate
 ontology_mapping:
   ontology_id: CHEBI:32599
-  ontology_label: Magnesium sulfate
+  ontology_label: magnesium sulfate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -179,6 +179,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.791344+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Magnesium sulfate'' -> ''magnesium sulfate'': synced
+    to canonical CHEBI label (preferred_term ''Magnesium sulfate'' unchanged).'
 chemical_properties:
   cas_rn: 7487-88-9
   data_source: PubChem API

--- a/data/ingredients/mapped/Malachite_Green.yaml
+++ b/data/ingredients/mapped/Malachite_Green.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:72449
 preferred_term: Malachite green
 ontology_mapping:
   ontology_id: CHEBI:72449
-  ontology_label: Malachite green
+  ontology_label: malachite green
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -122,6 +122,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: PH_INDICATOR (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.791440+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Malachite green'' -> ''malachite green'': synced to canonical
+    CHEBI label (preferred_term ''Malachite green'' unchanged).'
 chemical_properties:
   cas_rn: 569-64-2
   data_source: PubChem API

--- a/data/ingredients/mapped/Malate.yaml
+++ b/data/ingredients/mapped/Malate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:25115
 preferred_term: Malate
 ontology_mapping:
   ontology_id: CHEBI:25115
-  ontology_label: Malate
+  ontology_label: malate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -58,6 +58,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.791534+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Malate'' -> ''malate'': synced to canonical CHEBI label
+    (preferred_term ''Malate'' unchanged).'
 chemical_properties:
   cas_rn: 6915-15-7
   data_source: PubChem API

--- a/data/ingredients/mapped/Maltose.yaml
+++ b/data/ingredients/mapped/Maltose.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17306
 preferred_term: Maltose
 ontology_mapping:
   ontology_id: CHEBI:17306
-  ontology_label: Maltose
+  ontology_label: maltose
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -148,6 +148,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.792627+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Maltose'' -> ''maltose'': synced to canonical CHEBI label
+    (preferred_term ''Maltose'' unchanged).'
 chemical_properties:
   cas_rn: 69-79-4
   data_source: PubChem (via CHEBI:17306)

--- a/data/ingredients/mapped/Mannitol.yaml
+++ b/data/ingredients/mapped/Mannitol.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:29864
 preferred_term: Mannitol
 ontology_mapping:
   ontology_id: CHEBI:29864
-  ontology_label: Mannitol
+  ontology_label: mannitol
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -86,6 +86,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.793090+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Mannitol'' -> ''mannitol'': synced to canonical CHEBI
+    label (preferred_term ''Mannitol'' unchanged).'
 chemical_properties:
   cas_rn: 69-65-8
   data_source: PubChem API

--- a/data/ingredients/mapped/Melibiose.yaml
+++ b/data/ingredients/mapped/Melibiose.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:28053
 preferred_term: Melibiose
 ontology_mapping:
   ontology_id: CHEBI:28053
-  ontology_label: Melibiose
+  ontology_label: melibiose
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -95,6 +95,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.793752+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Melibiose'' -> ''melibiose'': synced to canonical CHEBI
+    label (preferred_term ''Melibiose'' unchanged).'
 chemical_properties:
   cas_rn: 585-99-9
   data_source: CultureBotHT/compounds_to_cas.csv

--- a/data/ingredients/mapped/Menadione.yaml
+++ b/data/ingredients/mapped/Menadione.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:28869
 preferred_term: Menadione
 ontology_mapping:
   ontology_id: CHEBI:28869
-  ontology_label: Menadione
+  ontology_label: menadione
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -148,6 +148,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: VITAMIN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.793847+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Menadione'' -> ''menadione'': synced to canonical CHEBI
+    label (preferred_term ''Menadione'' unchanged).'
 chemical_properties:
   cas_rn: 58-27-5
   data_source: PubChem API

--- a/data/ingredients/mapped/Methanol.yaml
+++ b/data/ingredients/mapped/Methanol.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17790
 preferred_term: Methanol
 ontology_mapping:
   ontology_id: CHEBI:17790
-  ontology_label: Methanol
+  ontology_label: methanol
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -113,6 +113,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: SALT (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.794657+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Methanol'' -> ''methanol'': synced to canonical CHEBI
+    label (preferred_term ''Methanol'' unchanged).'
 chemical_properties:
   cas_rn: 67-56-1
   data_source: PubChem API

--- a/data/ingredients/mapped/Methylamine.yaml
+++ b/data/ingredients/mapped/Methylamine.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:16830
 preferred_term: Methylamine
 ontology_mapping:
   ontology_id: CHEBI:16830
-  ontology_label: Methylamine
+  ontology_label: methylamine
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -75,6 +75,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.795755+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Methylamine'' -> ''methylamine'': synced to canonical
+    CHEBI label (preferred_term ''Methylamine'' unchanged).'
 chemical_properties:
   cas_rn: 74-89-5
   data_source: PubChem API

--- a/data/ingredients/mapped/Methylamine_Hydrochloride.yaml
+++ b/data/ingredients/mapped/Methylamine_Hydrochloride.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:59337
 preferred_term: Methylamine hydrochloride
 ontology_mapping:
   ontology_id: CHEBI:59337
-  ontology_label: Methylamine hydrochloride
+  ontology_label: methylamine hydrochloride
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -76,6 +76,12 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.795851+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Methylamine hydrochloride'' -> ''methylamine hydrochloride'':
+    synced to canonical CHEBI label (preferred_term ''Methylamine hydrochloride''
+    unchanged).'
 chemical_properties:
   cas_rn: 593-51-1
   data_source: PubChem API

--- a/data/ingredients/mapped/Methylene_Blue.yaml
+++ b/data/ingredients/mapped/Methylene_Blue.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:6872
 preferred_term: Methylene blue
 ontology_mapping:
   ontology_id: CHEBI:6872
-  ontology_label: Methylene blue
+  ontology_label: methylene blue
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -94,6 +94,11 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: REDOX_INDICATOR (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.795950+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Methylene blue'' -> ''methylene blue'': synced to canonical
+    CHEBI label (preferred_term ''Methylene blue'' unchanged).'
 chemical_properties:
   cas_rn: 61-73-4
   data_source: PubChem API

--- a/data/ingredients/mapped/Mg-citrate.yaml
+++ b/data/ingredients/mapped/Mg-citrate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:131389
 preferred_term: Mg-citrate
 ontology_mapping:
   ontology_id: CHEBI:131389
-  ontology_label: Mg-citrate
+  ontology_label: magnesium citrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -63,6 +63,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.796407+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Mg-citrate'' -> ''magnesium citrate'': synced to canonical
+    CHEBI label (preferred_term ''Mg-citrate'' unchanged).'
 chemical_properties:
   cas_rn: 3344-18-1
   data_source: PubChem API (preprocessed)

--- a/data/ingredients/mapped/Mgcl2.yaml
+++ b/data/ingredients/mapped/Mgcl2.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:6636
 preferred_term: MgCl2
 ontology_mapping:
   ontology_id: CHEBI:6636
-  ontology_label: MgCl2
+  ontology_label: magnesium dichloride
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -78,6 +78,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.796503+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''MgCl2'' -> ''magnesium dichloride'': synced to canonical
+    CHEBI label (preferred_term ''MgCl2'' unchanged).'
 chemical_properties:
   cas_rn: 7786-30-3
   data_source: PubChem API

--- a/data/ingredients/mapped/Mgcl2_X_2_H2o.yaml
+++ b/data/ingredients/mapped/Mgcl2_X_2_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:131394
 preferred_term: MgCl2 x 2 H2O
 ontology_mapping:
   ontology_id: CHEBI:131394
-  ontology_label: MgCl2 x 2 H2O
+  ontology_label: magnesium dichloride dihydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -63,6 +63,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.796599+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''MgCl2 x 2 H2O'' -> ''magnesium dichloride dihydrate'':
+    synced to canonical CHEBI label (preferred_term ''MgCl2 x 2 H2O'' unchanged).'
 chemical_properties:
   cas_rn: 19098-17-0
   data_source: PubChem (via CHEBI:131394)

--- a/data/ingredients/mapped/Mgcl2_X_6_H2o.yaml
+++ b/data/ingredients/mapped/Mgcl2_X_6_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:86345
 preferred_term: MgCl2 x 6 H2O
 ontology_mapping:
   ontology_id: CHEBI:86345
-  ontology_label: MgCl2 x 6 H2O
+  ontology_label: magnesium dichloride hexahydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -167,6 +167,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.796692+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''MgCl2 x 6 H2O'' -> ''magnesium dichloride hexahydrate'':
+    synced to canonical CHEBI label (preferred_term ''MgCl2 x 6 H2O'' unchanged).'
 chemical_properties:
   cas_rn: 7791-18-6
   data_source: PubChem (via CHEBI:86345)

--- a/data/ingredients/mapped/Mgcl2_X_H2o.yaml
+++ b/data/ingredients/mapped/Mgcl2_X_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:86355
 preferred_term: MgCl2 x H2O
 ontology_mapping:
   ontology_id: CHEBI:86355
-  ontology_label: MgCl2 x H2O
+  ontology_label: magnesium dichloride monohydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -66,6 +66,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.796878+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''MgCl2 x H2O'' -> ''magnesium dichloride monohydrate'':
+    synced to canonical CHEBI label (preferred_term ''MgCl2 x H2O'' unchanged).'
 chemical_properties:
   cas_rn: 22756-14-5
   data_source: PubChem (via CHEBI:86355)

--- a/data/ingredients/mapped/Mgso4_X_6_H2o.yaml
+++ b/data/ingredients/mapped/Mgso4_X_6_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:32599
 preferred_term: MgSO4 x 6 H2O
 ontology_mapping:
   ontology_id: CHEBI:32599
-  ontology_label: MgSO4 x 6 H2O
+  ontology_label: magnesium sulfate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -121,6 +121,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.797331+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''MgSO4 x 6 H2O'' -> ''magnesium sulfate'': synced to canonical
+    CHEBI label (preferred_term ''MgSO4 x 6 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:32599
 chemical_properties:
   cas_rn: 7487-88-9

--- a/data/ingredients/mapped/Mgso4_X_7_H2o.yaml
+++ b/data/ingredients/mapped/Mgso4_X_7_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:31795
 preferred_term: MgSO4 x 7 H2O
 ontology_mapping:
   ontology_id: CHEBI:31795
-  ontology_label: MgSO4 x 7 H2O
+  ontology_label: magnesium sulfate heptahydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -187,6 +187,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.797423+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''MgSO4 x 7 H2O'' -> ''magnesium sulfate heptahydrate'':
+    synced to canonical CHEBI label (preferred_term ''MgSO4 x 7 H2O'' unchanged).'
 chemical_properties:
   cas_rn: 10034-99-8
   data_source: OAK/CHEBI xref

--- a/data/ingredients/mapped/Mncl2_X_4_H2o.yaml
+++ b/data/ingredients/mapped/Mncl2_X_4_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:86368
 preferred_term: MnCl2 x 4 H2O
 ontology_mapping:
   ontology_id: CHEBI:86368
-  ontology_label: MnCl2 x 4 H2O
+  ontology_label: manganese(II) chloride tetrahydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -130,6 +130,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.799462+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''MnCl2 x 4 H2O'' -> ''manganese(II) chloride tetrahydrate'':
+    synced to canonical CHEBI label (preferred_term ''MnCl2 x 4 H2O'' unchanged).'
 chemical_properties:
   cas_rn: 13446-34-9
   data_source: PubChem (via CHEBI:86368)

--- a/data/ingredients/mapped/Mno2.yaml
+++ b/data/ingredients/mapped/Mno2.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:136511
 preferred_term: MnO2
 ontology_mapping:
   ontology_id: CHEBI:136511
-  ontology_label: MnO2
+  ontology_label: manganese dioxide
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -82,6 +82,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.799652+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''MnO2'' -> ''manganese dioxide'': synced to canonical
+    CHEBI label (preferred_term ''MnO2'' unchanged).'
 chemical_properties:
   cas_rn: 1313-13-9
   data_source: PubChem (via CHEBI:136511)

--- a/data/ingredients/mapped/Mnso4.yaml
+++ b/data/ingredients/mapped/Mnso4.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:86360
 preferred_term: MnSO4
 ontology_mapping:
   ontology_id: CHEBI:86360
-  ontology_label: MnSO4
+  ontology_label: manganese(II) sulfate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -107,6 +107,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.799747+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''MnSO4'' -> ''manganese(II) sulfate'': synced to canonical
+    CHEBI label (preferred_term ''MnSO4'' unchanged).'
 chemical_properties:
   cas_rn: 7785-87-7
   data_source: PubChem API

--- a/data/ingredients/mapped/Mnso4_X_1_H2o.yaml
+++ b/data/ingredients/mapped/Mnso4_X_1_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:86360
 preferred_term: MnSO4 x 1 H2O
 ontology_mapping:
   ontology_id: CHEBI:86360
-  ontology_label: MnSO4 x 1 H2O
+  ontology_label: manganese(II) sulfate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -75,6 +75,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.799839+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''MnSO4 x 1 H2O'' -> ''manganese(II) sulfate'': synced
+    to canonical CHEBI label (preferred_term ''MnSO4 x 1 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:86360
 chemical_properties:
   cas_rn: 7785-87-7

--- a/data/ingredients/mapped/Mnso4_X_2_H2o.yaml
+++ b/data/ingredients/mapped/Mnso4_X_2_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:86356
 preferred_term: MnSO4 x 2 H2O
 ontology_mapping:
   ontology_id: CHEBI:86356
-  ontology_label: MnSO4 x 2 H2O
+  ontology_label: manganese(II) sulfate dihydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -76,6 +76,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.799932+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''MnSO4 x 2 H2O'' -> ''manganese(II) sulfate dihydrate'':
+    synced to canonical CHEBI label (preferred_term ''MnSO4 x 2 H2O'' unchanged).'
 ingredient_type: SINGLE_INGREDIENT
 chemical_properties:
   molecular_formula: 2H2O.Mn.O4S

--- a/data/ingredients/mapped/Mnso4_X_4_H2o.yaml
+++ b/data/ingredients/mapped/Mnso4_X_4_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:86358
 preferred_term: MnSO4 x 4 H2O
 ontology_mapping:
   ontology_id: CHEBI:86358
-  ontology_label: MnSO4 x 4 H2O
+  ontology_label: manganese(II) sulfate tetrahydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -135,6 +135,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.800025+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''MnSO4 x 4 H2O'' -> ''manganese(II) sulfate tetrahydrate'':
+    synced to canonical CHEBI label (preferred_term ''MnSO4 x 4 H2O'' unchanged).'
 chemical_properties:
   cas_rn: 10101-68-5
   data_source: PubChem (via CHEBI:86358)

--- a/data/ingredients/mapped/Mnso4_X_5_H2o.yaml
+++ b/data/ingredients/mapped/Mnso4_X_5_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:131524
 preferred_term: MnSO4 x 5 H2O
 ontology_mapping:
   ontology_id: CHEBI:131524
-  ontology_label: MnSO4 x 5 H2O
+  ontology_label: manganese(II) sulfate pentahydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -117,6 +117,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.800121+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''MnSO4 x 5 H2O'' -> ''manganese(II) sulfate pentahydrate'':
+    synced to canonical CHEBI label (preferred_term ''MnSO4 x 5 H2O'' unchanged).'
 chemical_properties:
   cas_rn: 13465-27-5
   data_source: PubChem (via CHEBI:131524)

--- a/data/ingredients/mapped/Mnso4_X_6_H2o.yaml
+++ b/data/ingredients/mapped/Mnso4_X_6_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:131523
 preferred_term: MnSO4 x 6 H2O
 ontology_mapping:
   ontology_id: CHEBI:131523
-  ontology_label: MnSO4 x 6 H2O
+  ontology_label: manganese(II) sulfate hexahydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -64,6 +64,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.800214+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''MnSO4 x 6 H2O'' -> ''manganese(II) sulfate hexahydrate'':
+    synced to canonical CHEBI label (preferred_term ''MnSO4 x 6 H2O'' unchanged).'
 ingredient_type: SINGLE_INGREDIENT
 chemical_properties:
   molecular_formula: 6H2O.Mn.O4S

--- a/data/ingredients/mapped/Mnso4_X_7_H2o.yaml
+++ b/data/ingredients/mapped/Mnso4_X_7_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:86360
 preferred_term: MnSO4 x 7 H2O
 ontology_mapping:
   ontology_id: CHEBI:86360
-  ontology_label: MnSO4 x 7 H2O
+  ontology_label: manganese(II) sulfate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -75,6 +75,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.800306+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''MnSO4 x 7 H2O'' -> ''manganese(II) sulfate'': synced
+    to canonical CHEBI label (preferred_term ''MnSO4 x 7 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:86360
 chemical_properties:
   cas_rn: 7785-87-7

--- a/data/ingredients/mapped/Mnso4_X_H2o.yaml
+++ b/data/ingredients/mapped/Mnso4_X_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:86364
 preferred_term: MnSO4 x H2O
 ontology_mapping:
   ontology_id: CHEBI:86364
-  ontology_label: MnSO4 x H2O
+  ontology_label: manganese(II) sulfate monohydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -167,6 +167,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.800399+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''MnSO4 x H2O'' -> ''manganese(II) sulfate monohydrate'':
+    synced to canonical CHEBI label (preferred_term ''MnSO4 x H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:86364
 chemical_properties:
   cas_rn: 10034-96-5

--- a/data/ingredients/mapped/Moo3.yaml
+++ b/data/ingredients/mapped/Moo3.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:30627
 preferred_term: MoO3
 ontology_mapping:
   ontology_id: CHEBI:30627
-  ontology_label: MoO3
+  ontology_label: molybdenum trioxide
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -73,6 +73,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.800671+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''MoO3'' -> ''molybdenum trioxide'': synced to canonical
+    CHEBI label (preferred_term ''MoO3'' unchanged).'
 chemical_properties:
   cas_rn: 1313-27-5
   data_source: PubChem API

--- a/data/ingredients/mapped/Myo-inositol.yaml
+++ b/data/ingredients/mapped/Myo-inositol.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17268
 preferred_term: myo-Inositol
 ontology_mapping:
   ontology_id: CHEBI:17268
-  ontology_label: Myo-inositol
+  ontology_label: myo-inositol
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -130,6 +130,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: VITAMIN_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.801140+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Myo-inositol'' -> ''myo-inositol'': synced to canonical
+    CHEBI label (preferred_term ''myo-Inositol'' unchanged).'
 chemical_properties:
   cas_rn: 87-89-8
   data_source: PubChem API

--- a/data/ingredients/mapped/N-acetylglucosamine.yaml
+++ b/data/ingredients/mapped/N-acetylglucosamine.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:59640
 preferred_term: N-Acetylglucosamine
 ontology_mapping:
   ontology_id: CHEBI:59640
-  ontology_label: N-Acetylglucosamine
+  ontology_label: N-acetylglucosamine
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -66,6 +66,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.802250+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''N-Acetylglucosamine'' -> ''N-acetylglucosamine'': synced
+    to canonical CHEBI label (preferred_term ''N-Acetylglucosamine'' unchanged).'
 chemical_properties:
   cas_rn: 7512-17-6
   data_source: PubChem API

--- a/data/ingredients/mapped/N-decane.yaml
+++ b/data/ingredients/mapped/N-decane.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:41808
 preferred_term: n-Decane
 ontology_mapping:
   ontology_id: CHEBI:41808
-  ontology_label: n-Decane
+  ontology_label: decane
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -91,6 +91,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.802536+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''n-Decane'' -> ''decane'': synced to canonical CHEBI label
+    (preferred_term ''n-Decane'' unchanged).'
 kg_microbe_node_id: CHEBI:41808
 chemical_properties:
   cas_rn: 124-18-5

--- a/data/ingredients/mapped/Na-3-hydroxybutyrate.yaml
+++ b/data/ingredients/mapped/Na-3-hydroxybutyrate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:113373
 preferred_term: Na-3-hydroxybutyrate
 ontology_mapping:
   ontology_id: CHEBI:113373
-  ontology_label: Na-3-hydroxybutyrate
+  ontology_label: sodium 3-hydroxybutyrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -67,6 +67,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.803208+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na-3-hydroxybutyrate'' -> ''sodium 3-hydroxybutyrate'':
+    synced to canonical CHEBI label (preferred_term ''Na-3-hydroxybutyrate'' unchanged).'
 chemical_properties:
   cas_rn: 150-83-4
   data_source: PubChem API (preprocessed)

--- a/data/ingredients/mapped/Na-acetate.yaml
+++ b/data/ingredients/mapped/Na-acetate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:32954
 preferred_term: Na-acetate
 ontology_mapping:
   ontology_id: CHEBI:32954
-  ontology_label: Na-acetate
+  ontology_label: sodium acetate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -188,6 +188,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: BUFFER (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.803304+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na-acetate'' -> ''sodium acetate'': synced to canonical
+    CHEBI label (preferred_term ''Na-acetate'' unchanged).'
 chemical_properties:
   cas_rn: 127-09-3
   data_source: PubChem API (preprocessed)

--- a/data/ingredients/mapped/Na-ampicillin.yaml
+++ b/data/ingredients/mapped/Na-ampicillin.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:34535
 preferred_term: Na-ampicillin
 ontology_mapping:
   ontology_id: CHEBI:34535
-  ontology_label: Na-ampicillin
+  ontology_label: ampicillin sodium
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -83,6 +83,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: SELECTIVE_AGENT (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.803401+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na-ampicillin'' -> ''ampicillin sodium'': synced to canonical
+    CHEBI label (preferred_term ''Na-ampicillin'' unchanged).'
 chemical_properties:
   cas_rn: 69-52-3
   data_source: PubChem API (preprocessed)

--- a/data/ingredients/mapped/Na-ascorbate.yaml
+++ b/data/ingredients/mapped/Na-ascorbate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:113451
 preferred_term: Na-ascorbate
 ontology_mapping:
   ontology_id: CHEBI:113451
-  ontology_label: Na-ascorbate
+  ontology_label: sodium ascorbate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -128,6 +128,11 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: VITAMIN_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.803496+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na-ascorbate'' -> ''sodium ascorbate'': synced to canonical
+    CHEBI label (preferred_term ''Na-ascorbate'' unchanged).'
 chemical_properties:
   cas_rn: 134-03-2
   data_source: PubChem API (preprocessed)

--- a/data/ingredients/mapped/Na-benzoate.yaml
+++ b/data/ingredients/mapped/Na-benzoate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:113455
 preferred_term: Na-benzoate
 ontology_mapping:
   ontology_id: CHEBI:113455
-  ontology_label: Na-benzoate
+  ontology_label: sodium benzoate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -115,6 +115,11 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.803587+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na-benzoate'' -> ''sodium benzoate'': synced to canonical
+    CHEBI label (preferred_term ''Na-benzoate'' unchanged).'
 chemical_properties:
   cas_rn: 532-32-1
   data_source: PubChem API (preprocessed)

--- a/data/ingredients/mapped/Na-butyrate.yaml
+++ b/data/ingredients/mapped/Na-butyrate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:64103
 preferred_term: Na-butyrate
 ontology_mapping:
   ontology_id: CHEBI:64103
-  ontology_label: Na-butyrate
+  ontology_label: sodium butyrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -157,6 +157,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.803682+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na-butyrate'' -> ''sodium butyrate'': synced to canonical
+    CHEBI label (preferred_term ''Na-butyrate'' unchanged).'
 chemical_properties:
   cas_rn: 156-54-7
   data_source: PubChem API (preprocessed)

--- a/data/ingredients/mapped/Na-caproate.yaml
+++ b/data/ingredients/mapped/Na-caproate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:114126
 preferred_term: Na-caproate
 ontology_mapping:
   ontology_id: CHEBI:114126
-  ontology_label: Na-caproate
+  ontology_label: sodium hexanoate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -95,6 +95,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.803775+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na-caproate'' -> ''sodium hexanoate'': synced to canonical
+    CHEBI label (preferred_term ''Na-caproate'' unchanged).'
 chemical_properties:
   cas_rn: 10051-44-2
   data_source: PubChem API (preprocessed)

--- a/data/ingredients/mapped/Na-crotonate.yaml
+++ b/data/ingredients/mapped/Na-crotonate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:35899
 preferred_term: Na-crotonate
 ontology_mapping:
   ontology_id: CHEBI:35899
-  ontology_label: Na-crotonate
+  ontology_label: crotonate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -91,6 +91,11 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.803869+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na-crotonate'' -> ''crotonate'': synced to canonical
+    CHEBI label (preferred_term ''Na-crotonate'' unchanged).'
 chemical_properties:
   cas_rn: 17342-77-7
   data_source: PubChem API (preprocessed)

--- a/data/ingredients/mapped/Na-formate.yaml
+++ b/data/ingredients/mapped/Na-formate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:62965
 preferred_term: Na-formate
 ontology_mapping:
   ontology_id: CHEBI:62965
-  ontology_label: Na-formate
+  ontology_label: sodium formate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -149,6 +149,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.803963+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na-formate'' -> ''sodium formate'': synced to canonical
+    CHEBI label (preferred_term ''Na-formate'' unchanged).'
 chemical_properties:
   cas_rn: 141-53-7
   data_source: PubChem API (preprocessed)

--- a/data/ingredients/mapped/Na-gallate.yaml
+++ b/data/ingredients/mapped/Na-gallate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:115197
 preferred_term: Na-gallate
 ontology_mapping:
   ontology_id: CHEBI:115197
-  ontology_label: Na-gallate
+  ontology_label: sodium gallate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -57,6 +57,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.804059+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na-gallate'' -> ''sodium gallate'': synced to canonical
+    CHEBI label (preferred_term ''Na-gallate'' unchanged).'
 chemical_properties:
   cas_rn: 2053-21-6
   data_source: PubChem API (preprocessed)

--- a/data/ingredients/mapped/Na-laurate.yaml
+++ b/data/ingredients/mapped/Na-laurate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:131839
 preferred_term: Na-laurate
 ontology_mapping:
   ontology_id: CHEBI:131839
-  ontology_label: Na-laurate
+  ontology_label: sodium dodecanoate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -63,6 +63,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.804341+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na-laurate'' -> ''sodium dodecanoate'': synced to canonical
+    CHEBI label (preferred_term ''Na-laurate'' unchanged).'
 chemical_properties:
   cas_rn: 629-25-4
   data_source: PubChem API (preprocessed)

--- a/data/ingredients/mapped/Na-orotate.yaml
+++ b/data/ingredients/mapped/Na-orotate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:132101
 preferred_term: Na-orotate
 ontology_mapping:
   ontology_id: CHEBI:132101
-  ontology_label: Na-orotate
+  ontology_label: sodium orotate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -67,6 +67,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.804435+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na-orotate'' -> ''sodium orotate'': synced to canonical
+    CHEBI label (preferred_term ''Na-orotate'' unchanged).'
 chemical_properties:
   cas_rn: 154-85-8
   data_source: PubChem API (preprocessed)

--- a/data/ingredients/mapped/Na-propionate.yaml
+++ b/data/ingredients/mapped/Na-propionate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:132106
 preferred_term: Na-propionate
 ontology_mapping:
   ontology_id: CHEBI:132106
-  ontology_label: Na-propionate
+  ontology_label: sodium propionate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -132,6 +132,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.804528+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na-propionate'' -> ''sodium propionate'': synced to canonical
+    CHEBI label (preferred_term ''Na-propionate'' unchanged).'
 chemical_properties:
   cas_rn: 137-40-6
   data_source: PubChem API (preprocessed)

--- a/data/ingredients/mapped/Na-pyruvate.yaml
+++ b/data/ingredients/mapped/Na-pyruvate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:50144
 preferred_term: Na-pyruvate
 ontology_mapping:
   ontology_id: CHEBI:50144
-  ontology_label: Na-pyruvate
+  ontology_label: sodium pyruvate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -182,6 +182,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.804621+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na-pyruvate'' -> ''sodium pyruvate'': synced to canonical
+    CHEBI label (preferred_term ''Na-pyruvate'' unchanged).'
 chemical_properties:
   cas_rn: 113-24-6
   data_source: PubChem API (preprocessed)

--- a/data/ingredients/mapped/Na-silicate.yaml
+++ b/data/ingredients/mapped/Na-silicate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:60720
 preferred_term: Na-silicate
 ontology_mapping:
   ontology_id: CHEBI:60720
-  ontology_label: Na-silicate
+  ontology_label: sodium silicate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -142,6 +142,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.804715+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na-silicate'' -> ''sodium silicate'': synced to canonical
+    CHEBI label (preferred_term ''Na-silicate'' unchanged).'
 chemical_properties:
   cas_rn: 1344-09-8
   data_source: PubChem (via CHEBI:60720)

--- a/data/ingredients/mapped/Na-stearate.yaml
+++ b/data/ingredients/mapped/Na-stearate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:132109
 preferred_term: Na-stearate
 ontology_mapping:
   ontology_id: CHEBI:132109
-  ontology_label: Na-stearate
+  ontology_label: sodium octadecanoate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -63,6 +63,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.804806+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na-stearate'' -> ''sodium octadecanoate'': synced to
+    canonical CHEBI label (preferred_term ''Na-stearate'' unchanged).'
 chemical_properties:
   cas_rn: 822-16-2
   data_source: PubChem API (preprocessed)

--- a/data/ingredients/mapped/Na-thioglycolate.yaml
+++ b/data/ingredients/mapped/Na-thioglycolate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:86481
 preferred_term: Na-thioglycolate
 ontology_mapping:
   ontology_id: CHEBI:86481
-  ontology_label: Na-thioglycolate
+  ontology_label: sodium thioglycolate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -133,6 +133,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: REDUCING_AGENT (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.805009+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na-thioglycolate'' -> ''sodium thioglycolate'': synced
+    to canonical CHEBI label (preferred_term ''Na-thioglycolate'' unchanged).'
 chemical_properties:
   cas_rn: 367-51-1
   data_source: PubChem API (preprocessed)

--- a/data/ingredients/mapped/Na-vanillate.yaml
+++ b/data/ingredients/mapped/Na-vanillate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:132748
 preferred_term: Na-vanillate
 ontology_mapping:
   ontology_id: CHEBI:132748
-  ontology_label: Na-vanillate
+  ontology_label: sodium vanillate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -61,6 +61,11 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.805106+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na-vanillate'' -> ''sodium vanillate'': synced to canonical
+    CHEBI label (preferred_term ''Na-vanillate'' unchanged).'
 chemical_properties:
   cas_rn: 28508-48-7
   data_source: PubChem API (preprocessed)

--- a/data/ingredients/mapped/Na2-edta.yaml
+++ b/data/ingredients/mapped/Na2-edta.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:64734
 preferred_term: Na2-EDTA
 ontology_mapping:
   ontology_id: CHEBI:64734
-  ontology_label: Na2-EDTA
+  ontology_label: EDTA disodium salt (anhydrous)
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -169,6 +169,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CHELATOR (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.805204+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na2-EDTA'' -> ''EDTA disodium salt (anhydrous)'': synced
+    to canonical CHEBI label (preferred_term ''Na2-EDTA'' unchanged).'
 kg_microbe_node_id: CHEBI:64734
 chemical_properties:
   cas_rn: 139-33-3

--- a/data/ingredients/mapped/Na2-edta_X_2_H2o.yaml
+++ b/data/ingredients/mapped/Na2-edta_X_2_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:64734
 preferred_term: Na2-EDTA x 2 H2O
 ontology_mapping:
   ontology_id: CHEBI:64734
-  ontology_label: Na2-EDTA x 2 H2O
+  ontology_label: EDTA disodium salt (anhydrous)
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -108,6 +108,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CHELATOR (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.805298+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na2-EDTA x 2 H2O'' -> ''EDTA disodium salt (anhydrous)'':
+    synced to canonical CHEBI label (preferred_term ''Na2-EDTA x 2 H2O'' unchanged).'
 chemical_properties:
   cas_rn: 7487-55-0
   data_source: PubChem API (preprocessed)

--- a/data/ingredients/mapped/Na2-fumarate.yaml
+++ b/data/ingredients/mapped/Na2-fumarate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:115156
 preferred_term: Na2-fumarate
 ontology_mapping:
   ontology_id: CHEBI:115156
-  ontology_label: Na2-fumarate
+  ontology_label: disodium fumarate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -162,6 +162,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.805395+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na2-fumarate'' -> ''disodium fumarate'': synced to canonical
+    CHEBI label (preferred_term ''Na2-fumarate'' unchanged).'
 kg_microbe_node_id: CHEBI:115156
 chemical_properties:
   cas_rn: 17013-01-3

--- a/data/ingredients/mapped/Na2-glyoxalate.yaml
+++ b/data/ingredients/mapped/Na2-glyoxalate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:91251
 preferred_term: Na2-glyoxalate
 ontology_mapping:
   ontology_id: CHEBI:91251
-  ontology_label: Na2-glyoxalate
+  ontology_label: sodium glyoxylate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -70,6 +70,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.805491+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na2-glyoxalate'' -> ''sodium glyoxylate'': synced to
+    canonical CHEBI label (preferred_term ''Na2-glyoxalate'' unchanged).'
 chemical_properties:
   cas_rn: 2706-75-4
   data_source: PubChem (via CHEBI:91251)

--- a/data/ingredients/mapped/Na2_Alpha-ketoglutarate.yaml
+++ b/data/ingredients/mapped/Na2_Alpha-ketoglutarate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:16810
 preferred_term: Na2 alpha-ketoglutarate
 ontology_mapping:
   ontology_id: CHEBI:16810
-  ontology_label: Na2 alpha-ketoglutarate
+  ontology_label: 2-oxoglutarate(2-)
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -101,6 +101,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.805587+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na2 alpha-ketoglutarate'' -> ''2-oxoglutarate(2-)'':
+    synced to canonical CHEBI label (preferred_term ''Na2 alpha-ketoglutarate'' unchanged).'
 kg_microbe_node_id: CHEBI:16810
 chemical_properties:
   cas_rn: 64-15-3

--- a/data/ingredients/mapped/Na2co3.yaml
+++ b/data/ingredients/mapped/Na2co3.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:29377
 preferred_term: Na2CO3
 ontology_mapping:
   ontology_id: CHEBI:29377
-  ontology_label: Na2CO3
+  ontology_label: sodium carbonate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -173,6 +173,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: BUFFER (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.805862+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na2CO3'' -> ''sodium carbonate'': synced to canonical
+    CHEBI label (preferred_term ''Na2CO3'' unchanged).'
 chemical_properties:
   cas_rn: 497-19-8
   data_source: CultureBotHT compounds_to_cas.csv

--- a/data/ingredients/mapped/Na2haso4_X_7_H2o.yaml
+++ b/data/ingredients/mapped/Na2haso4_X_7_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:91257
 preferred_term: Na2HAsO4 x 7 H2O
 ontology_mapping:
   ontology_id: CHEBI:91257
-  ontology_label: Na2HAsO4 x 7 H2O
+  ontology_label: disodium hydrogenarsenate heptahydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -81,6 +81,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.806051+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na2HAsO4 x 7 H2O'' -> ''disodium hydrogenarsenate heptahydrate'':
+    synced to canonical CHEBI label (preferred_term ''Na2HAsO4 x 7 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:91257
 chemical_properties:
   cas_rn: 10048-95-0

--- a/data/ingredients/mapped/Na2hpo4.yaml
+++ b/data/ingredients/mapped/Na2hpo4.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:34683
 preferred_term: Na2HPO4
 ontology_mapping:
   ontology_id: CHEBI:34683
-  ontology_label: Na2HPO4
+  ontology_label: disodium hydrogenphosphate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -198,6 +198,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: BUFFER (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.806145+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na2HPO4'' -> ''disodium hydrogenphosphate'': synced to
+    canonical CHEBI label (preferred_term ''Na2HPO4'' unchanged).'
 chemical_properties:
   cas_rn: 7558-79-4
   data_source: CultureBotHT compounds_to_cas.csv

--- a/data/ingredients/mapped/Na2hpo4_X_12_H2o.yaml
+++ b/data/ingredients/mapped/Na2hpo4_X_12_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:34683
 preferred_term: Na2HPO4 x 12 H2O
 ontology_mapping:
   ontology_id: CHEBI:34683
-  ontology_label: Na2HPO4 x 12 H2O
+  ontology_label: disodium hydrogenphosphate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -101,6 +101,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: BUFFER (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.806237+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na2HPO4 x 12 H2O'' -> ''disodium hydrogenphosphate'':
+    synced to canonical CHEBI label (preferred_term ''Na2HPO4 x 12 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:34683
 chemical_properties:
   cas_rn: 7782-85-6

--- a/data/ingredients/mapped/Na2hpo4_X_2_H2o.yaml
+++ b/data/ingredients/mapped/Na2hpo4_X_2_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:34683
 preferred_term: Na2HPO4 x 2 H2O
 ontology_mapping:
   ontology_id: CHEBI:34683
-  ontology_label: Na2HPO4 x 2 H2O
+  ontology_label: disodium hydrogenphosphate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -131,6 +131,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: BUFFER (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.806328+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na2HPO4 x 2 H2O'' -> ''disodium hydrogenphosphate'':
+    synced to canonical CHEBI label (preferred_term ''Na2HPO4 x 2 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:34683
 chemical_properties:
   cas_rn: 7558-79-4

--- a/data/ingredients/mapped/Na2hpo4_X_3_H2o.yaml
+++ b/data/ingredients/mapped/Na2hpo4_X_3_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:34683
 preferred_term: Na2HPO4 x 3 H2O
 ontology_mapping:
   ontology_id: CHEBI:34683
-  ontology_label: Na2HPO4 x 3 H2O
+  ontology_label: disodium hydrogenphosphate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -91,6 +91,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: BUFFER (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.806419+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na2HPO4 x 3 H2O'' -> ''disodium hydrogenphosphate'':
+    synced to canonical CHEBI label (preferred_term ''Na2HPO4 x 3 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:34683
 chemical_properties:
   cas_rn: 7782-85-6

--- a/data/ingredients/mapped/Na2hpo4_X_6_H2o.yaml
+++ b/data/ingredients/mapped/Na2hpo4_X_6_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:34683
 preferred_term: Na2HPO4 x 6 H2O
 ontology_mapping:
   ontology_id: CHEBI:34683
-  ontology_label: Na2HPO4 x 6 H2O
+  ontology_label: disodium hydrogenphosphate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -97,6 +97,11 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: BUFFER (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.806512+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na2HPO4 x 6 H2O'' -> ''disodium hydrogenphosphate'':
+    synced to canonical CHEBI label (preferred_term ''Na2HPO4 x 6 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:34683
 chemical_properties:
   cas_rn: 7782-85-6

--- a/data/ingredients/mapped/Na2hpo4_X_7_H2o.yaml
+++ b/data/ingredients/mapped/Na2hpo4_X_7_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:34683
 preferred_term: Na2HPO4 x 7 H2O
 ontology_mapping:
   ontology_id: CHEBI:34683
-  ontology_label: Na2HPO4 x 7 H2O
+  ontology_label: disodium hydrogenphosphate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -99,6 +99,11 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: BUFFER (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.806604+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na2HPO4 x 7 H2O'' -> ''disodium hydrogenphosphate'':
+    synced to canonical CHEBI label (preferred_term ''Na2HPO4 x 7 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:34683
 chemical_properties:
   cas_rn: 7782-85-6

--- a/data/ingredients/mapped/Na2moo4.yaml
+++ b/data/ingredients/mapped/Na2moo4.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:75215
 preferred_term: Na2MoO4
 ontology_mapping:
   ontology_id: CHEBI:75215
-  ontology_label: Na2MoO4
+  ontology_label: sodium molybdate (anhydrous)
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -173,6 +173,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.806699+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na2MoO4'' -> ''sodium molybdate (anhydrous)'': synced
+    to canonical CHEBI label (preferred_term ''Na2MoO4'' unchanged).'
 chemical_properties:
   cas_rn: 7631-95-0
   data_source: OAK/CHEBI xref

--- a/data/ingredients/mapped/Na2moo4_X_2_H2o.yaml
+++ b/data/ingredients/mapped/Na2moo4_X_2_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:75213
 preferred_term: Na2MoO4 x 2 H2O
 ontology_mapping:
   ontology_id: CHEBI:75213
-  ontology_label: Na2MoO4 x 2 H2O
+  ontology_label: sodium molybdate dihydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -195,6 +195,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.806883+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na2MoO4 x 2 H2O'' -> ''sodium molybdate dihydrate'':
+    synced to canonical CHEBI label (preferred_term ''Na2MoO4 x 2 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:75213
 chemical_properties:
   cas_rn: 10102-40-6

--- a/data/ingredients/mapped/Na2moo4_X_7_H2o.yaml
+++ b/data/ingredients/mapped/Na2moo4_X_7_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:86473
 preferred_term: Na2MoO4 x 7 H2O
 ontology_mapping:
   ontology_id: CHEBI:86473
-  ontology_label: Na2MoO4 x 7 H2O
+  ontology_label: sodium molybdate heptahydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -60,6 +60,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.806976+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na2MoO4 x 7 H2O'' -> ''sodium molybdate heptahydrate'':
+    synced to canonical CHEBI label (preferred_term ''Na2MoO4 x 7 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:86473
 chemical_properties:
   cas_rn: 10102-40-6

--- a/data/ingredients/mapped/Na2s2o3_X_5_H2o.yaml
+++ b/data/ingredients/mapped/Na2s2o3_X_5_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:32150
 preferred_term: Na2S2O3 x 5 H2O
 ontology_mapping:
   ontology_id: CHEBI:32150
-  ontology_label: Na2S2O3 x 5 H2O
+  ontology_label: sodium thiosulfate pentahydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -147,6 +147,11 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: ELECTRON_DONOR (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.807267+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na2S2O3 x 5 H2O'' -> ''sodium thiosulfate pentahydrate'':
+    synced to canonical CHEBI label (preferred_term ''Na2S2O3 x 5 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:32150
 chemical_properties:
   cas_rn: 10102-17-7

--- a/data/ingredients/mapped/Na2s2o4.yaml
+++ b/data/ingredients/mapped/Na2s2o4.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:61278
 preferred_term: Na2S2O4
 ontology_mapping:
   ontology_id: CHEBI:61278
-  ontology_label: Na2S2O4
+  ontology_label: scutellarin
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -77,6 +77,11 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: REDUCING_AGENT (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.807363+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na2S2O4'' -> ''scutellarin'': synced to canonical CHEBI
+    label (preferred_term ''Na2S2O4'' unchanged).'
 chemical_properties:
   cas_rn: 7775-14-6
   data_source: PubChem API

--- a/data/ingredients/mapped/Na2s2o5.yaml
+++ b/data/ingredients/mapped/Na2s2o5.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:114786
 preferred_term: Na2S2O5
 ontology_mapping:
   ontology_id: CHEBI:114786
-  ontology_label: Na2S2O5
+  ontology_label: sodium disulfite
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -94,6 +94,11 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: REDUCING_AGENT (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.807459+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na2S2O5'' -> ''sodium disulfite'': synced to canonical
+    CHEBI label (preferred_term ''Na2S2O5'' unchanged).'
 chemical_properties:
   cas_rn: 7681-57-4
   data_source: PubChem API

--- a/data/ingredients/mapped/Na2s_X_9_H2o.yaml
+++ b/data/ingredients/mapped/Na2s_X_9_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:76209
 preferred_term: Na2S x 9 H2O
 ontology_mapping:
   ontology_id: CHEBI:76209
-  ontology_label: Na2S x 9 H2O
+  ontology_label: sodium sulfide nonahydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -143,6 +143,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: REDUCING_AGENT (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.807551+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na2S x 9 H2O'' -> ''sodium sulfide nonahydrate'': synced
+    to canonical CHEBI label (preferred_term ''Na2S x 9 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:76209
 chemical_properties:
   cas_rn: 1313-82-2

--- a/data/ingredients/mapped/Na2seo3.yaml
+++ b/data/ingredients/mapped/Na2seo3.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:48843
 preferred_term: Na2SeO3
 ontology_mapping:
   ontology_id: CHEBI:48843
-  ontology_label: Na2SeO3
+  ontology_label: disodium selenite
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -102,6 +102,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.807650+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na2SeO3'' -> ''disodium selenite'': synced to canonical
+    CHEBI label (preferred_term ''Na2SeO3'' unchanged).'
 chemical_properties:
   cas_rn: 26970-82-1
   data_source: CultureBotHT compounds_to_cas.csv

--- a/data/ingredients/mapped/Na2seo3_X_5_H2o.yaml
+++ b/data/ingredients/mapped/Na2seo3_X_5_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:131361
 preferred_term: Na2SeO3 x 5 H2O
 ontology_mapping:
   ontology_id: CHEBI:131361
-  ontology_label: Na2SeO3 x 5 H2O
+  ontology_label: disodium selenite pentahydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -101,6 +101,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.807840+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na2SeO3 x 5 H2O'' -> ''disodium selenite pentahydrate'':
+    synced to canonical CHEBI label (preferred_term ''Na2SeO3 x 5 H2O'' unchanged).'
 chemical_properties:
   cas_rn: 26970-82-1
   data_source: CultureBotHT/compounds_to_cas.csv

--- a/data/ingredients/mapped/Na2sio3_X_9_H2o.yaml
+++ b/data/ingredients/mapped/Na2sio3_X_9_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:132108
 preferred_term: Na2SiO3 x 9 H2O
 ontology_mapping:
   ontology_id: CHEBI:132108
-  ontology_label: Na2SiO3 x 9 H2O
+  ontology_label: sodium silicate nonahydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -117,6 +117,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.808025+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na2SiO3 x 9 H2O'' -> ''sodium silicate nonahydrate'':
+    synced to canonical CHEBI label (preferred_term ''Na2SiO3 x 9 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:132108
 chemical_properties:
   cas_rn: 13517-24-3

--- a/data/ingredients/mapped/Na2so3_X_5_H2o.yaml
+++ b/data/ingredients/mapped/Na2so3_X_5_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:86477
 preferred_term: Na2SO3 x 5 H2O
 ontology_mapping:
   ontology_id: CHEBI:86477
-  ontology_label: Na2SO3 x 5 H2O
+  ontology_label: sodium sulfite
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -56,6 +56,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.808207+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na2SO3 x 5 H2O'' -> ''sodium sulfite'': synced to canonical
+    CHEBI label (preferred_term ''Na2SO3 x 5 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:86477
 chemical_properties:
   cas_rn: 7757-83-7

--- a/data/ingredients/mapped/Na2so4.yaml
+++ b/data/ingredients/mapped/Na2so4.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:32149
 preferred_term: Na2SO4
 ontology_mapping:
   ontology_id: CHEBI:32149
-  ontology_label: Na2SO4
+  ontology_label: sodium sulfate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -144,6 +144,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.808307+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na2SO4'' -> ''sodium sulfate'': synced to canonical CHEBI
+    label (preferred_term ''Na2SO4'' unchanged).'
 chemical_properties:
   cas_rn: 7757-82-6
   data_source: PubChem API

--- a/data/ingredients/mapped/Na2so4_X_10_H2o.yaml
+++ b/data/ingredients/mapped/Na2so4_X_10_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:32586
 preferred_term: Na2SO4 x 10 H2O
 ontology_mapping:
   ontology_id: CHEBI:32586
-  ontology_label: Na2SO4 x 10 H2O
+  ontology_label: sodium sulfate decahydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -67,6 +67,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.808404+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na2SO4 x 10 H2O'' -> ''sodium sulfate decahydrate'':
+    synced to canonical CHEBI label (preferred_term ''Na2SO4 x 10 H2O'' unchanged).'
 chemical_properties:
   cas_rn: 7727-73-3
   data_source: PubChem (via CHEBI:32586)

--- a/data/ingredients/mapped/Na2wo4_X_2_H2o.yaml
+++ b/data/ingredients/mapped/Na2wo4_X_2_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:63939
 preferred_term: Na2WO4 x 2 H2O
 ontology_mapping:
   ontology_id: CHEBI:63939
-  ontology_label: Na2WO4 x 2 H2O
+  ontology_label: sodium tungstate dihydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -160,6 +160,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.808599+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na2WO4 x 2 H2O'' -> ''sodium tungstate dihydrate'': synced
+    to canonical CHEBI label (preferred_term ''Na2WO4 x 2 H2O'' unchanged).'
 chemical_properties:
   cas_rn: 10213-10-2
   data_source: PubChem (via CHEBI:63939)

--- a/data/ingredients/mapped/Na3-edta.yaml
+++ b/data/ingredients/mapped/Na3-edta.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:63125
 preferred_term: Na3-EDTA
 ontology_mapping:
   ontology_id: CHEBI:63125
-  ontology_label: Na3-EDTA
+  ontology_label: EDTA trisodium salt
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -103,6 +103,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CHELATOR (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.808783+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na3-EDTA'' -> ''EDTA trisodium salt'': synced to canonical
+    CHEBI label (preferred_term ''Na3-EDTA'' unchanged).'
 chemical_properties:
   cas_rn: 150-38-9
   data_source: PubChem (via CHEBI:63125)

--- a/data/ingredients/mapped/Na3vo4.yaml
+++ b/data/ingredients/mapped/Na3vo4.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:35607
 preferred_term: Na3VO4
 ontology_mapping:
   ontology_id: CHEBI:35607
-  ontology_label: Na3VO4
+  ontology_label: trisodium vanadate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -86,6 +86,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.808876+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na3VO4'' -> ''trisodium vanadate'': synced to canonical
+    CHEBI label (preferred_term ''Na3VO4'' unchanged).'
 chemical_properties:
   cas_rn: 13721-39-6
   data_source: PubChem API

--- a/data/ingredients/mapped/Na_Glutamate.yaml
+++ b/data/ingredients/mapped/Na_Glutamate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:64220
 preferred_term: Na glutamate
 ontology_mapping:
   ontology_id: CHEBI:64220
-  ontology_label: Na glutamate
+  ontology_label: monosodium glutamate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -137,6 +137,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: NITROGEN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.808971+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Na glutamate'' -> ''monosodium glutamate'': synced to
+    canonical CHEBI label (preferred_term ''Na glutamate'' unchanged).'
 kg_microbe_node_id: CHEBI:64220
 chemical_properties:
   cas_rn: 142-47-2

--- a/data/ingredients/mapped/Nabr.yaml
+++ b/data/ingredients/mapped/Nabr.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:63004
 preferred_term: NaBr
 ontology_mapping:
   ontology_id: CHEBI:63004
-  ontology_label: NaBr
+  ontology_label: sodium bromide
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -85,6 +85,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.809069+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''NaBr'' -> ''sodium bromide'': synced to canonical CHEBI
+    label (preferred_term ''NaBr'' unchanged).'
 chemical_properties:
   cas_rn: 7647-15-6
   data_source: PubChem API

--- a/data/ingredients/mapped/Nacl.yaml
+++ b/data/ingredients/mapped/Nacl.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:26710
 preferred_term: NaCl
 ontology_mapping:
   ontology_id: CHEBI:26710
-  ontology_label: NaCl
+  ontology_label: sodium chloride
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -194,6 +194,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.809165+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''NaCl'' -> ''sodium chloride'': synced to canonical CHEBI
+    label (preferred_term ''NaCl'' unchanged).'
 chemical_properties:
   cas_rn: 7647-14-5
   data_source: PubChem API

--- a/data/ingredients/mapped/Naf.yaml
+++ b/data/ingredients/mapped/Naf.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:28741
 preferred_term: NaF
 ontology_mapping:
   ontology_id: CHEBI:28741
-  ontology_label: NaF
+  ontology_label: sodium fluoride
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -63,6 +63,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.809354+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''NaF'' -> ''sodium fluoride'': synced to canonical CHEBI
+    label (preferred_term ''NaF'' unchanged).'
 chemical_properties:
   cas_rn: 7681-49-4
   data_source: PubChem API

--- a/data/ingredients/mapped/Nah2po4_X_2_H2o.yaml
+++ b/data/ingredients/mapped/Nah2po4_X_2_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:37585
 preferred_term: NaH2PO4 x 2 H2O
 ontology_mapping:
   ontology_id: CHEBI:37585
-  ontology_label: NaH2PO4 x 2 H2O
+  ontology_label: sodium dihydrogenphosphate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -108,6 +108,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: BUFFER (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.809627+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''NaH2PO4 x 2 H2O'' -> ''sodium dihydrogenphosphate'':
+    synced to canonical CHEBI label (preferred_term ''NaH2PO4 x 2 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:37585
 chemical_properties:
   cas_rn: 7558-80-7

--- a/data/ingredients/mapped/Nahco3.yaml
+++ b/data/ingredients/mapped/Nahco3.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:32139
 preferred_term: NaHCO3
 ontology_mapping:
   ontology_id: CHEBI:32139
-  ontology_label: NaHCO3
+  ontology_label: sodium hydrogencarbonate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -177,6 +177,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: BUFFER (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.809724+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''NaHCO3'' -> ''sodium hydrogencarbonate'': synced to canonical
+    CHEBI label (preferred_term ''NaHCO3'' unchanged).'
 chemical_properties:
   cas_rn: 144-55-8
   data_source: PubChem API

--- a/data/ingredients/mapped/Nahso3.yaml
+++ b/data/ingredients/mapped/Nahso3.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:26709
 preferred_term: NaHSO3
 ontology_mapping:
   ontology_id: CHEBI:26709
-  ontology_label: NaHSO3
+  ontology_label: sodium hydrogensulfite
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -124,6 +124,11 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: REDUCING_AGENT (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.809818+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''NaHSO3'' -> ''sodium hydrogensulfite'': synced to canonical
+    CHEBI label (preferred_term ''NaHSO3'' unchanged).'
 chemical_properties:
   cas_rn: 7631-90-5
   data_source: PubChem API

--- a/data/ingredients/mapped/Nano2.yaml
+++ b/data/ingredients/mapped/Nano2.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:78870
 preferred_term: NaNO2
 ontology_mapping:
   ontology_id: CHEBI:78870
-  ontology_label: NaNO2
+  ontology_label: sodium nitrite
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -82,6 +82,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: NITROGEN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.810009+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''NaNO2'' -> ''sodium nitrite'': synced to canonical CHEBI
+    label (preferred_term ''NaNO2'' unchanged).'
 chemical_properties:
   cas_rn: 7632-00-0
   data_source: PubChem API

--- a/data/ingredients/mapped/Naoh.yaml
+++ b/data/ingredients/mapped/Naoh.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:32145
 preferred_term: NaOH
 ontology_mapping:
   ontology_id: CHEBI:32145
-  ontology_label: NaOH
+  ontology_label: sodium hydroxide
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -123,6 +123,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.810191+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''NaOH'' -> ''sodium hydroxide'': synced to canonical CHEBI
+    label (preferred_term ''NaOH'' unchanged).'
 chemical_properties:
   cas_rn: 1310-73-2
   data_source: PubChem API

--- a/data/ingredients/mapped/Naphthalene.yaml
+++ b/data/ingredients/mapped/Naphthalene.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:16482
 preferred_term: Naphthalene
 ontology_mapping:
   ontology_id: CHEBI:16482
-  ontology_label: Naphthalene
+  ontology_label: naphthalene
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -80,6 +80,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.810286+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Naphthalene'' -> ''naphthalene'': synced to canonical
+    CHEBI label (preferred_term ''Naphthalene'' unchanged).'
 chemical_properties:
   cas_rn: 91-20-3
   data_source: PubChem API

--- a/data/ingredients/mapped/Navo3.yaml
+++ b/data/ingredients/mapped/Navo3.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:75221
 preferred_term: NaVO3
 ontology_mapping:
   ontology_id: CHEBI:75221
-  ontology_label: NaVO3
+  ontology_label: sodium metavanadate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -73,6 +73,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.810774+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''NaVO3'' -> ''sodium metavanadate'': synced to canonical
+    CHEBI label (preferred_term ''NaVO3'' unchanged).'
 chemical_properties:
   cas_rn: 13718-26-8
   data_source: PubChem API

--- a/data/ingredients/mapped/Navo3_X_H2o.yaml
+++ b/data/ingredients/mapped/Navo3_X_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:132095
 preferred_term: NaVO3 x H2O
 ontology_mapping:
   ontology_id: CHEBI:132095
-  ontology_label: NaVO3 x H2O
+  ontology_label: sodium metavanadate hydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -95,6 +95,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.810871+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''NaVO3 x H2O'' -> ''sodium metavanadate hydrate'': synced
+    to canonical CHEBI label (preferred_term ''NaVO3 x H2O'' unchanged).'
 chemical_properties:
   cas_rn: 20740-98-1
   data_source: PubChem (via CHEBI:132095)

--- a/data/ingredients/mapped/Nh4-oxalate.yaml
+++ b/data/ingredients/mapped/Nh4-oxalate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:91241
 preferred_term: NH4-oxalate
 ontology_mapping:
   ontology_id: CHEBI:91241
-  ontology_label: NH4-oxalate
+  ontology_label: ammonium oxalate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -70,6 +70,11 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: NITROGEN_SOURCE (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.811328+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''NH4-oxalate'' -> ''ammonium oxalate'': synced to canonical
+    CHEBI label (preferred_term ''NH4-oxalate'' unchanged).'
 chemical_properties:
   cas_rn: 1113-38-8
   data_source: PubChem (via CHEBI:91241)

--- a/data/ingredients/mapped/Nh42ni_So42.yaml
+++ b/data/ingredients/mapped/Nh42ni_So42.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:86149
 preferred_term: (NH4)2Ni(SO4)2
 ontology_mapping:
   ontology_id: CHEBI:86149
-  ontology_label: (NH4)2Ni(SO4)2
+  ontology_label: ammonium nickel sulfate hexahydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -60,6 +60,11 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: TRACE_ELEMENT (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.811604+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''(NH4)2Ni(SO4)2'' -> ''ammonium nickel sulfate hexahydrate'':
+    synced to canonical CHEBI label (preferred_term ''(NH4)2Ni(SO4)2'' unchanged).'
 chemical_properties:
   cas_rn: 56110-30-6
   data_source: PubChem (via CHEBI:86149)

--- a/data/ingredients/mapped/Nh42ni_So42_X_6_H2o.yaml
+++ b/data/ingredients/mapped/Nh42ni_So42_X_6_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:86149
 preferred_term: (NH4)2Ni(SO4)2 x 6 H2O
 ontology_mapping:
   ontology_id: CHEBI:86149
-  ontology_label: (NH4)2Ni(SO4)2 x 6 H2O
+  ontology_label: ammonium nickel sulfate hexahydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -136,6 +136,12 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.811698+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''(NH4)2Ni(SO4)2 x 6 H2O'' -> ''ammonium nickel sulfate
+    hexahydrate'': synced to canonical CHEBI label (preferred_term ''(NH4)2Ni(SO4)2
+    x 6 H2O'' unchanged).'
 chemical_properties:
   cas_rn: 56110-30-6
   data_source: PubChem (via CHEBI:86149)

--- a/data/ingredients/mapped/Nh42so4.yaml
+++ b/data/ingredients/mapped/Nh42so4.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:62946
 preferred_term: (NH4)2SO4
 ontology_mapping:
   ontology_id: CHEBI:62946
-  ontology_label: (NH4)2SO4
+  ontology_label: ammonium sulfate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -182,6 +182,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: NITROGEN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.811795+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''(NH4)2SO4'' -> ''ammonium sulfate'': synced to canonical
+    CHEBI label (preferred_term ''(NH4)2SO4'' unchanged).'
 kg_microbe_node_id: CHEBI:62946
 chemical_properties:
   cas_rn: 7783-20-2

--- a/data/ingredients/mapped/Nh43_Citrate.yaml
+++ b/data/ingredients/mapped/Nh43_Citrate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:63037
 preferred_term: (NH4)3 citrate
 ontology_mapping:
   ontology_id: CHEBI:63037
-  ontology_label: (NH4)3 citrate
+  ontology_label: triammonium citrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -116,6 +116,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: NITROGEN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.811889+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''(NH4)3 citrate'' -> ''triammonium citrate'': synced to
+    canonical CHEBI label (preferred_term ''(NH4)3 citrate'' unchanged).'
 chemical_properties:
   cas_rn: 3458-72-8
   data_source: PubChem (via CHEBI:63037)

--- a/data/ingredients/mapped/Nh4cl.yaml
+++ b/data/ingredients/mapped/Nh4cl.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:31206
 preferred_term: NH4Cl
 ontology_mapping:
   ontology_id: CHEBI:31206
-  ontology_label: NH4Cl
+  ontology_label: ammonium chloride
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -165,6 +165,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: NITROGEN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.811984+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''NH4Cl'' -> ''ammonium chloride'': synced to canonical
+    CHEBI label (preferred_term ''NH4Cl'' unchanged).'
 chemical_properties:
   cas_rn: 12125-02-9
   data_source: CultureBotHT compounds_to_cas.csv

--- a/data/ingredients/mapped/Nh4no3.yaml
+++ b/data/ingredients/mapped/Nh4no3.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:63038
 preferred_term: (NH4)NO3
 ontology_mapping:
   ontology_id: CHEBI:63038
-  ontology_label: (NH4)NO3
+  ontology_label: ammonium nitrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -169,6 +169,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: NITROGEN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.812264+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''(NH4)NO3'' -> ''ammonium nitrate'': synced to canonical
+    CHEBI label (preferred_term ''(NH4)NO3'' unchanged).'
 chemical_properties:
   cas_rn: 6484-52-2
   data_source: OAK/CHEBI xref

--- a/data/ingredients/mapped/Nicl2.yaml
+++ b/data/ingredients/mapped/Nicl2.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:34887
 preferred_term: NiCl2
 ontology_mapping:
   ontology_id: CHEBI:34887
-  ontology_label: NiCl2
+  ontology_label: nickel dichloride
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -153,6 +153,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.812547+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''NiCl2'' -> ''nickel dichloride'': synced to canonical
+    CHEBI label (preferred_term ''NiCl2'' unchanged).'
 chemical_properties:
   cas_rn: 7718-54-9
   data_source: PubChem API

--- a/data/ingredients/mapped/Nicl2_X_2_H2o.yaml
+++ b/data/ingredients/mapped/Nicl2_X_2_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:34887
 preferred_term: NiCl2 x 2 H2O
 ontology_mapping:
   ontology_id: CHEBI:34887
-  ontology_label: NiCl2 x 2 H2O
+  ontology_label: nickel dichloride
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -101,6 +101,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.812639+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''NiCl2 x 2 H2O'' -> ''nickel dichloride'': synced to canonical
+    CHEBI label (preferred_term ''NiCl2 x 2 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:34887
 chemical_properties:
   cas_rn: 7791-20-0

--- a/data/ingredients/mapped/Nicl2_X_5_H2o.yaml
+++ b/data/ingredients/mapped/Nicl2_X_5_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:34887
 preferred_term: NiCl2 x 5 H2O
 ontology_mapping:
   ontology_id: CHEBI:34887
-  ontology_label: NiCl2 x 5 H2O
+  ontology_label: nickel dichloride
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -101,6 +101,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.812731+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''NiCl2 x 5 H2O'' -> ''nickel dichloride'': synced to canonical
+    CHEBI label (preferred_term ''NiCl2 x 5 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:34887
 chemical_properties:
   cas_rn: 7791-20-0

--- a/data/ingredients/mapped/Nicl2_X_6_H2o.yaml
+++ b/data/ingredients/mapped/Nicl2_X_6_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:34887
 preferred_term: NiCl2 x 6 H2O
 ontology_mapping:
   ontology_id: CHEBI:34887
-  ontology_label: NiCl2 x 6 H2O
+  ontology_label: nickel dichloride
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -172,6 +172,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.812823+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''NiCl2 x 6 H2O'' -> ''nickel dichloride'': synced to canonical
+    CHEBI label (preferred_term ''NiCl2 x 6 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:34887
 chemical_properties:
   cas_rn: 7718-54-9

--- a/data/ingredients/mapped/Nicotinamide.yaml
+++ b/data/ingredients/mapped/Nicotinamide.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17154
 preferred_term: Nicotinamide
 ontology_mapping:
   ontology_id: CHEBI:17154
-  ontology_label: Nicotinamide
+  ontology_label: nicotinamide
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -184,6 +184,11 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: VITAMIN_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.812921+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Nicotinamide'' -> ''nicotinamide'': synced to canonical
+    CHEBI label (preferred_term ''Nicotinamide'' unchanged).'
 chemical_properties:
   cas_rn: 98-92-0
   data_source: CultureBotHT compounds_to_cas.csv

--- a/data/ingredients/mapped/Nicotinic_Acid.yaml
+++ b/data/ingredients/mapped/Nicotinic_Acid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:15940
 preferred_term: Nicotinic acid
 ontology_mapping:
   ontology_id: CHEBI:15940
-  ontology_label: Nicotinic acid
+  ontology_label: nicotinic acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -187,6 +187,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: VITAMIN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.813111+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Nicotinic acid'' -> ''nicotinic acid'': synced to canonical
+    CHEBI label (preferred_term ''Nicotinic acid'' unchanged).'
 chemical_properties:
   cas_rn: 59-67-6
   data_source: CultureBotHT compounds_to_cas.csv

--- a/data/ingredients/mapped/Niso4_X_6_H2o.yaml
+++ b/data/ingredients/mapped/Niso4_X_6_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:53001
 preferred_term: NiSO4 x 6 H2O
 ontology_mapping:
   ontology_id: CHEBI:53001
-  ontology_label: NiSO4 x 6 H2O
+  ontology_label: nickel sulfate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -69,6 +69,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.813391+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''NiSO4 x 6 H2O'' -> ''nickel sulfate'': synced to canonical
+    CHEBI label (preferred_term ''NiSO4 x 6 H2O'' unchanged).'
 chemical_properties:
   cas_rn: 10101-97-0
   data_source: CultureBotHT/compounds_to_cas.csv

--- a/data/ingredients/mapped/Niso4_X_7_H2o.yaml
+++ b/data/ingredients/mapped/Niso4_X_7_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:53001
 preferred_term: NiSO4 x 7 H2O
 ontology_mapping:
   ontology_id: CHEBI:53001
-  ontology_label: NiSO4 x 7 H2O
+  ontology_label: nickel sulfate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -69,6 +69,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.813483+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''NiSO4 x 7 H2O'' -> ''nickel sulfate'': synced to canonical
+    CHEBI label (preferred_term ''NiSO4 x 7 H2O'' unchanged).'
 chemical_properties:
   cas_rn: 10101-97-0
   data_source: CultureBotHT/compounds_to_cas.csv

--- a/data/ingredients/mapped/Nitrilotriacetate.yaml
+++ b/data/ingredients/mapped/Nitrilotriacetate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:25548
 preferred_term: Nitrilotriacetate
 ontology_mapping:
   ontology_id: CHEBI:25548
-  ontology_label: Nitrilotriacetate
+  ontology_label: nitrilotriacetate(3-)
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -64,6 +64,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.813581+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Nitrilotriacetate'' -> ''nitrilotriacetate(3-)'': synced
+    to canonical CHEBI label (preferred_term ''Nitrilotriacetate'' unchanged).'
 chemical_properties:
   cas_rn: 28528-44-1
   data_source: PubChem API

--- a/data/ingredients/mapped/Nitrilotriacetic_Acid.yaml
+++ b/data/ingredients/mapped/Nitrilotriacetic_Acid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:44557
 preferred_term: Nitrilotriacetic acid
 ontology_mapping:
   ontology_id: CHEBI:44557
-  ontology_label: Nitrilotriacetic acid
+  ontology_label: nitrilotriacetic acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -160,6 +160,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.813676+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Nitrilotriacetic acid'' -> ''nitrilotriacetic acid'':
+    synced to canonical CHEBI label (preferred_term ''Nitrilotriacetic acid'' unchanged).'
 chemical_properties:
   cas_rn: 139-13-9
   data_source: PubChem API

--- a/data/ingredients/mapped/Oleic_Acid.yaml
+++ b/data/ingredients/mapped/Oleic_Acid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:16196
 preferred_term: Oleic acid
 ontology_mapping:
   ontology_id: CHEBI:16196
-  ontology_label: Oleic acid
+  ontology_label: oleic acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -111,6 +111,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.815515+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Oleic acid'' -> ''oleic acid'': synced to canonical CHEBI
+    label (preferred_term ''Oleic acid'' unchanged).'
 chemical_properties:
   cas_rn: 112-80-1
   data_source: PubChem API

--- a/data/ingredients/mapped/P-aminobenzoic_Acid.yaml
+++ b/data/ingredients/mapped/P-aminobenzoic_Acid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:30753
 preferred_term: p-Aminobenzoic acid
 ontology_mapping:
   ontology_id: CHEBI:30753
-  ontology_label: p-Aminobenzoic acid
+  ontology_label: 4-aminobenzoic acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -224,6 +224,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: VITAMIN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.816413+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''p-Aminobenzoic acid'' -> ''4-aminobenzoic acid'': synced
+    to canonical CHEBI label (preferred_term ''p-Aminobenzoic acid'' unchanged).'
 chemical_properties:
   cas_rn: 150-13-0
   data_source: CultureBotHT compounds_to_cas.csv

--- a/data/ingredients/mapped/P-hydroxybenzoate.yaml
+++ b/data/ingredients/mapped/P-hydroxybenzoate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17879
 preferred_term: p-Hydroxybenzoate
 ontology_mapping:
   ontology_id: CHEBI:17879
-  ontology_label: p-Hydroxybenzoate
+  ontology_label: 4-hydroxybenzoate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -56,6 +56,11 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.816511+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''p-Hydroxybenzoate'' -> ''4-hydroxybenzoate'': synced
+    to canonical CHEBI label (preferred_term ''p-Hydroxybenzoate'' unchanged).'
 chemical_properties:
   cas_rn: 456-23-5
   data_source: PubChem API

--- a/data/ingredients/mapped/Pantothenate.yaml
+++ b/data/ingredients/mapped/Pantothenate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:16454
 preferred_term: Pantothenate
 ontology_mapping:
   ontology_id: CHEBI:16454
-  ontology_label: Pantothenate
+  ontology_label: pantothenate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -71,6 +71,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: VITAMIN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.817080+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Pantothenate'' -> ''pantothenate'': synced to canonical
+    CHEBI label (preferred_term ''Pantothenate'' unchanged).'
 chemical_properties:
   cas_rn: 20938-62-9
   data_source: PubChem API

--- a/data/ingredients/mapped/Pantothenic_Acid.yaml
+++ b/data/ingredients/mapped/Pantothenic_Acid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:7916
 preferred_term: Pantothenic acid
 ontology_mapping:
   ontology_id: CHEBI:7916
-  ontology_label: Pantothenic acid
+  ontology_label: pantothenic acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -101,6 +101,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: VITAMIN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.817180+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Pantothenic acid'' -> ''pantothenic acid'': synced to
+    canonical CHEBI label (preferred_term ''Pantothenic acid'' unchanged).'
 chemical_properties:
   cas_rn: 599-54-2
   data_source: OAK/CHEBI xref

--- a/data/ingredients/mapped/Pectin.yaml
+++ b/data/ingredients/mapped/Pectin.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17309
 preferred_term: Pectin
 ontology_mapping:
   ontology_id: CHEBI:17309
-  ontology_label: Pectin
+  ontology_label: pectin
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -96,6 +96,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.818420+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Pectin'' -> ''pectin'': synced to canonical CHEBI label
+    (preferred_term ''Pectin'' unchanged).'
 chemical_properties:
   cas_rn: 9000-69-5
   data_source: CultureBotHT/compounds_to_cas.csv

--- a/data/ingredients/mapped/Penicillin.yaml
+++ b/data/ingredients/mapped/Penicillin.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17334
 preferred_term: Penicillin
 ontology_mapping:
   ontology_id: CHEBI:17334
-  ontology_label: Penicillin
+  ontology_label: penicillin
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -74,6 +74,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: SELECTIVE_AGENT (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.818532+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Penicillin'' -> ''penicillin'': synced to canonical CHEBI
+    label (preferred_term ''Penicillin'' unchanged).'
 chemical_properties:
   cas_rn: 215-794-6
   data_source: PubChem API

--- a/data/ingredients/mapped/Phenol.yaml
+++ b/data/ingredients/mapped/Phenol.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:15882
 preferred_term: Phenol
 ontology_mapping:
   ontology_id: CHEBI:15882
-  ontology_label: Phenol
+  ontology_label: phenol
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -90,6 +90,11 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.819518+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Phenol'' -> ''phenol'': synced to canonical CHEBI label
+    (preferred_term ''Phenol'' unchanged).'
 chemical_properties:
   cas_rn: 108-95-2
   data_source: PubChem API

--- a/data/ingredients/mapped/Phenol_Red.yaml
+++ b/data/ingredients/mapped/Phenol_Red.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:31991
 preferred_term: Phenol red
 ontology_mapping:
   ontology_id: CHEBI:31991
-  ontology_label: Phenol red
+  ontology_label: phenol red
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -115,6 +115,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: PH_INDICATOR (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.819619+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Phenol red'' -> ''phenol red'': synced to canonical CHEBI
+    label (preferred_term ''Phenol red'' unchanged).'
 chemical_properties:
   cas_rn: 143-74-8
   data_source: PubChem API

--- a/data/ingredients/mapped/Poly_3-hydroxybutyrate.yaml
+++ b/data/ingredients/mapped/Poly_3-hydroxybutyrate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:53389
 preferred_term: Poly(3-hydroxybutyrate)
 ontology_mapping:
   ontology_id: CHEBI:53389
-  ontology_label: Poly(3-hydroxybutyrate)
+  ontology_label: poly(3-hydroxybutyrate)
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -72,6 +72,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.821850+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Poly(3-hydroxybutyrate)'' -> ''poly(3-hydroxybutyrate)'':
+    synced to canonical CHEBI label (preferred_term ''Poly(3-hydroxybutyrate)'' unchanged).'
 ingredient_type: SINGLE_INGREDIENT
 chemical_properties:
   molecular_formula: (C4H6O2)n

--- a/data/ingredients/mapped/Proline.yaml
+++ b/data/ingredients/mapped/Proline.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:26271
 preferred_term: Proline
 ontology_mapping:
   ontology_id: CHEBI:26271
-  ontology_label: Proline
+  ontology_label: proline
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -69,6 +69,11 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: AMINO_ACID_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.823156+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Proline'' -> ''proline'': synced to canonical CHEBI label
+    (preferred_term ''Proline'' unchanged).'
 chemical_properties:
   cas_rn: 147-85-3
   data_source: PubChem API

--- a/data/ingredients/mapped/Propionic_Acid.yaml
+++ b/data/ingredients/mapped/Propionic_Acid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:30768
 preferred_term: Propionic acid
 ontology_mapping:
   ontology_id: CHEBI:30768
-  ontology_label: Propionic acid
+  ontology_label: propionic acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -101,6 +101,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.823523+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Propionic acid'' -> ''propionic acid'': synced to canonical
+    CHEBI label (preferred_term ''Propionic acid'' unchanged).'
 chemical_properties:
   cas_rn: 79-09-4
   data_source: PubChem API

--- a/data/ingredients/mapped/Putrescine.yaml
+++ b/data/ingredients/mapped/Putrescine.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17148
 preferred_term: Putrescine
 ontology_mapping:
   ontology_id: CHEBI:17148
-  ontology_label: Putrescine
+  ontology_label: putrescine
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -99,6 +99,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: NITROGEN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.824265+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Putrescine'' -> ''putrescine'': synced to canonical CHEBI
+    label (preferred_term ''Putrescine'' unchanged).'
 chemical_properties:
   cas_rn: 110-60-1
   data_source: PubChem API

--- a/data/ingredients/mapped/Pyridoxal_Hydrochloride.yaml
+++ b/data/ingredients/mapped/Pyridoxal_Hydrochloride.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:131529
 preferred_term: Pyridoxal hydrochloride
 ontology_mapping:
   ontology_id: CHEBI:131529
-  ontology_label: Pyridoxal hydrochloride
+  ontology_label: pyridoxal hydrochloride
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -78,6 +78,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: VITAMIN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.824639+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Pyridoxal hydrochloride'' -> ''pyridoxal hydrochloride'':
+    synced to canonical CHEBI label (preferred_term ''Pyridoxal hydrochloride'' unchanged).'
 chemical_properties:
   cas_rn: 65-22-5
   data_source: PubChem API

--- a/data/ingredients/mapped/Pyridoxal_Phosphate.yaml
+++ b/data/ingredients/mapped/Pyridoxal_Phosphate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:18405
 preferred_term: Pyridoxal phosphate
 ontology_mapping:
   ontology_id: CHEBI:18405
-  ontology_label: Pyridoxal phosphate
+  ontology_label: pyridoxal 5'-phosphate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -91,6 +91,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: VITAMIN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.824734+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Pyridoxal phosphate'' -> "pyridoxal 5''-phosphate": synced
+    to canonical CHEBI label (preferred_term ''Pyridoxal phosphate'' unchanged).'
 chemical_properties:
   cas_rn: 54-47-7
   data_source: PubChem API

--- a/data/ingredients/mapped/Pyridoxamine.yaml
+++ b/data/ingredients/mapped/Pyridoxamine.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:16410
 preferred_term: Pyridoxamine
 ontology_mapping:
   ontology_id: CHEBI:16410
-  ontology_label: Pyridoxamine
+  ontology_label: pyridoxamine
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -77,6 +77,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: VITAMIN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.824831+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Pyridoxamine'' -> ''pyridoxamine'': synced to canonical
+    CHEBI label (preferred_term ''Pyridoxamine'' unchanged).'
 chemical_properties:
   cas_rn: 85-87-0
   data_source: PubChem API

--- a/data/ingredients/mapped/Pyridoxamine_Dihydrochloride.yaml
+++ b/data/ingredients/mapped/Pyridoxamine_Dihydrochloride.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:131532
 preferred_term: Pyridoxamine Dihydrochloride
 ontology_mapping:
   ontology_id: CHEBI:131532
-  ontology_label: Pyridoxamine Dihydrochloride
+  ontology_label: pyridoxamine dihydrochloride
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -100,6 +100,12 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: VITAMIN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.824925+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Pyridoxamine Dihydrochloride'' -> ''pyridoxamine dihydrochloride'':
+    synced to canonical CHEBI label (preferred_term ''Pyridoxamine Dihydrochloride''
+    unchanged).'
 chemical_properties:
   cas_rn: 524-36-7
   data_source: PubChem API

--- a/data/ingredients/mapped/Pyridoxamine_Hydrochloride.yaml
+++ b/data/ingredients/mapped/Pyridoxamine_Hydrochloride.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:131531
 preferred_term: Pyridoxamine hydrochloride
 ontology_mapping:
   ontology_id: CHEBI:131531
-  ontology_label: Pyridoxamine hydrochloride
+  ontology_label: pyridoxamine hydrochloride
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -116,6 +116,12 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: VITAMIN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.825017+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Pyridoxamine hydrochloride'' -> ''pyridoxamine hydrochloride'':
+    synced to canonical CHEBI label (preferred_term ''Pyridoxamine hydrochloride''
+    unchanged).'
 chemical_properties:
   cas_rn: 5103-96-8
   data_source: PubChem (via CHEBI:131531)

--- a/data/ingredients/mapped/Pyridoxine_Hydrochloride.yaml
+++ b/data/ingredients/mapped/Pyridoxine_Hydrochloride.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:30961
 preferred_term: Pyridoxine hydrochloride
 ontology_mapping:
   ontology_id: CHEBI:30961
-  ontology_label: Pyridoxine hydrochloride
+  ontology_label: pyridoxine hydrochloride
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -155,6 +155,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: VITAMIN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.825203+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Pyridoxine hydrochloride'' -> ''pyridoxine hydrochloride'':
+    synced to canonical CHEBI label (preferred_term ''Pyridoxine hydrochloride'' unchanged).'
 chemical_properties:
   cas_rn: 58-56-0
   data_source: PubChem API

--- a/data/ingredients/mapped/Pyruvate.yaml
+++ b/data/ingredients/mapped/Pyruvate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:15361
 preferred_term: Pyruvate
 ontology_mapping:
   ontology_id: CHEBI:15361
-  ontology_label: Pyruvate
+  ontology_label: pyruvate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -63,6 +63,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.825770+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Pyruvate'' -> ''pyruvate'': synced to canonical CHEBI
+    label (preferred_term ''Pyruvate'' unchanged).'
 chemical_properties:
   cas_rn: 57-60-3
   data_source: PubChem API

--- a/data/ingredients/mapped/Pyruvic_Acid.yaml
+++ b/data/ingredients/mapped/Pyruvic_Acid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:32816
 preferred_term: Pyruvic acid
 ontology_mapping:
   ontology_id: CHEBI:32816
-  ontology_label: Pyruvic acid
+  ontology_label: pyruvic acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -101,6 +101,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.825862+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Pyruvic acid'' -> ''pyruvic acid'': synced to canonical
+    CHEBI label (preferred_term ''Pyruvic acid'' unchanged).'
 chemical_properties:
   cas_rn: 127-17-3
   data_source: PubChem API

--- a/data/ingredients/mapped/Quinic_Acid.yaml
+++ b/data/ingredients/mapped/Quinic_Acid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:26493
 preferred_term: Quinic acid
 ontology_mapping:
   ontology_id: CHEBI:26493
-  ontology_label: Quinic acid
+  ontology_label: quinic acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -53,6 +53,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.826234+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Quinic acid'' -> ''quinic acid'': synced to canonical
+    CHEBI label (preferred_term ''Quinic acid'' unchanged).'
 chemical_properties:
   cas_rn: 7729-33-1
   data_source: PubChem API

--- a/data/ingredients/mapped/Riboflavin.yaml
+++ b/data/ingredients/mapped/Riboflavin.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17015
 preferred_term: Riboflavin
 ontology_mapping:
   ontology_id: CHEBI:17015
-  ontology_label: Riboflavin
+  ontology_label: riboflavin
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -169,6 +169,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: VITAMIN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.827070+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Riboflavin'' -> ''riboflavin'': synced to canonical CHEBI
+    label (preferred_term ''Riboflavin'' unchanged).'
 chemical_properties:
   cas_rn: 83-88-5
   data_source: PubChem API

--- a/data/ingredients/mapped/Ribose.yaml
+++ b/data/ingredients/mapped/Ribose.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:33942
 preferred_term: Ribose
 ontology_mapping:
   ontology_id: CHEBI:33942
-  ontology_label: Ribose
+  ontology_label: ribose
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -62,6 +62,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.827326+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Ribose'' -> ''ribose'': synced to canonical CHEBI label
+    (preferred_term ''Ribose'' unchanged).'
 chemical_properties:
   cas_rn: 200-059-4
   data_source: PubChem API

--- a/data/ingredients/mapped/Rifampicin.yaml
+++ b/data/ingredients/mapped/Rifampicin.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:28077
 preferred_term: Rifampicin
 ontology_mapping:
   ontology_id: CHEBI:28077
-  ontology_label: Rifampicin
+  ontology_label: rifampicin
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -81,6 +81,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: SELECTIVE_AGENT (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.827641+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Rifampicin'' -> ''rifampicin'': synced to canonical CHEBI
+    label (preferred_term ''Rifampicin'' unchanged).'
 chemical_properties:
   cas_rn: 13292-46-1
   data_source: PubChem API

--- a/data/ingredients/mapped/Sio2.yaml
+++ b/data/ingredients/mapped/Sio2.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:30563
 preferred_term: SiO2
 ontology_mapping:
   ontology_id: CHEBI:30563
-  ontology_label: SiO2
+  ontology_label: silicon dioxide
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -79,6 +79,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.831453+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''SiO2'' -> ''silicon dioxide'': synced to canonical CHEBI
+    label (preferred_term ''SiO2'' unchanged).'
 chemical_properties:
   cas_rn: 7631-86-9
   data_source: PubChem API

--- a/data/ingredients/mapped/Sncl2_X_2_H2o.yaml
+++ b/data/ingredients/mapped/Sncl2_X_2_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:78074
 preferred_term: SnCl2 x 2 H2O
 ontology_mapping:
   ontology_id: CHEBI:78074
-  ontology_label: SnCl2 x 2 H2O
+  ontology_label: tin(II) chloride dihydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -93,6 +93,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.832035+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''SnCl2 x 2 H2O'' -> ''tin(II) chloride dihydrate'': synced
+    to canonical CHEBI label (preferred_term ''SnCl2 x 2 H2O'' unchanged).'
 ingredient_type: SINGLE_INGREDIENT
 chemical_properties:
   molecular_formula: 2Cl.2H2O.Sn

--- a/data/ingredients/mapped/Sodium_Acetate_Trihydrate.yaml
+++ b/data/ingredients/mapped/Sodium_Acetate_Trihydrate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:32138
 preferred_term: Sodium acetate trihydrate
 ontology_mapping:
   ontology_id: CHEBI:32138
-  ontology_label: Sodium acetate trihydrate
+  ontology_label: sodium acetate trihydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -68,6 +68,12 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: BUFFER (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.832497+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Sodium acetate trihydrate'' -> ''sodium acetate trihydrate'':
+    synced to canonical CHEBI label (preferred_term ''Sodium acetate trihydrate''
+    unchanged).'
 chemical_properties:
   cas_rn: 6131-90-4
   data_source: PubChem API

--- a/data/ingredients/mapped/Sodium_Alginate.yaml
+++ b/data/ingredients/mapped/Sodium_Alginate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:53311
 preferred_term: Sodium alginate
 ontology_mapping:
   ontology_id: CHEBI:53311
-  ontology_label: Sodium alginate
+  ontology_label: sodium alginate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -78,6 +78,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: SOLIDIFYING_AGENT (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.832708+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Sodium alginate'' -> ''sodium alginate'': synced to canonical
+    CHEBI label (preferred_term ''Sodium alginate'' unchanged).'
 chemical_properties:
   cas_rn: 9005-38-3
   data_source: CultureBotHT compounds_to_cas.csv

--- a/data/ingredients/mapped/Sodium_Beta-glycerophosphate.yaml
+++ b/data/ingredients/mapped/Sodium_Beta-glycerophosphate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:132089
 preferred_term: Sodium beta-glycerophosphate
 ontology_mapping:
   ontology_id: CHEBI:132089
-  ontology_label: Sodium beta-glycerophosphate
+  ontology_label: sodium glycerol 2-phosphate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -94,6 +94,12 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.832907+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Sodium beta-glycerophosphate'' -> ''sodium glycerol 2-phosphate'':
+    synced to canonical CHEBI label (preferred_term ''Sodium beta-glycerophosphate''
+    unchanged).'
 chemical_properties:
   cas_rn: 819-83-0
   data_source: PubChem (via CHEBI:132089)

--- a/data/ingredients/mapped/Sodium_Dithionite.yaml
+++ b/data/ingredients/mapped/Sodium_Dithionite.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:66870
 preferred_term: Sodium dithionite
 ontology_mapping:
   ontology_id: CHEBI:66870
-  ontology_label: Sodium dithionite
+  ontology_label: sodium dithionite
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -69,6 +69,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: REDUCING_AGENT (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.833979+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Sodium dithionite'' -> ''sodium dithionite'': synced
+    to canonical CHEBI label (preferred_term ''Sodium dithionite'' unchanged).'
 chemical_properties:
   cas_rn: 7775-14-6
   data_source: PubChem API

--- a/data/ingredients/mapped/Sodium_Gluconate.yaml
+++ b/data/ingredients/mapped/Sodium_Gluconate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:84997
 preferred_term: Sodium gluconate
 ontology_mapping:
   ontology_id: CHEBI:84997
-  ontology_label: Sodium gluconate
+  ontology_label: sodium gluconate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -124,6 +124,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.834575+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Sodium gluconate'' -> ''sodium gluconate'': synced to
+    canonical CHEBI label (preferred_term ''Sodium gluconate'' unchanged).'
 chemical_properties:
   cas_rn: 527-07-1
   data_source: CultureBotHT compounds_to_cas.csv

--- a/data/ingredients/mapped/Sodium_Glutamate_Monohydrate.yaml
+++ b/data/ingredients/mapped/Sodium_Glutamate_Monohydrate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:64243
 preferred_term: Sodium glutamate monohydrate
 ontology_mapping:
   ontology_id: CHEBI:64243
-  ontology_label: Sodium glutamate monohydrate
+  ontology_label: monosodium L-glutamate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -56,6 +56,12 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: NITROGEN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.834675+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Sodium glutamate monohydrate'' -> ''monosodium L-glutamate'':
+    synced to canonical CHEBI label (preferred_term ''Sodium glutamate monohydrate''
+    unchanged).'
 chemical_properties:
   cas_rn: 6106-04-3
   data_source: PubChem API

--- a/data/ingredients/mapped/Sodium_Lactate.yaml
+++ b/data/ingredients/mapped/Sodium_Lactate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:75228
 preferred_term: Sodium lactate
 ontology_mapping:
   ontology_id: CHEBI:75228
-  ontology_label: Sodium lactate
+  ontology_label: sodium lactate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -256,6 +256,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.835326+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Sodium lactate'' -> ''sodium lactate'': synced to canonical
+    CHEBI label (preferred_term ''Sodium lactate'' unchanged).'
 chemical_properties:
   cas_rn: 72-17-3
   data_source: OAK/CHEBI xref

--- a/data/ingredients/mapped/Sodium_Malate.yaml
+++ b/data/ingredients/mapped/Sodium_Malate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:91261
 preferred_term: Sodium malate
 ontology_mapping:
   ontology_id: CHEBI:91261
-  ontology_label: Sodium malate
+  ontology_label: disodium (S)-malate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -194,6 +194,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.835512+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Sodium malate'' -> ''disodium (S)-malate'': synced to
+    canonical CHEBI label (preferred_term ''Sodium malate'' unchanged).'
 chemical_properties:
   cas_rn: 138-09-0
   data_source: OAK/CHEBI xref

--- a/data/ingredients/mapped/Sodium_Maleate.yaml
+++ b/data/ingredients/mapped/Sodium_Maleate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:91263
 preferred_term: Sodium maleate
 ontology_mapping:
   ontology_id: CHEBI:91263
-  ontology_label: Sodium maleate
+  ontology_label: disodium maleate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -66,6 +66,11 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: BUFFER (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.835611+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Sodium maleate'' -> ''disodium maleate'': synced to canonical
+    CHEBI label (preferred_term ''Sodium maleate'' unchanged).'
 chemical_properties:
   cas_rn: 371-47-1
   data_source: PubChem API

--- a/data/ingredients/mapped/Sodium_Perchlorate.yaml
+++ b/data/ingredients/mapped/Sodium_Perchlorate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:132103
 preferred_term: Sodium perchlorate
 ontology_mapping:
   ontology_id: CHEBI:132103
-  ontology_label: Sodium perchlorate
+  ontology_label: sodium perchlorate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -66,6 +66,11 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: ELECTRON_ACCEPTOR (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.836155+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Sodium perchlorate'' -> ''sodium perchlorate'': synced
+    to canonical CHEBI label (preferred_term ''Sodium perchlorate'' unchanged).'
 chemical_properties:
   cas_rn: 7601-89-0
   data_source: PubChem API

--- a/data/ingredients/mapped/Sodium_Pyrophosphate.yaml
+++ b/data/ingredients/mapped/Sodium_Pyrophosphate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:71240
 preferred_term: Sodium pyrophosphate
 ontology_mapping:
   ontology_id: CHEBI:71240
-  ontology_label: Sodium pyrophosphate
+  ontology_label: sodium diphosphate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -69,6 +69,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.836546+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Sodium pyrophosphate'' -> ''sodium diphosphate'': synced
+    to canonical CHEBI label (preferred_term ''Sodium pyrophosphate'' unchanged).'
 chemical_properties:
   cas_rn: 7722-88-5
   data_source: PubChem API

--- a/data/ingredients/mapped/Sodium_Succinate.yaml
+++ b/data/ingredients/mapped/Sodium_Succinate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:63675
 preferred_term: Sodium succinate
 ontology_mapping:
   ontology_id: CHEBI:63675
-  ontology_label: Sodium succinate
+  ontology_label: sodium succinate (anhydrous)
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -138,6 +138,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.836736+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Sodium succinate'' -> ''sodium succinate (anhydrous)'':
+    synced to canonical CHEBI label (preferred_term ''Sodium succinate'' unchanged).'
 chemical_properties:
   cas_rn: 150-90-3
   data_source: OAK/CHEBI xref

--- a/data/ingredients/mapped/Sodium_Succinate_Dibasic.yaml
+++ b/data/ingredients/mapped/Sodium_Succinate_Dibasic.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:150903
 preferred_term: Sodium succinate dibasic
 ontology_mapping:
   ontology_id: CHEBI:150903
-  ontology_label: Sodium succinate dibasic
+  ontology_label: (2S,3S,4R,5S,6S)-2-[(3R,4R,5S,6R)-2,3-Dihydroxy-6-(hydroxymethyl)-5-[(2R,3R,4S,5S,6R)-3,4,5-trihydroxy-6-(hydroxymethyl)oxan-2-yl]oxyoxan-4-yl]oxy-6-methyloxane-3,4,5-triol
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -69,6 +69,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.836846+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Sodium succinate dibasic'' -> ''(2S,3S,4R,5S,6S)-2-[(3R,4R,5S,6R)-2,3-Dihydroxy-6-(hydroxymethyl)-5-[(2R,3R,4S,5S,6R)-3,4,5-trihydroxy-6-(hydroxymethyl)oxan-2-yl]oxyoxan-4-yl]oxy-6-methyloxane-3,4,5-triol'':
+    synced to canonical CHEBI label (preferred_term ''Sodium succinate dibasic'' unchanged).'
 chemical_properties:
   cas_rn: 150-90-3
   data_source: PubChem API

--- a/data/ingredients/mapped/Sodium_Tartrate.yaml
+++ b/data/ingredients/mapped/Sodium_Tartrate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:63017
 preferred_term: Sodium tartrate
 ontology_mapping:
   ontology_id: CHEBI:63017
-  ontology_label: Sodium tartrate
+  ontology_label: sodium L-tartrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -101,6 +101,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.836955+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Sodium tartrate'' -> ''sodium L-tartrate'': synced to
+    canonical CHEBI label (preferred_term ''Sodium tartrate'' unchanged).'
 chemical_properties:
   cas_rn: 868-18-8
   data_source: PubChem API

--- a/data/ingredients/mapped/Sorbitol.yaml
+++ b/data/ingredients/mapped/Sorbitol.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:30911
 preferred_term: Sorbitol
 ontology_mapping:
   ontology_id: CHEBI:30911
-  ontology_label: Sorbitol
+  ontology_label: glucitol
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -77,6 +77,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.837527+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Sorbitol'' -> ''glucitol'': synced to canonical CHEBI
+    label (preferred_term ''Sorbitol'' unchanged).'
 chemical_properties:
   cas_rn: 50-70-4
   data_source: PubChem API

--- a/data/ingredients/mapped/Srcl2.yaml
+++ b/data/ingredients/mapped/Srcl2.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:36383
 preferred_term: SrCl2
 ontology_mapping:
   ontology_id: CHEBI:36383
-  ontology_label: SrCl2
+  ontology_label: strontium dichloride
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -74,6 +74,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.838201+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''SrCl2'' -> ''strontium dichloride'': synced to canonical
+    CHEBI label (preferred_term ''SrCl2'' unchanged).'
 chemical_properties:
   cas_rn: 10476-85-4
   data_source: CultureBotHT compounds_to_cas.csv

--- a/data/ingredients/mapped/Srcl2_X_6_H2o.yaml
+++ b/data/ingredients/mapped/Srcl2_X_6_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:36385
 preferred_term: SrCl2 x 6 H2O
 ontology_mapping:
   ontology_id: CHEBI:36385
-  ontology_label: SrCl2 x 6 H2O
+  ontology_label: strontium dichloride hexahydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -140,6 +140,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.838293+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''SrCl2 x 6 H2O'' -> ''strontium dichloride hexahydrate'':
+    synced to canonical CHEBI label (preferred_term ''SrCl2 x 6 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:36385
 chemical_properties:
   cas_rn: 10025-70-4

--- a/data/ingredients/mapped/Stallimycin.yaml
+++ b/data/ingredients/mapped/Stallimycin.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:41958
 preferred_term: Stallimycin
 ontology_mapping:
   ontology_id: CHEBI:41958
-  ontology_label: distamycin A
+  ontology_label: DISTAMYCIN A
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -50,6 +50,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: SELECTIVE_AGENT (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.838493+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''distamycin A'' -> ''DISTAMYCIN A'': synced to canonical
+    CHEBI label (preferred_term ''Stallimycin'' unchanged).'
 ingredient_type: SINGLE_INGREDIENT
 chemical_properties:
   molecular_formula: C22H27N9O4

--- a/data/ingredients/mapped/Starch.yaml
+++ b/data/ingredients/mapped/Starch.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:28017
 preferred_term: Starch
 ontology_mapping:
   ontology_id: CHEBI:28017
-  ontology_label: Starch
+  ontology_label: starch
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -154,6 +154,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.838597+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Starch'' -> ''starch'': synced to canonical CHEBI label
+    (preferred_term ''Starch'' unchanged).'
 chemical_properties:
   cas_rn: 9005-25-8
   data_source: CultureBotHT compounds_to_cas.csv

--- a/data/ingredients/mapped/Stearic_Acid.yaml
+++ b/data/ingredients/mapped/Stearic_Acid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:28842
 preferred_term: Stearic acid
 ontology_mapping:
   ontology_id: CHEBI:28842
-  ontology_label: Stearic acid
+  ontology_label: octadecanoic acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -83,6 +83,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.838696+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Stearic acid'' -> ''octadecanoic acid'': synced to canonical
+    CHEBI label (preferred_term ''Stearic acid'' unchanged).'
 chemical_properties:
   cas_rn: 57-11-4
   data_source: PubChem API

--- a/data/ingredients/mapped/Succinate.yaml
+++ b/data/ingredients/mapped/Succinate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:26806
 preferred_term: Succinate
 ontology_mapping:
   ontology_id: CHEBI:26806
-  ontology_label: Succinate
+  ontology_label: succinate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -74,6 +74,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.839177+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Succinate'' -> ''succinate'': synced to canonical CHEBI
+    label (preferred_term ''Succinate'' unchanged).'
 chemical_properties:
   cas_rn: 56-14-4
   data_source: PubChem API

--- a/data/ingredients/mapped/Succinic_Acid.yaml
+++ b/data/ingredients/mapped/Succinic_Acid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:15741
 preferred_term: Succinic acid
 ontology_mapping:
   ontology_id: CHEBI:15741
-  ontology_label: Succinic acid
+  ontology_label: succinic acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -112,6 +112,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.839292+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Succinic acid'' -> ''succinic acid'': synced to canonical
+    CHEBI label (preferred_term ''Succinic acid'' unchanged).'
 chemical_properties:
   cas_rn: 110-15-6
   data_source: PubChem API

--- a/data/ingredients/mapped/Sucrose.yaml
+++ b/data/ingredients/mapped/Sucrose.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17992
 preferred_term: Sucrose
 ontology_mapping:
   ontology_id: CHEBI:17992
-  ontology_label: Sucrose
+  ontology_label: sucrose
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -125,6 +125,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.839401+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Sucrose'' -> ''sucrose'': synced to canonical CHEBI label
+    (preferred_term ''Sucrose'' unchanged).'
 chemical_properties:
   cas_rn: 57-50-1
   data_source: PubChem API

--- a/data/ingredients/mapped/Sulfur.yaml
+++ b/data/ingredients/mapped/Sulfur.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:26833
 preferred_term: Sulfur
 ontology_mapping:
   ontology_id: CHEBI:26833
-  ontology_label: Sulfur
+  ontology_label: sulfur atom
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -120,6 +120,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.840485+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Sulfur'' -> ''sulfur atom'': synced to canonical CHEBI
+    label (preferred_term ''Sulfur'' unchanged).'
 chemical_properties:
   cas_rn: 7783-06-4
   data_source: PubChem (via CHEBI:26833)

--- a/data/ingredients/mapped/Sulphur.yaml
+++ b/data/ingredients/mapped/Sulphur.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17909
 preferred_term: Sulphur
 ontology_mapping:
   ontology_id: CHEBI:17909
-  ontology_label: Sulphur
+  ontology_label: polysulfur
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -72,6 +72,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.840780+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Sulphur'' -> ''polysulfur'': synced to canonical CHEBI
+    label (preferred_term ''Sulphur'' unchanged).'
 chemical_properties:
   cas_rn: 12597-03-4
   data_source: PubChem (via CHEBI:17909)

--- a/data/ingredients/mapped/Taurine.yaml
+++ b/data/ingredients/mapped/Taurine.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:15891
 preferred_term: Taurine
 ontology_mapping:
   ontology_id: CHEBI:15891
-  ontology_label: Taurine
+  ontology_label: taurine
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -63,6 +63,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.841625+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Taurine'' -> ''taurine'': synced to canonical CHEBI label
+    (preferred_term ''Taurine'' unchanged).'
 chemical_properties:
   cas_rn: 107-35-7
   data_source: PubChem API

--- a/data/ingredients/mapped/Thiamin_Pyrophosphate.yaml
+++ b/data/ingredients/mapped/Thiamin_Pyrophosphate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:45931
 preferred_term: Thiamin pyrophosphate
 ontology_mapping:
   ontology_id: CHEBI:45931
-  ontology_label: Thiamin pyrophosphate
+  ontology_label: thiamine(1+) diphosphate(1-)
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -58,6 +58,11 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: VITAMIN_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.843020+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Thiamin pyrophosphate'' -> ''thiamine(1+) diphosphate(1-)'':
+    synced to canonical CHEBI label (preferred_term ''Thiamin pyrophosphate'' unchanged).'
 chemical_properties:
   cas_rn: 136-09-4
   data_source: PubChem API

--- a/data/ingredients/mapped/Thiamine-hcl_X_2_H2o.yaml
+++ b/data/ingredients/mapped/Thiamine-hcl_X_2_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:132751
 preferred_term: Thiamine-HCl x 2 H2O
 ontology_mapping:
   ontology_id: CHEBI:132751
-  ontology_label: Thiamine-HCl x 2 H2O
+  ontology_label: thiamine hydrochloride dihydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -75,6 +75,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: VITAMIN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.843119+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Thiamine-HCl x 2 H2O'' -> ''thiamine hydrochloride dihydrate'':
+    synced to canonical CHEBI label (preferred_term ''Thiamine-HCl x 2 H2O'' unchanged).'
 chemical_properties:
   cas_rn: 13465-05-9
   data_source: PubChem API (preprocessed)

--- a/data/ingredients/mapped/Thiamine_Hcl.yaml
+++ b/data/ingredients/mapped/Thiamine_Hcl.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:49105
 preferred_term: Thiamine HCl
 ontology_mapping:
   ontology_id: CHEBI:49105
-  ontology_label: Thiamine HCl
+  ontology_label: thiamine hydrochloride
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -244,6 +244,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: VITAMIN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.843315+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Thiamine HCl'' -> ''thiamine hydrochloride'': synced
+    to canonical CHEBI label (preferred_term ''Thiamine HCl'' unchanged).'
 chemical_properties:
   cas_rn: 67-03-8
   data_source: CultureBotHT compounds_to_cas.csv

--- a/data/ingredients/mapped/Thiamine_Pyrophosphate.yaml
+++ b/data/ingredients/mapped/Thiamine_Pyrophosphate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:18290
 preferred_term: Thiamine pyrophosphate
 ontology_mapping:
   ontology_id: CHEBI:18290
-  ontology_label: Thiamine pyrophosphate
+  ontology_label: thiamine(1+) diphosphate chloride
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -165,6 +165,12 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: VITAMIN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.843417+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Thiamine pyrophosphate'' -> ''thiamine(1+) diphosphate
+    chloride'': synced to canonical CHEBI label (preferred_term ''Thiamine pyrophosphate''
+    unchanged).'
 chemical_properties:
   cas_rn: 136-09-4
   data_source: PubChem API

--- a/data/ingredients/mapped/Thiosulfate.yaml
+++ b/data/ingredients/mapped/Thiosulfate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:26977
 preferred_term: Thiosulfate
 ontology_mapping:
   ontology_id: CHEBI:26977
-  ontology_label: Thiosulfate
+  ontology_label: thiosulfate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -73,6 +73,11 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: ELECTRON_DONOR (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.843790+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Thiosulfate'' -> ''thiosulfate'': synced to canonical
+    CHEBI label (preferred_term ''Thiosulfate'' unchanged).'
 ingredient_type: SINGLE_INGREDIENT
 media_roles:
 - role: ELECTRON_DONOR

--- a/data/ingredients/mapped/Thymidine.yaml
+++ b/data/ingredients/mapped/Thymidine.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17748
 preferred_term: Thymidine
 ontology_mapping:
   ontology_id: CHEBI:17748
-  ontology_label: Thymidine
+  ontology_label: thymidine
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -82,6 +82,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.843979+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Thymidine'' -> ''thymidine'': synced to canonical CHEBI
+    label (preferred_term ''Thymidine'' unchanged).'
 chemical_properties:
   cas_rn: 50-89-5
   data_source: PubChem API

--- a/data/ingredients/mapped/Thymine.yaml
+++ b/data/ingredients/mapped/Thymine.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17821
 preferred_term: Thymine
 ontology_mapping:
   ontology_id: CHEBI:17821
-  ontology_label: Thymine
+  ontology_label: thymine
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -76,6 +76,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.844079+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Thymine'' -> ''thymine'': synced to canonical CHEBI label
+    (preferred_term ''Thymine'' unchanged).'
 chemical_properties:
   cas_rn: 65-71-4
   data_source: PubChem API

--- a/data/ingredients/mapped/Toluene.yaml
+++ b/data/ingredients/mapped/Toluene.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17578
 preferred_term: Toluene
 ontology_mapping:
   ontology_id: CHEBI:17578
-  ontology_label: Toluene
+  ontology_label: toluene
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -73,6 +73,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.844552+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Toluene'' -> ''toluene'': synced to canonical CHEBI label
+    (preferred_term ''Toluene'' unchanged).'
 chemical_properties:
   cas_rn: 108-88-3
   data_source: PubChem API

--- a/data/ingredients/mapped/Trans-cinnamic_Acid.yaml
+++ b/data/ingredients/mapped/Trans-cinnamic_Acid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:35697
 preferred_term: trans-Cinnamic acid
 ontology_mapping:
   ontology_id: CHEBI:35697
-  ontology_label: trans-Cinnamic acid
+  ontology_label: trans-cinnamic acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -86,6 +86,11 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.845215+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''trans-Cinnamic acid'' -> ''trans-cinnamic acid'': synced
+    to canonical CHEBI label (preferred_term ''trans-Cinnamic acid'' unchanged).'
 chemical_properties:
   cas_rn: 621-82-9
   data_source: PubChem API

--- a/data/ingredients/mapped/Trehalose.yaml
+++ b/data/ingredients/mapped/Trehalose.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:27082
 preferred_term: Trehalose
 ontology_mapping:
   ontology_id: CHEBI:27082
-  ontology_label: Trehalose
+  ontology_label: trehalose
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -106,6 +106,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.845407+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Trehalose'' -> ''trehalose'': synced to canonical CHEBI
+    label (preferred_term ''Trehalose'' unchanged).'
 chemical_properties:
   cas_rn: 52613-20-4
   data_source: PubChem (via CHEBI:27082)

--- a/data/ingredients/mapped/Trichloroethylene.yaml
+++ b/data/ingredients/mapped/Trichloroethylene.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:16602
 preferred_term: Trichloroethylene
 ontology_mapping:
   ontology_id: CHEBI:16602
-  ontology_label: Trichloroethylene
+  ontology_label: trichloroethene
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -94,6 +94,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.845688+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Trichloroethylene'' -> ''trichloroethene'': synced to
+    canonical CHEBI label (preferred_term ''Trichloroethylene'' unchanged).'
 chemical_properties:
   cas_rn: 79-01-6
   data_source: PubChem API

--- a/data/ingredients/mapped/Triethanolamine.yaml
+++ b/data/ingredients/mapped/Triethanolamine.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:28621
 preferred_term: Triethanolamine
 ontology_mapping:
   ontology_id: CHEBI:28621
-  ontology_label: Triethanolamine
+  ontology_label: triethanolamine
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -85,6 +85,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: SALT (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.845878+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Triethanolamine'' -> ''triethanolamine'': synced to canonical
+    CHEBI label (preferred_term ''Triethanolamine'' unchanged).'
 chemical_properties:
   cas_rn: 102-71-6
   data_source: PubChem API

--- a/data/ingredients/mapped/Trimethylamine.yaml
+++ b/data/ingredients/mapped/Trimethylamine.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:18139
 preferred_term: Trimethylamine
 ontology_mapping:
   ontology_id: CHEBI:18139
-  ontology_label: Trimethylamine
+  ontology_label: trimethylamine
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -74,6 +74,11 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.846359+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Trimethylamine'' -> ''trimethylamine'': synced to canonical
+    CHEBI label (preferred_term ''Trimethylamine'' unchanged).'
 chemical_properties:
   cas_rn: 75-50-3
   data_source: PubChem API

--- a/data/ingredients/mapped/Tris_Base.yaml
+++ b/data/ingredients/mapped/Tris_Base.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:9754
 preferred_term: Tris base
 ontology_mapping:
   ontology_id: CHEBI:9754
-  ontology_label: Tris base
+  ontology_label: tris
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -226,6 +226,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: BUFFER (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.846733+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Tris base'' -> ''tris'': synced to canonical CHEBI label
+    (preferred_term ''Tris base'' unchanged).'
 kg_microbe_node_id: CHEBI:9754
 chemical_properties:
   cas_rn: 77-86-1

--- a/data/ingredients/mapped/Trisodium_Citrate.yaml
+++ b/data/ingredients/mapped/Trisodium_Citrate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:53258
 preferred_term: Trisodium citrate
 ontology_mapping:
   ontology_id: CHEBI:53258
-  ontology_label: Trisodium citrate
+  ontology_label: sodium citrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -162,6 +162,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: BUFFER (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.846827+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Trisodium citrate'' -> ''sodium citrate'': synced to
+    canonical CHEBI label (preferred_term ''Trisodium citrate'' unchanged).'
 kg_microbe_node_id: CHEBI:53258
 chemical_properties:
   cas_rn: 68-04-2

--- a/data/ingredients/mapped/Tryptophan.yaml
+++ b/data/ingredients/mapped/Tryptophan.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:27897
 preferred_term: Tryptophan
 ontology_mapping:
   ontology_id: CHEBI:27897
-  ontology_label: Tryptophan
+  ontology_label: tryptophan
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -99,6 +99,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: NITROGEN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.847195+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Tryptophan'' -> ''tryptophan'': synced to canonical CHEBI
+    label (preferred_term ''Tryptophan'' unchanged).'
 chemical_properties:
   cas_rn: 73-22-3
   data_source: PubChem API

--- a/data/ingredients/mapped/Tungstate.yaml
+++ b/data/ingredients/mapped/Tungstate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:46502
 preferred_term: Tungstate
 ontology_mapping:
   ontology_id: CHEBI:46502
-  ontology_label: Tungstate
+  ontology_label: tungstate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -65,6 +65,11 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: TRACE_ELEMENT (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.847303+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Tungstate'' -> ''tungstate'': synced to canonical CHEBI
+    label (preferred_term ''Tungstate'' unchanged).'
 chemical_properties:
   cas_rn: 14311-52-5
   data_source: PubChem API

--- a/data/ingredients/mapped/Tween_40.yaml
+++ b/data/ingredients/mapped/Tween_40.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:53423
 preferred_term: Tween 40
 ontology_mapping:
   ontology_id: CHEBI:53423
-  ontology_label: Tween 40
+  ontology_label: polysorbate 40
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -54,6 +54,11 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: SURFACTANT (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.847591+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Tween 40'' -> ''polysorbate 40'': synced to canonical
+    CHEBI label (preferred_term ''Tween 40'' unchanged).'
 ingredient_type: SINGLE_INGREDIENT
 chemical_properties:
   molecular_formula: (C2H4O)w.(C2H4O)x.(C2H4O)y.(C2H4O)z.C22H42O6

--- a/data/ingredients/mapped/Tween_80.yaml
+++ b/data/ingredients/mapped/Tween_80.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:53426
 preferred_term: Tween 80
 ontology_mapping:
   ontology_id: CHEBI:53426
-  ontology_label: Tween 80
+  ontology_label: polysorbate 80
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -94,6 +94,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: SURFACTANT (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.847776+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Tween 80'' -> ''polysorbate 80'': synced to canonical
+    CHEBI label (preferred_term ''Tween 80'' unchanged).'
 chemical_properties:
   cas_rn: 9005-65-6
   data_source: CultureBotHT compounds_to_cas.csv

--- a/data/ingredients/mapped/Uracil.yaml
+++ b/data/ingredients/mapped/Uracil.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17568
 preferred_term: Uracil
 ontology_mapping:
   ontology_id: CHEBI:17568
-  ontology_label: Uracil
+  ontology_label: uracil
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -79,6 +79,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.848065+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Uracil'' -> ''uracil'': synced to canonical CHEBI label
+    (preferred_term ''Uracil'' unchanged).'
 chemical_properties:
   cas_rn: 66-22-8
   data_source: PubChem API

--- a/data/ingredients/mapped/Urea.yaml
+++ b/data/ingredients/mapped/Urea.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:16199
 preferred_term: Urea
 ontology_mapping:
   ontology_id: CHEBI:16199
-  ontology_label: Urea
+  ontology_label: urea
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -98,6 +98,11 @@ curation_history:
   curator: claude_in_session_curation
   action: ANNOTATED
   changes: 'Added media role: NITROGEN_SOURCE (confidence: 0.60)'
+- timestamp: '2026-06-09T05:23:46.848166+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Urea'' -> ''urea'': synced to canonical CHEBI label (preferred_term
+    ''Urea'' unchanged).'
 chemical_properties:
   cas_rn: 57-13-6
   data_source: PubChem API

--- a/data/ingredients/mapped/Uric_Acid.yaml
+++ b/data/ingredients/mapped/Uric_Acid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:27226
 preferred_term: Uric acid
 ontology_mapping:
   ontology_id: CHEBI:27226
-  ontology_label: Uric acid
+  ontology_label: uric acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -59,6 +59,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=SINGLE_INGREDIENT (chemical structure populated (molecular_formula))
   llm_assisted: false
+- timestamp: '2026-06-09T05:23:46.848262+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Uric acid'' -> ''uric acid'': synced to canonical CHEBI
+    label (preferred_term ''Uric acid'' unchanged).'
 chemical_properties:
   cas_rn: 69-93-2
   data_source: PubChem API

--- a/data/ingredients/mapped/Valeric_Acid.yaml
+++ b/data/ingredients/mapped/Valeric_Acid.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17418
 preferred_term: Valeric acid
 ontology_mapping:
   ontology_id: CHEBI:17418
-  ontology_label: Valeric acid
+  ontology_label: valeric acid
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -118,6 +118,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.848548+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Valeric acid'' -> ''valeric acid'': synced to canonical
+    CHEBI label (preferred_term ''Valeric acid'' unchanged).'
 chemical_properties:
   cas_rn: 109-52-4
   data_source: CultureBotHT compounds_to_cas.csv

--- a/data/ingredients/mapped/Vitamin_K1.yaml
+++ b/data/ingredients/mapped/Vitamin_K1.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:18067
 preferred_term: Vitamin K1
 ontology_mapping:
   ontology_id: CHEBI:18067
-  ontology_label: Vitamin K1
+  ontology_label: phylloquinone
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -157,6 +157,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: VITAMIN_SOURCE (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.849789+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Vitamin K1'' -> ''phylloquinone'': synced to canonical
+    CHEBI label (preferred_term ''Vitamin K1'' unchanged).'
 chemical_properties:
   cas_rn: 84-80-0
   data_source: PubChem API

--- a/data/ingredients/mapped/Voso4_X_2_H2o.yaml
+++ b/data/ingredients/mapped/Voso4_X_2_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:87009
 preferred_term: VOSO4 x 2 H2O
 ontology_mapping:
   ontology_id: CHEBI:87009
-  ontology_label: VOSO4 x 2 H2O
+  ontology_label: vanadyl sulfate dihydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -86,6 +86,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.849889+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''VOSO4 x 2 H2O'' -> ''vanadyl sulfate dihydrate'': synced
+    to canonical CHEBI label (preferred_term ''VOSO4 x 2 H2O'' unchanged).'
 ingredient_type: SINGLE_INGREDIENT
 chemical_properties:
   molecular_formula: 2H2O.O4S.OV

--- a/data/ingredients/mapped/Voso4_X_5_H2o.yaml
+++ b/data/ingredients/mapped/Voso4_X_5_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:132758
 preferred_term: VOSO4 x 5 H2O
 ontology_mapping:
   ontology_id: CHEBI:132758
-  ontology_label: VOSO4 x 5 H2O
+  ontology_label: vanadyl sulfate pentahydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -86,6 +86,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.849991+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''VOSO4 x 5 H2O'' -> ''vanadyl sulfate pentahydrate'':
+    synced to canonical CHEBI label (preferred_term ''VOSO4 x 5 H2O'' unchanged).'
 chemical_properties:
   cas_rn: 14708-82-8
   data_source: PubChem (via CHEBI:132758)

--- a/data/ingredients/mapped/Voso4_X_N_H2o.yaml
+++ b/data/ingredients/mapped/Voso4_X_N_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:87020
 preferred_term: VOSO4 x n H2O
 ontology_mapping:
   ontology_id: CHEBI:87020
-  ontology_label: VOSO4 x n H2O
+  ontology_label: vanadyl sulfate hydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -110,6 +110,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.850089+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''VOSO4 x n H2O'' -> ''vanadyl sulfate hydrate'': synced
+    to canonical CHEBI label (preferred_term ''VOSO4 x n H2O'' unchanged).'
 chemical_properties:
   cas_rn: 123334-20-3
   data_source: PubChem (via CHEBI:87020)

--- a/data/ingredients/mapped/Xylan.yaml
+++ b/data/ingredients/mapped/Xylan.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:37166
 preferred_term: Xylan
 ontology_mapping:
   ontology_id: CHEBI:37166
-  ontology_label: Xylan
+  ontology_label: xylan
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -62,6 +62,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.90)'
+- timestamp: '2026-06-09T05:23:46.850749+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Xylan'' -> ''xylan'': synced to canonical CHEBI label
+    (preferred_term ''Xylan'' unchanged).'
 kg_microbe_node_id: CHEBI:37166
 ingredient_type: SINGLE_INGREDIENT
 media_roles:

--- a/data/ingredients/mapped/Xylitol.yaml
+++ b/data/ingredients/mapped/Xylitol.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:17151
 preferred_term: Xylitol
 ontology_mapping:
   ontology_id: CHEBI:17151
-  ontology_label: Xylitol
+  ontology_label: xylitol
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -75,6 +75,11 @@ curation_history:
   curator: infer_roles_from_chebi_ancestry
   action: ANNOTATED
   changes: 'Added media role: CARBON_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.851012+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Xylitol'' -> ''xylitol'': synced to canonical CHEBI label
+    (preferred_term ''Xylitol'' unchanged).'
 chemical_properties:
   cas_rn: 488-81-3
   data_source: PubChem API

--- a/data/ingredients/mapped/Xylose.yaml
+++ b/data/ingredients/mapped/Xylose.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:18222
 preferred_term: Xylose
 ontology_mapping:
   ontology_id: CHEBI:18222
-  ontology_label: Xylose
+  ontology_label: xylose
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -96,6 +96,11 @@ curation_history:
   curator: infer_energy_source
   action: ANNOTATED
   changes: 'Added media role: ENERGY_SOURCE (confidence: 0.70)'
+- timestamp: '2026-06-09T05:23:46.851257+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Xylose'' -> ''xylose'': synced to canonical CHEBI label
+    (preferred_term ''Xylose'' unchanged).'
 chemical_properties:
   cas_rn: 200-400-7
   data_source: PubChem API

--- a/data/ingredients/mapped/Zinc_Sulfate.yaml
+++ b/data/ingredients/mapped/Zinc_Sulfate.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:35176
 preferred_term: Zinc sulfate
 ontology_mapping:
   ontology_id: CHEBI:35176
-  ontology_label: Zinc Sulfate
+  ontology_label: zinc sulfate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -113,6 +113,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.852001+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''Zinc Sulfate'' -> ''zinc sulfate'': synced to canonical
+    CHEBI label (preferred_term ''Zinc sulfate'' unchanged).'
 chemical_properties:
   cas_rn: 7733-02-0
   data_source: PubChem API

--- a/data/ingredients/mapped/Zncl2.yaml
+++ b/data/ingredients/mapped/Zncl2.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:49976
 preferred_term: ZnCl2
 ontology_mapping:
   ontology_id: CHEBI:49976
-  ontology_label: ZnCl2
+  ontology_label: zinc dichloride
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -123,6 +123,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.852105+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''ZnCl2'' -> ''zinc dichloride'': synced to canonical CHEBI
+    label (preferred_term ''ZnCl2'' unchanged).'
 chemical_properties:
   cas_rn: 7646-85-7
   data_source: CultureBotHT/compounds_to_cas.csv

--- a/data/ingredients/mapped/Znso4_X_6_H2o.yaml
+++ b/data/ingredients/mapped/Znso4_X_6_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:132762
 preferred_term: ZnSO4 x 6 H2O
 ontology_mapping:
   ontology_id: CHEBI:132762
-  ontology_label: ZnSO4 x 6 H2O
+  ontology_label: zinc sulfate hexahydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -60,6 +60,11 @@ curation_history:
   curator: infer_roles_from_name_lists
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 0.80)'
+- timestamp: '2026-06-09T05:23:46.852209+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''ZnSO4 x 6 H2O'' -> ''zinc sulfate hexahydrate'': synced
+    to canonical CHEBI label (preferred_term ''ZnSO4 x 6 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:132762
 chemical_properties:
   cas_rn: 13986-24-8

--- a/data/ingredients/mapped/Znso4_X_7_H2o.yaml
+++ b/data/ingredients/mapped/Znso4_X_7_H2o.yaml
@@ -2,7 +2,7 @@ identifier: CHEBI:32312
 preferred_term: ZnSO4 x 7 H2O
 ontology_mapping:
   ontology_id: CHEBI:32312
-  ontology_label: ZnSO4 x 7 H2O
+  ontology_label: zinc sulfate heptahydrate
   ontology_source: CHEBI
   mapping_quality: EXACT_MATCH
   evidence:
@@ -192,6 +192,11 @@ curation_history:
   curator: extract_roles_from_synonyms
   action: ANNOTATED
   changes: 'Added media role: MINERAL (confidence: 1.00)'
+- timestamp: '2026-06-09T05:23:46.852311+00:00'
+  curator: correct_stale_ontology_labels.py
+  action: CORRECTED
+  changes: 'ontology_label ''ZnSO4 x 7 H2O'' -> ''zinc sulfate heptahydrate'': synced
+    to canonical CHEBI label (preferred_term ''ZnSO4 x 7 H2O'' unchanged).'
 kg_microbe_node_id: CHEBI:32312
 chemical_properties:
   cas_rn: 7446-20-0

--- a/scripts/correct_stale_ontology_labels.py
+++ b/scripts/correct_stale_ontology_labels.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Correct stale/empty ``ontology_label`` values to the canonical OBO label.
+
+``OntologyMapping.ontology_label`` is meant to carry the *ontology's* canonical
+label, while ``preferred_term`` holds the curated media-ingredient surface form
+(a formula, catalog name, or common name). Many CHEBI records, however, have the
+surface form copied into ``ontology_label`` too — e.g. ``CHEBI:17905`` carried
+``ontology_label: "2-Mercaptoethanesulfonate"`` when CHEBI's canonical label is
+``coenzyme M``. The 2026-05-23 backfill only filled *empty* labels; it never
+corrected stale-but-nonempty ones.
+
+This script resolves the canonical label from the same local OAK sqlite adapters
+the repo already uses (``~/.data/oaklib/<onto>.db``) and overwrites
+``ontology_label`` wherever it differs. ``preferred_term`` is never touched.
+
+Safety guards (mirrors ``backfill_ontology_labels.py``):
+  * skip records whose ``ontology_source`` disagrees with the CURIE prefix
+    (the documented id/source-mismatch class — fix the record first);
+  * never overwrite with a junk IRI-fragment label (e.g. ``CHEBI_8150``, the
+    string OAK returns for obsolete/stub terms) or an empty string;
+  * only prefixes with a populated local adapter are processed; others are left
+    untouched (``micro.db`` is currently a 0-byte stub, so MICRO is skipped).
+
+Every change is recorded as a ``CORRECTED`` curation event. Idempotent: a second
+run finds nothing to do.
+
+Usage::
+
+    python scripts/correct_stale_ontology_labels.py            # writes in place
+    python scripts/correct_stale_ontology_labels.py --dry-run  # report only
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from mediaingredientmech.curate.curation_event import record_curation_event
+from mediaingredientmech.utils.yaml_handler import save_yaml
+
+DATA = Path("data/curated/mapped_ingredients.yaml")
+
+# Prefixes with a local OAK sqlite adapter whose labels we trust. MICRO is
+# excluded on purpose: ~/.data/oaklib/micro.db is a 0-byte stub, so every MICRO
+# id would resolve to nothing and look (wrongly) like a missing term.
+OAK_DBS = {
+    "CHEBI": "chebi.db",
+    "FOODON": "foodon.db",
+    "ENVO": "envo.db",
+    "UBERON": "uberon.db",
+    "BTO": "bto.db",
+}
+REGISTRY_PREFIXES = {"kgmicrobe.compound", "kgmicrobe.ingredient", "cas", "registry", "mesh"}
+
+
+def make_resolver():
+    """Return f(curie) -> canonical label or None, lazily opening adapters."""
+    from oaklib import get_adapter
+
+    adapters: dict = {}
+    base = Path.home() / ".data" / "oaklib"
+
+    def resolve(curie: str) -> str | None:
+        prefix = curie.split(":", 1)[0]
+        db = OAK_DBS.get(prefix)
+        if not db or not (base / db).exists() or (base / db).stat().st_size == 0:
+            return None
+        try:
+            if prefix not in adapters:
+                adapters[prefix] = get_adapter(f"sqlite:///{base / db}")
+            label = adapters[prefix].label(curie)
+        except Exception as e:  # missing cache / adapter failure
+            print(f"  warning: could not resolve {curie} ({e})", file=sys.stderr)
+            return None
+        if not label:
+            return None
+        # IRI-fragment fallback (e.g. "CHEBI_8150") = obsolete/stub, not a label.
+        local = curie.split(":", 1)[1]
+        if label.replace("_", ":") == curie or label == f"{prefix}_{local}":
+            return None
+        return label
+
+    return resolve
+
+
+def needs_correction(om: dict, resolve) -> str | None:
+    """Return the canonical label an OntologyMapping should adopt, or None to skip.
+
+    Pure (modulo ``resolve``) so it can be unit-tested with a stub resolver.
+    Returns None when: the id has no trusted adapter, the source disagrees with
+    the prefix (id/source-mismatch class), the canonical label is unresolvable/
+    junk, or the label is already byte-canonical.
+    """
+    oid = om.get("ontology_id")
+    if not oid or oid.split(":", 1)[0] not in OAK_DBS:
+        return None
+    prefix = oid.split(":", 1)[0]
+    source = (om.get("ontology_source") or "").strip()
+    if source and prefix.lower() not in REGISTRY_PREFIXES and source.upper() != prefix.upper():
+        return None
+    canonical = resolve(oid)
+    if not canonical:
+        return None
+    if (om.get("ontology_label") or "").strip() == canonical.strip():
+        return None
+    return canonical
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--limit", type=int, default=0, help="show N samples in dry-run")
+    args = parser.parse_args()
+
+    data = yaml.safe_load(DATA.read_text())
+    resolve = make_resolver()
+
+    corrected, filled, samples = 0, 0, []
+    for r in data["ingredients"]:
+        om = r.get("ontology_mapping") or {}
+        canonical = needs_correction(om, resolve)
+        if not canonical:
+            continue
+        current = om.get("ontology_label") or ""
+        was_empty = current.strip() == ""
+        if len(samples) < (args.limit or 12):
+            samples.append((om["ontology_id"], current, canonical))
+        if not args.dry_run:
+            om["ontology_label"] = canonical
+            record_curation_event(
+                r,
+                curator="correct_stale_ontology_labels.py",
+                action="CORRECTED",
+                changes=(
+                    f"ontology_label {'(empty)' if was_empty else repr(current)} -> "
+                    f"{canonical!r}: synced to canonical {om['ontology_id'].split(':',1)[0]} "
+                    f"label (preferred_term {r.get('preferred_term')!r} unchanged)."
+                ),
+            )
+        corrected += 1
+        filled += int(was_empty)
+
+    print(f"Records needing correction: {corrected}  (of which empty->filled: {filled})")
+    for oid, cur, canon in samples:
+        print(f"  {oid:16s} {('(empty)' if cur.strip()=='' else repr(cur)):42s} -> {canon!r}")
+    if corrected > len(samples):
+        print(f"  ... and {corrected - len(samples)} more")
+
+    if not args.dry_run and corrected:
+        save_yaml(data, DATA, backup=False, validate=True, target_class="IngredientCollection")
+        print(f"\nSaved {DATA}")
+    elif args.dry_run:
+        print("\n[dry-run] no changes written")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_ontology_label_correction.py
+++ b/tests/test_ontology_label_correction.py
@@ -1,0 +1,66 @@
+"""Tests for the ontology_label canonicalization logic.
+
+`scripts/correct_stale_ontology_labels.py` rewrites stale/empty
+`ontology_mapping.ontology_label` values to the canonical OBO label. These pin
+the decision logic (`needs_correction`) with a stub resolver so it stays
+CI-safe (no OAK sqlite needed) and can't silently regress its guards.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+_spec = importlib.util.spec_from_file_location(
+    "correct_stale_ontology_labels",
+    Path(__file__).parent.parent / "scripts" / "correct_stale_ontology_labels.py",
+)
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)
+
+# stub canonical-label resolver: only CHEBI:1 and CHEBI:2 "exist".
+CANON = {"CHEBI:1": "coenzyme M", "CHEBI:2": "acetate"}
+
+
+def resolve(oid):
+    return CANON.get(oid)
+
+
+def test_stale_label_corrected():
+    om = {"ontology_id": "CHEBI:1", "ontology_label": "2-Mercaptoethanesulfonate", "ontology_source": "CHEBI"}
+    assert mod.needs_correction(om, resolve) == "coenzyme M"
+
+
+def test_casing_only_corrected():
+    # exact (byte) comparison: a casing-only difference IS corrected to canonical.
+    om = {"ontology_id": "CHEBI:2", "ontology_label": "Acetate", "ontology_source": "CHEBI"}
+    assert mod.needs_correction(om, resolve) == "acetate"
+
+
+def test_already_canonical_skipped():
+    om = {"ontology_id": "CHEBI:1", "ontology_label": "coenzyme M", "ontology_source": "CHEBI"}
+    assert mod.needs_correction(om, resolve) is None
+
+
+def test_empty_label_filled():
+    om = {"ontology_id": "CHEBI:2", "ontology_label": "", "ontology_source": "CHEBI"}
+    assert mod.needs_correction(om, resolve) == "acetate"
+
+
+def test_id_source_mismatch_skipped():
+    # CHEBI id tagged with a non-CHEBI source = the documented mismatch class; skip.
+    om = {"ontology_id": "CHEBI:1", "ontology_label": "x", "ontology_source": "NCIT"}
+    assert mod.needs_correction(om, resolve) is None
+
+
+def test_unresolvable_id_skipped():
+    # resolver returns None (obsolete/junk/absent) -> never blank a label.
+    om = {"ontology_id": "CHEBI:999", "ontology_label": "keep me", "ontology_source": "CHEBI"}
+    assert mod.needs_correction(om, resolve) is None
+
+
+def test_no_adapter_prefix_skipped():
+    # cas:/registry prefixes have no trusted adapter -> untouched.
+    om = {"ontology_id": "cas:7647-14-5", "ontology_label": "NaCl", "ontology_source": "cas"}
+    assert mod.needs_correction(om, resolve) is None


### PR DESCRIPTION
## Summary
`ontology_mapping.ontology_label` is meant to carry the **ontology's canonical OBO label**, while `preferred_term` holds the curated media-ingredient surface form. **413 CHEBI records** had the surface form copied into `ontology_label` too. The 2026-05-23 backfill only filled *empty* labels — it never corrected stale-but-nonempty ones.

| identifier | `ontology_label` was | → corrected to |
|---|---|---|
| CHEBI:17905 | `2-Mercaptoethanesulfonate` | `coenzyme M` |
| CHEBI:30114 | `AlCl3` | `aluminium trichloride` |
| CHEBI:17750 | `Betaine x H2O` | `glycine betaine` |
| CHEBI:40957 | `BICINE buffer` | `N,N-bis(2-hydroxyethyl)glycine` |
| CHEBI:15377 | `Distilled water` | `water` |

Of the 413: ~246 substantive surface-form→canonical, ~167 casing-only normalizations (`Acetate`→`acetate`, matching CHEBI's lowercase canonical). **`preferred_term` is never touched.**

## How
New `scripts/correct_stale_ontology_labels.py` resolves the canonical label from the local OAK `chebi.db` and overwrites `ontology_label` wherever it differs (byte-exact). Guards mirror `backfill_ontology_labels.py`:
- skip `ontology_source`/CURIE-prefix mismatch records (the documented id/source-mismatch class — fix the record first);
- never overwrite with a junk IRI-fragment (`CHEBI_8150`, returned for obsolete terms) or an empty string;
- only prefixes with a populated local adapter are processed — MICRO's `micro.db` is a 0-byte stub, so MICRO is skipped (that's also why 194 MICRO ids show as unresolvable to the id-label validator: empty local db, not bad data).

Each change records a `CORRECTED` curation event. The script is **idempotent** (2nd run = 0). The decision core `needs_correction()` is unit-tested with a stub resolver — **CI-safe, no OAK needed** (7 new tests).

## Effect
- id↔label correspondence validator: **curated_yaml MISMATCH 492 → 0**, OK_CANONICAL 6948 → 7440.
- SSSOM was already canonical → no change. Per-record corpus resynced (413 files).
- `validate_strict`: 0 errors / 2274 files · full suite: **321 passed**.

## Out of scope (follow-up)
`docs/data/mapped_ingredients.csv` (from `scripts/export_lists.py`) also carries surface-form labels, but that exporter is independently stale — it still emits the rolled-back `id` field and reads `ontology_id` from the top level (now nested under `ontology_mapping`), so regenerating it needs an exporter repair, separate from this label fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)