### PR TITLE
Add id↔label correspondence validation (canonical label gate + product checker)

### DIFF
--- a/.claude/skills/id-label-correspondence/skill.md
+++ b/.claude/skills/id-label-correspondence/skill.md
@@ -1,0 +1,91 @@
+---
+name: id-label-correspondence
+description: Validate that every ontology ID carries its correct ontology LABEL across MIM data inputs, intermediates, and data products (SSSOM/CSV). Uses LinkML schema bindings + linkml-term-validator for YAML data (canonical label) and a shared OAK validator for products (canonical-or-synonym). Run report-then-enforce; triage drift as wrong-label vs wrong-id.
+category: validation
+requires_database: false
+requires_internet: true
+version: 1.0.0
+---
+
+# ID↔Label correspondence (MIM)
+
+## The invariant
+
+Every ontology **ID** must carry its **correct ontology label**, everywhere it
+appears — data inputs, intermediates, and data products. Checking that an ID
+*exists* is not enough; the **label must be the right label for that ID**.
+
+Policy (**Hybrid**):
+- **Schema YAML label fields** (`ontology_mapping.ontology_label`,
+  `environmental_context.environment_label`) must equal the **canonical OBO
+  label** (e.g. `CHEBI:26710` → `sodium chloride`). Abbreviations, formulas,
+  and free names (`NaCl`) belong in `preferred_term` / `synonyms`, **not** in
+  `ontology_label`.
+- **Product `*_label` columns** (SSSOM, CSV) accept the **canonical label OR an
+  exact/related ontology synonym** — the conventional surface form.
+
+See `docs/ID_LABEL_CORRESPONDENCE.md` for the cross-repo rationale.
+
+## How it's enforced
+
+**Engine A — LinkML-native (YAML data).** The schema
+(`src/mediaingredientmech/schema/mediaingredientmech.yaml`) marks each label
+slot `slot_uri: rdfs:label` and gives the term-bearing slot a range-less
+`binding` (`binds_value_of: <id_field>`). That makes
+`linkml-term-validator validate-data --labels` look up the id's canonical label
+via OAK and **fail** when the asserted label differs.
+
+```bash
+just validate-terms data/ingredients/mapped/<file>.yaml   # one file
+just validate-terms-all                                    # all data
+```
+
+**Engine B — shared OAK validator (products).**
+`scripts/validate_id_label_correspondence.py` (vendored byte-identical across
+the Mech repos) walks the surfaces in `conf/id_label_targets.yaml`, resolves
+canonical label + synonyms from OAK, and flags drift.
+
+```bash
+just validate-products       # enforce (exit 2 on mismatch / unknown id)
+just report-label-drift      # baseline: writes reports/label_drift.tsv, never fails
+```
+
+## Rollout: report → baseline → enforce
+
+The gates are **not** in `qc` yet — enforcing them will fail on existing drift
+(MIM `ontology_label` often holds formulas/abbreviations instead of the
+canonical label). The CI workflow `label-correspondence.yaml` runs
+`report-label-drift` **non-blocking** and uploads `reports/label_drift.tsv`.
+
+1. `just report-label-drift` → open `reports/label_drift.tsv`.
+2. **Triage each row** (see below).
+3. Once drift is cleared, add `validate-terms-all` + `validate-products` to the
+   `qc` recipe and flip the CI workflow to blocking (Phase 2).
+
+## Triage: wrong label vs wrong ID
+
+A `MISMATCH` means the label is not a name for that ID. Two root causes:
+- **Stale/wrong label, right ID** → replace the label with the canonical OBO
+  label (move the old surface form to `preferred_term`/`synonyms`).
+- **Wrong ID** → the label describes a *different* term; fix the **ID** (the
+  more serious bug). Use `scripts/backfill_ontology_labels.py` (OLS4) and the
+  `merge-ingredients` / `map-media-ingredients` skills to re-resolve.
+
+An `ID_NOT_FOUND` means the CURIE is absent/obsolete in the ontology — re-map.
+
+## Surfaces covered (`conf/id_label_targets.yaml`)
+
+- `data/curated/mapped_ingredients.yaml`, `data/ingredients/{mapped,unmapped}/*.yaml`
+  (`ontology_id`/`ontology_label`, `environment_term`/`environment_label`) — canonical
+- `mappings/ingredient_mappings.sssom.tsv` (`subject_*`/`object_*`) — canonical-or-synonym
+- `docs/data/mapped_ingredients.csv` (`ontology_id`/`ontology_label`) — canonical-or-synonym
+- `mappings/*review*.tsv` — canonical-or-synonym
+
+Prefixes without a configured OAK adapter (`cas:`, `kgmicrobe.compound:`,
+`registry:`, `MIM:`) are reported `SKIPPED_NO_ADAPTER`.
+
+## Related
+
+- `scripts/validate_sssom_invariants.py` (Rule B4 — the SSSOM canonical-or-synonym
+  check this generalizes), `scripts/backfill_ontology_labels.py`,
+  `src/mediaingredientmech/validation/ontology_validator.py` (`validate_term_via_oak`).

--- a/.github/workflows/label-correspondence.yaml
+++ b/.github/workflows/label-correspondence.yaml
@@ -1,0 +1,58 @@
+name: label-correspondence
+
+# Phase 1 (report-only): generate the id↔label drift report and upload it as
+# an artifact. This job does NOT fail the build — it surfaces existing label
+# drift so it can be triaged. Phase 2 will switch to the blocking gates
+# (`just validate-terms-all` + `just validate-products`).
+
+on:
+  pull_request:
+    paths: &trigger_paths
+      - "data/ingredients/**"
+      - "data/curated/**"
+      - "mappings/**"
+      - "docs/data/**"
+      - "src/mediaingredientmech/schema/**"
+      - "scripts/validate_id_label_correspondence.py"
+      - "conf/id_label_targets.yaml"
+      - ".github/workflows/label-correspondence.yaml"
+  push:
+    branches: [main]
+    paths: *trigger_paths
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  label-drift-report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: extractions/setup-just@v3
+      - uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+      - name: Set up Python
+        run: uv python install 3.12
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      # Cache the OAK sqlite ontologies (CHEBI etc.) so repeat runs don't
+      # re-download. First run on a fresh cache will be slow.
+      - name: Cache OAK ontologies
+        uses: actions/cache@v4
+        with:
+          path: ~/.data/oaklib
+          key: oaklib-${{ runner.os }}-v1
+
+      - name: Generate id↔label drift report (non-blocking)
+        run: just report-label-drift
+
+      - name: Upload drift report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: label-drift-report-${{ github.run_id }}
+          path: reports/label_drift.tsv
+          if-no-files-found: warn

--- a/.github/workflows/label-correspondence.yaml
+++ b/.github/workflows/label-correspondence.yaml
@@ -14,6 +14,7 @@ on:
       - "docs/data/**"
       - "src/mediaingredientmech/schema/**"
       - "scripts/validate_id_label_correspondence.py"
+      - "scripts/.validate_id_label_correspondence.sha256"
       - "conf/id_label_targets.yaml"
       - ".github/workflows/label-correspondence.yaml"
   push:
@@ -45,6 +46,12 @@ jobs:
         with:
           path: ~/.data/oaklib
           key: oaklib-${{ runner.os }}-v1
+
+      # Durability guard: fail the build if the vendored validator script has
+      # drifted from its pinned sha256 (the .py is byte-identical across the
+      # Mech repos; an accidental one-copy edit must not silently diverge).
+      - name: Verify id↔label validator pin
+        run: just verify-validator-pin
 
       - name: Generate id↔label drift report (non-blocking)
         run: just report-label-drift

--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,6 @@ data/curated/backups/
 references_cache/
 data/analysis/
 enrichment_failures.json
+
+# linkml-term-validator / OAK label cache
+cache/

--- a/conf/id_label_targets.yaml
+++ b/conf/id_label_targets.yaml
@@ -37,7 +37,6 @@ targets:
     pairs:
       - [ontology_id, ontology_label]
       - [environment_term, environment_label]
-      - [term_id, term_label]
 
   # --- data products (TSV/CSV) — canonical OR synonym surface form
   - name: sssom

--- a/conf/id_label_targets.yaml
+++ b/conf/id_label_targets.yaml
@@ -1,0 +1,67 @@
+# Targets for scripts/validate_id_label_correspondence.py (Engine B).
+#
+# Declares which surfaces carry ontology (id, label) pairs and how strictly
+# the label must correspond to the id's ontology label. Prefixes NOT in the
+# `adapters` allowlist (cas:, MIM:, kgmicrobe.compound:, registry:, …) are
+# reported as SKIPPED_NO_ADAPTER and never looked up.
+#
+# Policy:
+#   canonical            label must equal the canonical OBO label (mirrors the
+#                        linkml-term-validator schema gate; used for YAML data).
+#   canonical_or_synonym label may be the canonical label OR a synonym within
+#                        `synonym_scope` (used for product/surface labels).
+# synonym_scope: exact | exact_related | all   (exact_related = +hasRelatedSynonym)
+
+adapters:
+  CHEBI: sqlite:obo:chebi
+  FOODON: sqlite:obo:foodon
+  NCIT: sqlite:obo:ncit
+  MESH: sqlite:obo:mesh
+  UBERON: sqlite:obo:uberon
+  ENVO: sqlite:obo:envo
+  BTO: sqlite:obo:bto
+  MICRO: sqlite:obo:micro
+  PATO: sqlite:obo:pato
+
+synonym_scope: exact_related
+
+targets:
+  # --- data inputs / intermediates (YAML) — strict canonical, mirrors Engine A
+  - name: curated_yaml
+    kind: yaml
+    glob:
+      - "data/curated/mapped_ingredients.yaml"
+      - "data/ingredients/mapped/*.yaml"
+      - "data/ingredients/unmapped/*.yaml"
+    policy: canonical
+    pairs:
+      - [ontology_id, ontology_label]
+      - [environment_term, environment_label]
+      - [term_id, term_label]
+
+  # --- data products (TSV/CSV) — canonical OR synonym surface form
+  - name: sssom
+    kind: tabular
+    format: tsv
+    glob: "mappings/ingredient_mappings.sssom.tsv"
+    policy: canonical_or_synonym
+    pairs:
+      - [subject_id, subject_label]
+      - [object_id, object_label]
+
+  - name: mapped_csv
+    kind: tabular
+    format: csv
+    glob: "docs/data/mapped_ingredients.csv"
+    policy: canonical_or_synonym
+    pairs:
+      - [ontology_id, ontology_label]
+
+  - name: review_tsvs
+    kind: tabular
+    format: tsv
+    glob: "mappings/*review*.tsv"
+    policy: canonical_or_synonym
+    pairs:
+      - [subject_id, subject_label]
+      - [object_id, object_label]

--- a/conf/id_label_targets.yaml
+++ b/conf/id_label_targets.yaml
@@ -39,20 +39,36 @@ targets:
       - [environment_term, environment_label]
 
   # --- data products (TSV/CSV) — canonical OR synonym surface form
+  # required:true — ingredient_mappings.sssom.tsv is THE canonical MIM mapping
+  # artifact; if the build didn't produce it, enforce must FAIL rather than
+  # silently green on a missing product (Engine-B zero-match false-green fix).
   - name: sssom
     kind: tabular
     format: tsv
     glob: "mappings/ingredient_mappings.sssom.tsv"
+    required: true
     policy: canonical_or_synonym
     pairs:
       - [subject_id, subject_label]
       - [object_id, object_label]
 
+  # PRODUCT DECISION (item 3c): docs/data/mapped_ingredients.csv surfaces the
+  # CURATOR-INTENDED ingredient label in ontology_label (e.g. CHEBI:15377
+  # "Distilled water", CHEBI:86158 "CaCl2 x 2 H2O", CHEBI:63036 "KH2PO4"),
+  # mirroring the human-facing recipe names rather than the OBO canonical
+  # label. We KEEP those labels and EXEMPT the ontology_id column from
+  # canonical-label matching (label_waived_keys names the id column for a
+  # tabular target). The id is STILL existence-checked — a bogus CHEBI id here
+  # still surfaces as ID_NOT_FOUND; only the label match is waived. (The
+  # ingredient YAMLs' ontology_label IS the OBO canonical form and stays under
+  # strict `canonical` policy above, so genuinely-wrong ids still surface there.)
   - name: mapped_csv
     kind: tabular
     format: csv
     glob: "docs/data/mapped_ingredients.csv"
     policy: canonical_or_synonym
+    label_waived_keys:
+      - ontology_id
     pairs:
       - [ontology_id, ontology_label]
 

--- a/conf/id_label_targets.yaml
+++ b/conf/id_label_targets.yaml
@@ -28,8 +28,14 @@ adapters:
   UBERON: sqlite:obo:uberon
   ENVO: sqlite:obo:envo
   BTO: sqlite:obo:bto
-  MICRO: sqlite:obo:micro
   PATO: sqlite:obo:pato
+  # MICRO is intentionally NOT an adapter here: sqlite:obo:micro is a 0-byte
+  # stub with no remote db, so handing OAK a MICRO: id triggers a futile S3
+  # download that errors (ADAPTER_ERROR, fatal under enforce) on a cold CI
+  # cache. This mirrors Engine A, which omits MICRO from `obo_prefixes` in the
+  # justfile. MICRO ids are therefore an explicit `ignored_prefixes` skip
+  # (SKIPPED_NO_ADAPTER, no download) — move MICRO back here once a real
+  # micro.db exists so its labels can actually be validated.
 
 # Legitimate NON-ontology id prefixes — skipped without a lookup, but
 # acknowledged so a typoed ontology prefix (CHBEI:, CHEB:) is NOT mistaken for
@@ -37,6 +43,7 @@ adapters:
 # prefixes actually emitted by the curation/import pipelines.
 ignored_prefixes:
   - MIM                    # MediaIngredientMech-local record ids
+  - MICRO                  # sqlite:obo:micro is a 0-byte stub w/ no remote db (see adapters note)
   - cas                    # CAS registry numbers
   - registry               # generic registry fallback
   - kgmicrobe.compound     # KG-Microbe compound nodes
@@ -94,10 +101,21 @@ targets:
     pairs:
       - [ontology_id, ontology_label]
 
+  # Only the review TSVs that use the SSSOM subject/object schema are listed
+  # explicitly. A bare `mappings/*review*.tsv` glob over-matches review
+  # artifacts with bespoke schemas (`*_row_review_manifest.tsv` →
+  # predicate_context_object_id, `*_unknown_term_*_review.tsv` →
+  # subject_label/current_object_id only). Those lack the configured
+  # subject_id/object_id columns, so the MISSING_COLUMN-is-ERROR rule would
+  # fail enforce on populated files that aren't SSSOM products at all. Add a
+  # file here only once it carries subject_id/subject_label/object_id/object_label.
   - name: review_tsvs
     kind: tabular
     format: tsv
-    glob: "mappings/*review*.tsv"
+    glob:
+      - "mappings/ingredient_mappings_oak_ols_review.tsv"
+      - "mappings/ingredient_mappings_synonym_enrich_review.tsv"
+      - "mappings/needs_curator_review.tsv"
     policy: canonical_or_synonym
     pairs:
       - [subject_id, subject_label]

--- a/conf/id_label_targets.yaml
+++ b/conf/id_label_targets.yaml
@@ -1,9 +1,17 @@
 # Targets for scripts/validate_id_label_correspondence.py (Engine B).
 #
 # Declares which surfaces carry ontology (id, label) pairs and how strictly
-# the label must correspond to the id's ontology label. Prefixes NOT in the
-# `adapters` allowlist (cas:, MIM:, kgmicrobe.compound:, registry:, …) are
-# reported as SKIPPED_NO_ADAPTER and never looked up.
+# the label must correspond to the id's ontology label.
+#
+# A CURIE prefix is handled three ways:
+#   * in `adapters`          → looked up against that OAK ontology.
+#   * in `ignored_prefixes`  → legitimate non-ontology id (cas:, MIM:, …);
+#                              SKIPPED_NO_ADAPTER, never looked up.
+#   * neither                → UNKNOWN_PREFIX (ERROR) — a typo (CHBEI:) or an
+#                              unexpected new prefix that must be triaged (added
+#                              to `adapters` or `ignored_prefixes`) rather than
+#                              silently passing the gate. Ids with NO prefix at
+#                              all (UNMAPPED_0001) are a benign skip.
 #
 # Policy:
 #   canonical            label must equal the canonical OBO label (mirrors the
@@ -22,6 +30,20 @@ adapters:
   BTO: sqlite:obo:bto
   MICRO: sqlite:obo:micro
   PATO: sqlite:obo:pato
+
+# Legitimate NON-ontology id prefixes — skipped without a lookup, but
+# acknowledged so a typoed ontology prefix (CHBEI:, CHEB:) is NOT mistaken for
+# one of these and instead fails as UNKNOWN_PREFIX. Keep in sync with the
+# prefixes actually emitted by the curation/import pipelines.
+ignored_prefixes:
+  - MIM                    # MediaIngredientMech-local record ids
+  - cas                    # CAS registry numbers
+  - registry               # generic registry fallback
+  - kgmicrobe.compound     # KG-Microbe compound nodes
+  - kgmicrobe.ingredient   # KG-Microbe ingredient nodes
+  - mediadive.ingredient   # MediaDive ingredient nodes
+  - mediadive.solution     # MediaDive solution nodes
+  - mediadive.compound     # MediaDive compound nodes
 
 synonym_scope: exact_related
 

--- a/docs/ID_LABEL_CORRESPONDENCE.md
+++ b/docs/ID_LABEL_CORRESPONDENCE.md
@@ -1,0 +1,75 @@
+# ID↔Label correspondence
+
+A cross-repo invariant for CultureMech, MIM, and CommunityMech.
+
+## The invariant
+
+> Every ontology **ID** must carry its **correct ontology label**, everywhere it
+> appears — data **inputs**, **intermediates**, and **data products** (mappings,
+> exports, results).
+
+Checking that an ID *exists* in an ontology is **not** sufficient. The label
+asserted next to the ID must be the **right label for that ID**. A wrong label
+is often the visible symptom of a **wrong ID** — the more serious bug.
+
+## Why this was needed
+
+The previous term validation (`linkml-term-validator validate-data --labels`)
+silently passed files with wrong labels, because `--labels` only fires for slots
+that declare a LinkML **`binding`** — and no schema had bindings. Demonstration:
+corrupting `ENVO:00002046`'s label to `ZZZ_not_sludge_wrong` still reported
+"✅ Validation passed". Data products (SSSOM/CSV/KGX) were never label-checked at
+all, since no LinkML tool reads them.
+
+## Policy (Hybrid)
+
+| Surface | Field | Required label |
+|---|---|---|
+| Schema YAML | `*_label` / `term.label` / `ontology_label` | the **canonical** OBO label |
+| Products | SSSOM/CSV `*_label` columns | canonical **or** an exact/related synonym |
+
+The schema `label` field holds the **canonical** ontology label. Human / project
+/ surface names (abbreviations, formulas like `NaCl`, recipe names) live in
+`preferred_term` (or `synonyms` / `notes`), never in the canonical `label` field.
+
+## How it's enforced — two engines
+
+**Engine A — LinkML-native gate (YAML data).** Each schema marks its label slot
+`slot_uri: rdfs:label` and gives the term-bearing slot a **range-less**
+`binding` (`binds_value_of: <id_field>`). A range-less binding triggers
+`linkml-term-validator validate-data --labels` to compare the asserted label to
+OAK's canonical label and **fail** on mismatch — without an enum-membership
+check (which would require expensive per-ontology tree expansion). ID existence
+is covered by Engine B's OAK lookup.
+
+**Engine B — shared OAK validator (products + unified report).**
+`scripts/validate_id_label_correspondence.py` is **vendored byte-identical**
+across the three Mech repos (same convention as `_edison_capture.py`; verify
+with `md5`). It reads `conf/id_label_targets.yaml`, resolves canonical label +
+synonyms from the same OAK sqlite adapters the repos already use, and classifies
+each `(id, label)` pair: `OK_CANONICAL`, `OK_SYNONYM`, `MISMATCH`,
+`ID_NOT_FOUND`, `EMPTY_LABEL`, or `SKIPPED_NO_ADAPTER` (prefix with no adapter,
+e.g. `cas:`, `kgmicrobe.compound:`). It runs in `--report` mode (non-failing
+TSV) or enforce mode (exit 2).
+
+## Rollout: report → baseline → enforce
+
+Enforcement surfaces existing drift, so it lands in three steps:
+
+1. **Report** — `just report-label-drift` writes `reports/label_drift.tsv`; the
+   `label-correspondence` CI workflow runs this **non-blocking**.
+2. **Baseline / triage** — fix each row: stale label → write the canonical
+   label; wrong ID → re-map the ID.
+3. **Enforce** — add `validate-terms-all` + `validate-products` to `qc` and flip
+   the CI workflow to blocking.
+
+## Per-repo recipes
+
+| Repo | Engine A (YAML) | Engine B (products) | Report |
+|---|---|---|---|
+| MIM | `just validate-terms[-all]` | `just validate-products` | `just report-label-drift` |
+| CultureMech | `just validate-terms <file>` | `just validate-products` | `just report-label-drift` |
+| CommunityMech | `just validate-terms[-all]` | `just validate-products` | `just report-label-drift` |
+
+Engine A and Engine B agree on canonical labels for YAML; Engine B additionally
+tolerates synonyms on product surface labels.

--- a/justfile
+++ b/justfile
@@ -67,25 +67,55 @@ qc-sssom:
 
 schema_path := "src/mediaingredientmech/schema/mediaingredientmech.yaml"
 
+# OBO-resolvable prefixes that linkml-term-validator's `sqlite:obo:` adapter
+# can actually download/open. Engine A's --labels passes EVERY ontology_id to
+# OAK, so a NON-OBO prefix (cas:, kgmicrobe.compound:, kgmicrobe.ingredient:,
+# MICRO: — whose bbop-sqlite .db.gz does not exist / is a 0-byte stub) makes
+# OAK attempt a futile S3 download and exit 1, crashing the whole recipe and
+# blocking the Phase-2 `qc` promotion regardless of label correctness
+# (PR #50 RISK). We pre-filter to these prefixes; everything else is left to
+# Engine B (validate-products), which reports it SKIPPED_NO_ADAPTER /
+# SKIPPED_EMPTY_ADAPTER instead of downloading. Keep in sync with the OBO
+# entries of conf/id_label_targets.yaml `adapters` (MICRO is intentionally
+# OMITTED here: sqlite:obo:micro is a 0-byte stub with no remote db).
+obo_prefixes := "CHEBI FOODON NCIT MESH UBERON ENVO BTO PATO"
+
 # id↔label gate (Engine A): verify ontology_label is the CANONICAL OBO label
 # for ontology_id in one ingredient file. Fails (exit 1) on any label mismatch.
 # The schema binds ontology_mapping/environmental_context so --labels fires.
+# Skips (exit 0) a file whose ontology ids use a non-OBO prefix — Engine B
+# (validate-products) covers those without triggering an OAK download/crash.
 validate-terms FILE:
-    uv run linkml-term-validator validate-data {{FILE}} -s {{schema_path}} -t IngredientRecord --labels
+    #!/usr/bin/env bash
+    set -uo pipefail
+    if scripts/_engine_a_obo_safe.sh "{{FILE}}" "{{obo_prefixes}}"; then
+        uv run linkml-term-validator validate-data "{{FILE}}" -s {{schema_path}} -t IngredientRecord --labels
+    else
+        echo "  - skipping Engine A (non-OBO prefix; covered by validate-products): {{FILE}}"
+    fi
 
 # Same, across every per-ingredient record file. NOTE: data/curated/*.yaml is
 # intentionally excluded — those are collection/container docs
 # (generation_date/total_count/ingredients:[...] or category/count/ingredients)
 # not single IngredientRecords, so `-t IngredientRecord` would fail
 # structurally. Engine B (validate-products, recursive walk) covers them.
+# Records whose ontology_id uses a non-OBO prefix (cas:/kgmicrobe.compound:/
+# MICRO:/…) are SKIPPED here to avoid OAK download crashes — Engine B handles
+# them as SKIPPED_NO_ADAPTER/SKIPPED_EMPTY_ADAPTER.
 validate-terms-all:
     #!/usr/bin/env bash
     set -uo pipefail
     rc=0
+    skipped=0
     for file in data/ingredients/mapped/*.yaml data/ingredients/unmapped/*.yaml; do
         [ -e "$file" ] || continue
-        uv run linkml-term-validator validate-data "$file" -s {{schema_path}} -t IngredientRecord --labels || rc=1
+        if scripts/_engine_a_obo_safe.sh "$file" "{{obo_prefixes}}"; then
+            uv run linkml-term-validator validate-data "$file" -s {{schema_path}} -t IngredientRecord --labels || rc=1
+        else
+            skipped=$((skipped+1))
+        fi
     done
+    echo "  - Engine A skipped $skipped file(s) with non-OBO ontology prefixes (covered by validate-products)"
     exit $rc
 
 # id↔label gate (Engine B): verify (id,label) pairs in DATA PRODUCTS
@@ -98,6 +128,29 @@ validate-products:
 # data + products to reports/label_drift.tsv. Use before enforcing.
 report-label-drift:
     uv run python scripts/validate_id_label_correspondence.py -c conf/id_label_targets.yaml --report reports/label_drift.tsv
+
+# Durability guard: fail if scripts/validate_id_label_correspondence.py drifts
+# from the pinned sha256 (it is vendored byte-identical across the Mech repos —
+# see the file's own docstring). CI runs this so an accidental edit to one copy
+# can't silently diverge. Uses sha256sum on CI (ubuntu), shasum -a 256 on macOS.
+verify-validator-pin:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum -c scripts/.validate_id_label_correspondence.sha256
+    else
+        shasum -a 256 -c scripts/.validate_id_label_correspondence.sha256
+    fi
+
+# Intentional sync only: re-pin the sha256 to the CURRENT script contents after
+# a deliberate, all-repos byte-identical update. Run this in every Mech copy.
+refresh-validator-pin:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    f=scripts/validate_id_label_correspondence.py
+    if command -v sha256sum >/dev/null 2>&1; then h=$(sha256sum "$f" | cut -d' ' -f1); else h=$(shasum -a 256 "$f" | cut -d' ' -f1); fi
+    printf '%s  %s\n' "$h" "$f" > scripts/.validate_id_label_correspondence.sha256
+    echo "re-pinned $f to $h"
 
 # Composite QC: schema validation + strict closed-schema check +
 # evidence reference validation + SSSOM invariants.

--- a/justfile
+++ b/justfile
@@ -65,8 +65,42 @@ fetch-pubmed *args:
 qc-sssom:
     python3 scripts/validate_sssom_invariants.py
 
+schema_path := "src/mediaingredientmech/schema/mediaingredientmech.yaml"
+
+# id↔label gate (Engine A): verify ontology_label is the CANONICAL OBO label
+# for ontology_id in one ingredient file. Fails (exit 1) on any label mismatch.
+# The schema binds ontology_mapping/environmental_context so --labels fires.
+validate-terms FILE:
+    uv run linkml-term-validator validate-data {{FILE}} -s {{schema_path}} -t IngredientRecord --labels
+
+# Same, across every ingredient + curated collection file.
+validate-terms-all:
+    #!/usr/bin/env bash
+    set -uo pipefail
+    rc=0
+    for file in data/ingredients/mapped/*.yaml data/ingredients/unmapped/*.yaml data/curated/*.yaml; do
+        [ -e "$file" ] || continue
+        uv run linkml-term-validator validate-data "$file" -s {{schema_path}} -t IngredientRecord --labels || rc=1
+    done
+    exit $rc
+
+# id↔label gate (Engine B): verify (id,label) pairs in DATA PRODUCTS
+# (SSSOM/CSV/review TSVs) correspond to the ontology. canonical_or_synonym
+# for product surface labels. Exits 2 on any mismatch / unknown id.
+validate-products:
+    uv run python scripts/validate_id_label_correspondence.py -c conf/id_label_targets.yaml
+
+# Baseline (non-failing): write a unified id↔label drift report across YAML
+# data + products to reports/label_drift.tsv. Use before enforcing.
+report-label-drift:
+    uv run python scripts/validate_id_label_correspondence.py -c conf/id_label_targets.yaml --report reports/label_drift.tsv
+
 # Composite QC: schema validation + strict closed-schema check +
 # evidence reference validation + SSSOM invariants.
+# NOTE: validate-terms-all + validate-products are intentionally NOT in `qc`
+# yet — they enforce id↔label correspondence and will fail on existing label
+# drift. Run `just report-label-drift`, triage reports/label_drift.tsv, then
+# add them here (Phase 2 of the rollout).
 qc: validate-all validate-strict qc-evidence qc-sssom
 
 # Render per-ingredient HTML detail pages from data/ingredients/*.yaml

--- a/justfile
+++ b/justfile
@@ -73,12 +73,16 @@ schema_path := "src/mediaingredientmech/schema/mediaingredientmech.yaml"
 validate-terms FILE:
     uv run linkml-term-validator validate-data {{FILE}} -s {{schema_path}} -t IngredientRecord --labels
 
-# Same, across every ingredient + curated collection file.
+# Same, across every per-ingredient record file. NOTE: data/curated/*.yaml is
+# intentionally excluded — those are collection/container docs
+# (generation_date/total_count/ingredients:[...] or category/count/ingredients)
+# not single IngredientRecords, so `-t IngredientRecord` would fail
+# structurally. Engine B (validate-products, recursive walk) covers them.
 validate-terms-all:
     #!/usr/bin/env bash
     set -uo pipefail
     rc=0
-    for file in data/ingredients/mapped/*.yaml data/ingredients/unmapped/*.yaml data/curated/*.yaml; do
+    for file in data/ingredients/mapped/*.yaml data/ingredients/unmapped/*.yaml; do
         [ -e "$file" ] || continue
         uv run linkml-term-validator validate-data "$file" -s {{schema_path}} -t IngredientRecord --labels || rc=1
     done

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ dependencies = [
     # `linkml-validate` startup with `AttributeError: Format has no attribute 'JSON'`.
     # Lift this cap when bumping linkml past 1.9.x.
     "linkml-runtime>=1.7.0,<1.10",
+    # Drives the id↔label gate: `linkml-term-validator validate-data --labels`
+    # checks that ontology_label is the canonical OBO label for ontology_id.
+    "linkml-term-validator>=0.1.0",
     "oaklib>=0.5.0",
     "pyyaml>=6.0",
     "click>=8.1.0",

--- a/scripts/.validate_id_label_correspondence.sha256
+++ b/scripts/.validate_id_label_correspondence.sha256
@@ -1,1 +1,1 @@
-0a446a80ae932f229a45d69995f1e68a1409ef0bb89479a77d5f08265ee0c582  scripts/validate_id_label_correspondence.py
+706987057cd83610ac62e6c82b55383ee529e34d299af3fa74fe2639deef8f6f  scripts/validate_id_label_correspondence.py

--- a/scripts/.validate_id_label_correspondence.sha256
+++ b/scripts/.validate_id_label_correspondence.sha256
@@ -1,0 +1,1 @@
+0a446a80ae932f229a45d69995f1e68a1409ef0bb89479a77d5f08265ee0c582  scripts/validate_id_label_correspondence.py

--- a/scripts/_engine_a_obo_safe.sh
+++ b/scripts/_engine_a_obo_safe.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Engine-A OBO-safety gate for `just validate-terms[-all]` (PR #50 RISK fix).
+#
+# linkml-term-validator validate-data --labels passes EVERY ontology id in the
+# file to OAK's sqlite:obo: adapter. A NON-OBO prefix (cas:, kgmicrobe.compound:,
+# kgmicrobe.ingredient:, MICRO: — no bbop-sqlite remote db, or a 0-byte stub)
+# makes OAK attempt a futile S3 download and exit 1, crashing the whole recipe
+# and blocking the documented Phase-2 `qc` promotion regardless of whether the
+# labels are correct. Engine B (scripts/validate_id_label_correspondence.py,
+# `just validate-products`) already covers those ids via its prefix allowlist,
+# reporting them SKIPPED_NO_ADAPTER / SKIPPED_EMPTY_ADAPTER without downloading.
+#
+# This helper inspects a single ingredient YAML and exits:
+#   0  -> SAFE: every ontology id/term prefix is in the OBO allowlist (or there
+#         are no ontology ids at all) -> the caller runs Engine A.
+#   1  -> UNSAFE: at least one ontology id uses a non-OBO prefix -> the caller
+#         SKIPS Engine A for this file (Engine B will validate it instead).
+#
+# Usage: scripts/_engine_a_obo_safe.sh <file.yaml> "CHEBI FOODON NCIT ..."
+set -uo pipefail
+
+file="${1:?usage: _engine_a_obo_safe.sh <file.yaml> <allowed-prefixes>}"
+allowed="${2:?missing allowed-prefixes}"
+
+# Pull the CURIE values bound by the schema for --labels: ontology_id and
+# environment_term. Match `  ontology_id: PREFIX:local` (quoted or not) and
+# extract the bare prefix. Only these two slots drive Engine A's OAK lookups.
+prefixes=$(
+    grep -hoE '^[[:space:]]*(ontology_id|environment_term):[[:space:]]*"?[A-Za-z][A-Za-z0-9._]*:' "$file" 2>/dev/null \
+        | sed -E 's/^[[:space:]]*(ontology_id|environment_term):[[:space:]]*"?//; s/:$//' \
+        | sort -u
+)
+
+# No ontology ids -> nothing for OAK to download -> safe to run Engine A.
+[ -z "$prefixes" ] && exit 0
+
+# Build a lookup of allowed prefixes (whitespace-separated).
+while IFS= read -r p; do
+    [ -z "$p" ] && continue
+    found=1
+    for a in $allowed; do
+        if [ "$p" = "$a" ]; then found=0; break; fi
+    done
+    # An id whose prefix is NOT in the OBO allowlist would crash OAK -> unsafe.
+    [ "$found" -ne 0 ] && exit 1
+done <<< "$prefixes"
+
+exit 0

--- a/scripts/validate_id_label_correspondence.py
+++ b/scripts/validate_id_label_correspondence.py
@@ -28,6 +28,8 @@ repos already use, and classifies the pair:
     EMPTY_LABEL         id present, label blank                             (ERROR)
     ADAPTER_ERROR       a CONFIGURED adapter failed to load                 (ERROR)
     SKIPPED_NO_ADAPTER  prefix has no configured OAK adapter (cas:, MIM:, …)
+    SKIPPED_EMPTY_ADAPTER  configured adapter loaded but holds no terms (e.g. a
+                        0-byte sqlite stub); db needs populating, data isn't wrong
 
 Policy (per target, ``conf/id_label_targets.yaml``)
     ``canonical``            accept only the canonical OBO label (strict;
@@ -104,6 +106,13 @@ def prefix_of(curie: str) -> str | None:
 # caller can raise a fatal ADAPTER_ERROR instead of a benign SKIPPED_NO_ADAPTER.
 LOAD_FAILED = object()
 
+# Sentinel for a CONFIGURED adapter that loads but contains no terms (e.g. a
+# 0-byte ``~/.data/oaklib/micro.db`` stub that OAK opens happily but that yields
+# ``label() == None`` for every id). Without this, every id under such a prefix
+# would be reported as a false ``ID_NOT_FOUND``. Treated as a benign skip
+# (``SKIPPED_EMPTY_ADAPTER``) — the db needs populating, the data isn't wrong.
+EMPTY_ADAPTER = object()
+
 
 class AdapterPool:
     """Lazily loads OAK adapters, but ONLY for prefixes in the allowlist.
@@ -151,11 +160,33 @@ class AdapterPool:
             try:
                 from oaklib import get_adapter
 
-                self._cache[key] = get_adapter(self._selectors[key])
+                adapter = get_adapter(self._selectors[key])
             except Exception as exc:  # pragma: no cover - environment dependent
                 print(f"  ! failed to load adapter for {key}: {exc}", file=sys.stderr)
                 self._cache[key] = LOAD_FAILED
+            else:
+                self._cache[key] = EMPTY_ADAPTER if self._is_empty(adapter, key) else adapter
         return self._cache[key]
+
+    @staticmethod
+    def _is_empty(adapter: Any, key: str) -> bool:
+        """True if the adapter loaded but holds no terms (e.g. a 0-byte sqlite).
+
+        Peeks a single entity (O(1)) rather than counting. Two empty shapes:
+        a valid-but-termless db (``entities()`` yields nothing), and an
+        uninitialized 0-byte sqlite stub whose tables don't exist yet
+        (``entities()`` raises ``no such table`` — OAK's ``sqlite:obo:micro``
+        points at exactly such a stub). Any *other* probe error is treated as
+        non-empty so a genuinely broken adapter still surfaces per-id verdicts
+        rather than being masked as an empty skip.
+        """
+        try:
+            return next(iter(adapter.entities()), None) is None
+        except Exception as exc:  # pragma: no cover - environment dependent
+            if "no such table" in str(exc).lower():  # uninitialized/0-byte stub
+                return True
+            print(f"  ! emptiness probe failed for {key}: {exc}", file=sys.stderr)
+            return False
 
 
 def accepted_labels(
@@ -380,6 +411,9 @@ def run(config_path: Path, report_path: Path | None) -> int:
                 elif adapter is LOAD_FAILED:
                     rec = {"id": curie, "label": label, "canonical": "",
                            "verdict": "ADAPTER_ERROR"}
+                elif adapter is EMPTY_ADAPTER:
+                    rec = {"id": curie, "label": label, "canonical": "",
+                           "verdict": "SKIPPED_EMPTY_ADAPTER"}
                 else:
                     # Rewrite the CURIE prefix to the canonical allowlist case
                     # (e.g. mesh: -> MESH:) so OAK, which keys on uppercase OBO
@@ -393,7 +427,8 @@ def run(config_path: Path, report_path: Path | None) -> int:
                         scope=scope, lookup_curie=lookup_curie,
                     )
                 counts[rec["verdict"]] = counts.get(rec["verdict"], 0) + 1
-                if rec["verdict"] not in ("OK_CANONICAL", "OK_SYNONYM", "SKIPPED_NO_ADAPTER"):
+                if rec["verdict"] not in ("OK_CANONICAL", "OK_SYNONYM",
+                                          "SKIPPED_NO_ADAPTER", "SKIPPED_EMPTY_ADAPTER"):
                     findings.append({
                         "surface": name,
                         "file": str(rel),
@@ -412,6 +447,7 @@ def run(config_path: Path, report_path: Path | None) -> int:
         "EMPTY_LABEL",
         "ADAPTER_ERROR",
         "SKIPPED_NO_ADAPTER",
+        "SKIPPED_EMPTY_ADAPTER",
     ):
         if verdict in counts:
             print(f"  {verdict:>20}: {counts[verdict]}")

--- a/scripts/validate_id_label_correspondence.py
+++ b/scripts/validate_id_label_correspondence.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""Validate that every ontology ID carries its correct ontology LABEL.
+
+Shared, schema/config-driven id↔label correspondence checker. Vendored
+**byte-identical** across the Mech repos (CultureMech / MIM / CommunityMech)
+— the same convention as ``scripts/_edison_capture.py``. Verify with
+``md5``; a fix here must be synced to all copies.
+
+Why this exists
+---------------
+``linkml-term-validator validate-data --labels`` only checks that the
+label of an ontology ID matches the ontology — and only for LinkML data
+instances (YAML) whose schema declares a ``binding``. It does NOT cover
+**data products**: SSSOM TSVs, mapping CSVs, KGX node tables, and review
+TSVs all carry (id, label) columns that no LinkML tool reads. This script
+closes that gap and also produces a single cross-surface drift report.
+
+What it checks
+--------------
+For every (id, label) pair in the configured targets it resolves the
+canonical label (and synonyms) from the same OAK sqlite adapters the
+repos already use, and classifies the pair:
+
+    OK_CANONICAL        label == canonical OBO label
+    OK_SYNONYM          label is an accepted synonym (policy-dependent)
+    MISMATCH            label is neither canonical nor an accepted synonym  (ERROR)
+    ID_NOT_FOUND        id has an adapter but is absent from the ontology   (ERROR)
+    EMPTY_LABEL         id present, label blank                             (ERROR)
+    SKIPPED_NO_ADAPTER  prefix has no configured OAK adapter (cas:, MIM:, …)
+
+Policy (per target, ``conf/id_label_targets.yaml``)
+    ``canonical``            accept only the canonical OBO label (strict;
+                             mirrors the linkml-term-validator schema gate).
+    ``canonical_or_synonym`` accept canonical OR a synonym within
+                             ``synonym_scope`` (exact | exact_related | all).
+
+Modes
+    ``--report PATH``  write a TSV of every non-OK pair and exit 0 (baseline).
+    (default)          enforce: exit 2 if any ERROR-class pair is found.
+
+Usage::
+
+    python scripts/validate_id_label_correspondence.py -c conf/id_label_targets.yaml
+    python scripts/validate_id_label_correspondence.py -c conf/id_label_targets.yaml \\
+        --report reports/label_drift.tsv
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+import sys
+from pathlib import Path
+from typing import Any, Iterator
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _safe_rel(path: Path) -> str:
+    """``path`` relative to the repo when possible; else its absolute string."""
+    try:
+        return str(path.resolve().relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+# Verdict classes that should fail an --enforce run.
+_ERROR_VERDICTS = {"MISMATCH", "ID_NOT_FOUND", "EMPTY_LABEL"}
+
+_CURIE_RE = re.compile(r"^([A-Za-z][A-Za-z0-9.]*):(.+)$")
+_WS_RE = re.compile(r"\s+")
+
+# OAK alias predicates by synonym scope (always includes label + exact).
+_SYNONYM_PREDICATES = {
+    "exact": ["oio:hasExactSynonym"],
+    "exact_related": ["oio:hasExactSynonym", "oio:hasRelatedSynonym"],
+    "all": [
+        "oio:hasExactSynonym",
+        "oio:hasRelatedSynonym",
+        "oio:hasBroadSynonym",
+        "oio:hasNarrowSynonym",
+    ],
+}
+
+
+def normalize(text: str) -> str:
+    """Casefold, strip, collapse internal whitespace — for label comparison."""
+    return _WS_RE.sub(" ", str(text).strip()).casefold()
+
+
+def prefix_of(curie: str) -> str | None:
+    m = _CURIE_RE.match(str(curie).strip())
+    return m.group(1) if m else None
+
+
+class AdapterPool:
+    """Lazily loads OAK adapters, but ONLY for prefixes in the allowlist.
+
+    The allowlist (``adapters`` map in the config) is the safety boundary:
+    prefixes without an entry (``cas:``, ``MIM:``, ``kgmicrobe.compound:``,
+    ``DSMZ``, …) are never looked up — they are reported as
+    ``SKIPPED_NO_ADAPTER`` instead of triggering a futile ontology download.
+    """
+
+    def __init__(self, adapters: dict[str, str]):
+        self._selectors = adapters
+        self._cache: dict[str, Any] = {}
+
+    def get(self, prefix: str | None):
+        if not prefix or prefix not in self._selectors:
+            return None
+        if prefix not in self._cache:
+            try:
+                from oaklib import get_adapter
+
+                self._cache[prefix] = get_adapter(self._selectors[prefix])
+            except Exception as exc:  # pragma: no cover - environment dependent
+                print(f"  ! failed to load adapter for {prefix}: {exc}", file=sys.stderr)
+                self._cache[prefix] = None
+        return self._cache[prefix]
+
+
+def accepted_labels(adapter: Any, curie: str, scope: str) -> tuple[str | None, set[str], bool]:
+    """Return (canonical_label, accepted_normalized_set, id_found).
+
+    ``accepted_normalized_set`` always contains the canonical label; with a
+    non-``canonical`` policy the caller widens it via ``scope`` synonyms.
+    ``id_found`` is False when the id is absent from the ontology.
+    """
+    try:
+        canonical = adapter.label(curie)
+    except Exception:
+        canonical = None
+    if canonical is None:
+        return None, set(), False
+    accepted = {normalize(canonical)}
+    alias_map: dict[str, list[str]] = {}
+    try:
+        alias_map = adapter.entity_alias_map(curie) or {}
+    except Exception:
+        alias_map = {}
+    for pred in _SYNONYM_PREDICATES.get(scope, _SYNONYM_PREDICATES["exact"]):
+        for alias in alias_map.get(pred, []) or []:
+            accepted.add(normalize(alias))
+    return canonical, accepted, True
+
+
+def classify(
+    *,
+    curie: str,
+    label: str,
+    adapter: Any,
+    policy: str,
+    scope: str,
+) -> dict[str, Any]:
+    """Classify one (id, label) pair into a verdict dict."""
+    canonical, accepted, found = accepted_labels(adapter, curie, scope)
+    base = {"id": curie, "label": label, "canonical": canonical or ""}
+    if not found:
+        return {**base, "verdict": "ID_NOT_FOUND"}
+    if label is None or str(label).strip() == "":
+        return {**base, "verdict": "EMPTY_LABEL"}
+    norm_label = normalize(label)
+    if canonical and norm_label == normalize(canonical):
+        return {**base, "verdict": "OK_CANONICAL"}
+    if policy == "canonical_or_synonym" and norm_label in accepted:
+        return {**base, "verdict": "OK_SYNONYM"}
+    return {**base, "verdict": "MISMATCH"}
+
+
+# -- target readers -------------------------------------------------------
+
+def _read_tabular_rows(path: Path, fmt: str) -> tuple[list[str], list[dict[str, str]]]:
+    """Read a TSV/CSV, skipping SSSOM ``#`` comment-prelude lines."""
+    delim = "," if fmt == "csv" else "\t"
+    with path.open(newline="", encoding="utf-8") as fh:
+        lines = [ln for ln in fh if not ln.lstrip().startswith("#")]
+    if not lines:
+        return [], []
+    reader = csv.DictReader(lines, delimiter=delim)
+    return list(reader.fieldnames or []), list(reader)
+
+
+def iter_tabular(path: Path, fmt: str, pairs: list[list[str]]) -> Iterator[tuple[str, str, str]]:
+    """Yield (locator, id, label) for each configured id/label column pair."""
+    fields, rows = _read_tabular_rows(path, fmt)
+    field_set = set(fields)
+    usable = [(i, l) for (i, l) in pairs if i in field_set and l in field_set]
+    for n, row in enumerate(rows, start=2):  # row 1 is the header
+        for id_col, label_col in usable:
+            curie = (row.get(id_col) or "").strip()
+            if not curie:
+                continue
+            label = (row.get(label_col) or "").strip()
+            yield f"row {n} [{id_col}/{label_col}]", curie, label
+
+
+def _walk_yaml(node: Any, pairs: list[tuple[str, str]], path: str) -> Iterator[tuple[str, str, str]]:
+    if isinstance(node, dict):
+        for id_key, label_key in pairs:
+            if id_key in node and label_key in node:
+                curie = node.get(id_key)
+                if isinstance(curie, str) and curie.strip():
+                    label = node.get(label_key)
+                    label = label if isinstance(label, str) else ""
+                    yield f"{path}.{id_key}", curie.strip(), (label or "").strip()
+        for k, v in node.items():
+            yield from _walk_yaml(v, pairs, f"{path}.{k}")
+    elif isinstance(node, list):
+        for idx, item in enumerate(node):
+            yield from _walk_yaml(item, pairs, f"{path}[{idx}]")
+
+
+def iter_yaml(path: Path, pairs: list[list[str]]) -> Iterator[tuple[str, str, str]]:
+    """Yield (locator, id, label) from a YAML doc by recursively finding dicts
+    that carry BOTH an id key and its sibling label key."""
+    try:
+        doc = yaml.safe_load(path.read_text())
+    except Exception as exc:  # pragma: no cover
+        print(f"  ! failed to parse {path}: {exc}", file=sys.stderr)
+        return
+    yield from _walk_yaml(doc, [(a, b) for a, b in pairs], path.name)
+
+
+# -- driver ---------------------------------------------------------------
+
+def load_config(config_path: Path) -> dict[str, Any]:
+    cfg = yaml.safe_load(config_path.read_text())
+    if not isinstance(cfg, dict):
+        raise SystemExit(f"Config is not a mapping: {config_path}")
+    cfg.setdefault("adapters", {})
+    cfg.setdefault("synonym_scope", "exact_related")
+    cfg.setdefault("targets", [])
+    return cfg
+
+
+def run(config_path: Path, report_path: Path | None) -> int:
+    cfg = load_config(config_path)
+    pool = AdapterPool(cfg["adapters"])
+    default_scope = cfg["synonym_scope"]
+
+    findings: list[dict[str, Any]] = []
+    counts: dict[str, int] = {}
+    for target in cfg["targets"]:
+        name = target.get("name", target.get("glob", "?"))
+        kind = target.get("kind", "tabular")
+        policy = target.get("policy", "canonical_or_synonym")
+        scope = target.get("synonym_scope", default_scope)
+        pairs = target.get("pairs", [])
+        globs = target.get("glob")
+        glob_list = globs if isinstance(globs, list) else [globs]
+        paths: list[Path] = []
+        for g in glob_list:
+            paths.extend(sorted(REPO_ROOT.glob(g)))
+        if not paths:
+            print(f"  - {name}: no files match {glob_list}")
+            continue
+        for path in paths:
+            rel = _safe_rel(path)
+            if kind == "yaml":
+                pairs_iter = iter_yaml(path, pairs)
+            else:
+                pairs_iter = iter_tabular(path, target.get("format", "tsv"), pairs)
+            for locator, curie, label in pairs_iter:
+                prefix = prefix_of(curie)
+                adapter = pool.get(prefix)
+                if adapter is None:
+                    verdict = "SKIPPED_NO_ADAPTER"
+                    rec = {"id": curie, "label": label, "canonical": "", "verdict": verdict}
+                else:
+                    rec = classify(
+                        curie=curie, label=label, adapter=adapter, policy=policy, scope=scope
+                    )
+                counts[rec["verdict"]] = counts.get(rec["verdict"], 0) + 1
+                if rec["verdict"] not in ("OK_CANONICAL", "OK_SYNONYM", "SKIPPED_NO_ADAPTER"):
+                    findings.append({
+                        "surface": name,
+                        "file": str(rel),
+                        "locator": locator,
+                        "policy": policy,
+                        **rec,
+                    })
+
+    # Summary
+    print("\nid↔label correspondence summary:")
+    for verdict in (
+        "OK_CANONICAL",
+        "OK_SYNONYM",
+        "MISMATCH",
+        "ID_NOT_FOUND",
+        "EMPTY_LABEL",
+        "SKIPPED_NO_ADAPTER",
+    ):
+        if verdict in counts:
+            print(f"  {verdict:>20}: {counts[verdict]}")
+
+    if report_path is not None:
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        with report_path.open("w", newline="", encoding="utf-8") as fh:
+            w = csv.writer(fh, delimiter="\t")
+            w.writerow(
+                ["surface", "file", "locator", "id", "current_label",
+                 "canonical_label", "verdict", "policy"]
+            )
+            for f in findings:
+                w.writerow([
+                    f["surface"], f["file"], f["locator"], f["id"],
+                    f["label"], f["canonical"], f["verdict"], f["policy"],
+                ])
+        print(f"\nWrote {len(findings)} flagged pairs to {_safe_rel(report_path)}")
+        return 0
+
+    errors = [f for f in findings if f["verdict"] in _ERROR_VERDICTS]
+    if errors:
+        print(f"\n❌ {len(errors)} id↔label correspondence error(s):")
+        for f in errors[:50]:
+            print(f"  {f['verdict']}: {f['file']} {f['locator']} "
+                  f"{f['id']} label='{f['label']}' canonical='{f['canonical']}'")
+        if len(errors) > 50:
+            print(f"  ... {len(errors) - 50} more")
+        return 2
+    print("\n✅ All id↔label pairs correspond.")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("-c", "--config", type=Path, default=REPO_ROOT / "conf" / "id_label_targets.yaml")
+    ap.add_argument("--report", type=Path, default=None,
+                    help="Write a drift TSV here and exit 0 (baseline mode).")
+    args = ap.parse_args(argv)
+    if not args.config.is_file():
+        print(f"Config not found: {args.config}", file=sys.stderr)
+        return 2
+    return run(args.config, args.report)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_id_label_correspondence.py
+++ b/scripts/validate_id_label_correspondence.py
@@ -26,6 +26,7 @@ repos already use, and classifies the pair:
     MISMATCH            label is neither canonical nor an accepted synonym  (ERROR)
     ID_NOT_FOUND        id has an adapter but is absent from the ontology   (ERROR)
     EMPTY_LABEL         id present, label blank                             (ERROR)
+    ADAPTER_ERROR       a CONFIGURED adapter failed to load                 (ERROR)
     SKIPPED_NO_ADAPTER  prefix has no configured OAK adapter (cas:, MIM:, …)
 
 Policy (per target, ``conf/id_label_targets.yaml``)
@@ -67,7 +68,10 @@ def _safe_rel(path: Path) -> str:
 
 
 # Verdict classes that should fail an --enforce run.
-_ERROR_VERDICTS = {"MISMATCH", "ID_NOT_FOUND", "EMPTY_LABEL"}
+# ADAPTER_ERROR is fatal: a configured adapter that fails to LOAD must never be
+# silently downgraded to SKIPPED_NO_ADAPTER (which would let an enforce run pass
+# while checking nothing).
+_ERROR_VERDICTS = {"MISMATCH", "ID_NOT_FOUND", "EMPTY_LABEL", "ADAPTER_ERROR"}
 
 _CURIE_RE = re.compile(r"^([A-Za-z][A-Za-z0-9.]*):(.+)$")
 _WS_RE = re.compile(r"\s+")
@@ -95,6 +99,12 @@ def prefix_of(curie: str) -> str | None:
     return m.group(1) if m else None
 
 
+# Sentinel returned by ``AdapterPool.get`` when a CONFIGURED adapter fails to
+# load. Distinct from ``None`` (prefix not configured → legitimate skip) so the
+# caller can raise a fatal ADAPTER_ERROR instead of a benign SKIPPED_NO_ADAPTER.
+LOAD_FAILED = object()
+
+
 class AdapterPool:
     """Lazily loads OAK adapters, but ONLY for prefixes in the allowlist.
 
@@ -102,6 +112,21 @@ class AdapterPool:
     prefixes without an entry (``cas:``, ``MIM:``, ``kgmicrobe.compound:``,
     ``DSMZ``, …) are never looked up — they are reported as
     ``SKIPPED_NO_ADAPTER`` instead of triggering a futile ontology download.
+
+    Prefix matching is case-insensitive: data carries lowercase ``mesh:`` while
+    the allowlist (and OAK's OBO CURIEs) use uppercase ``MESH:``. ``get`` keys
+    on the canonical allowlist case, and callers can rewrite the CURIE prefix
+    via ``canonical_prefix`` so the lookup actually resolves.
+
+    ``get`` returns one of three things:
+
+    * ``None``          — prefix is not in the allowlist (legitimate skip).
+    * ``LOAD_FAILED``   — prefix IS configured but its adapter raised on load.
+    * an OAK adapter    — ready to query.
+
+    The ``LOAD_FAILED`` case is deliberately NOT collapsed into ``None`` so a
+    broken-but-configured adapter surfaces as a fatal verdict rather than
+    silently passing an enforce run.
     """
 
     def __init__(self, adapters: dict[str, str]):
@@ -129,18 +154,18 @@ class AdapterPool:
                 self._cache[key] = get_adapter(self._selectors[key])
             except Exception as exc:  # pragma: no cover - environment dependent
                 print(f"  ! failed to load adapter for {key}: {exc}", file=sys.stderr)
-                self._cache[key] = None
+                self._cache[key] = LOAD_FAILED
         return self._cache[key]
 
 
 def accepted_labels(
-    adapter: Any, curie: str, scope: str, include_synonyms: bool = True
+    adapter: Any, curie: str, scope: str, *, include_synonyms: bool = True
 ) -> tuple[str | None, set[str], bool]:
     """Return (canonical_label, accepted_normalized_set, id_found).
 
     ``accepted_normalized_set`` always contains the canonical label; when
     ``include_synonyms`` is set it is widened via ``scope`` synonyms. Callers
-    using a ``canonical`` policy never consult synonyms, so they pass
+    using a strict ``canonical`` policy never consult synonyms, so they pass
     ``include_synonyms=False`` to skip the (potentially expensive)
     ``entity_alias_map`` lookup entirely. ``id_found`` is False when the id is
     absent from the ontology.
@@ -178,10 +203,11 @@ def classify(
     ``curie`` is reported verbatim; ``lookup_curie`` (when given) is the
     case-normalized CURIE actually passed to the adapter so that, e.g., a
     lowercase ``mesh:`` row resolves against OAK's uppercase ``MESH:`` ids.
+    Synonyms are only built when the policy actually consults them.
     """
-    include_synonyms = policy == "canonical_or_synonym"
+    include_synonyms = policy != "canonical"
     canonical, accepted, found = accepted_labels(
-        adapter, lookup_curie or curie, scope, include_synonyms
+        adapter, lookup_curie or curie, scope, include_synonyms=include_synonyms
     )
     base = {"id": curie, "label": label, "canonical": canonical or ""}
     if not found:
@@ -201,22 +227,32 @@ def classify(
 def _read_tabular_rows(
     path: Path, fmt: str
 ) -> tuple[list[str], list[dict[str, str]], list[int]]:
-    """Read a TSV/CSV, skipping SSSOM ``#`` comment-prelude lines.
+    """Read a TSV/CSV, skipping ONLY the leading SSSOM ``#`` comment prelude.
 
-    Also returns the *physical* (1-based) file line number of each data row so
-    the report can point at the real line, not a post-strip ordinal.
+    Returns ``(fieldnames, rows, data_line_numbers)`` where each entry of
+    ``data_line_numbers`` is the TRUE 1-based physical file line where the
+    corresponding data row begins, so locators stay accurate even after the
+    prelude is removed. ``#`` lines that appear *after* the header are NOT
+    stripped (only the contiguous top-of-file prelude is), matching the SSSOM
+    convention where the metadata block precedes the table.
+
+    The physical line numbers come from the original file, so a quoted
+    multiline field could desync ``len(data_line_numbers)`` from ``len(rows)``;
+    the caller falls back to a post-header ordinal in that case.
     """
     delim = "," if fmt == "csv" else "\t"
-    kept: list[tuple[int, str]] = []
     with path.open(newline="", encoding="utf-8") as fh:
-        for phys, ln in enumerate(fh, start=1):
-            if ln.lstrip().startswith("#"):
-                continue
-            kept.append((phys, ln))
-    if not kept:
+        raw = list(enumerate(fh, start=1))  # (physical_line_number, text)
+    # Strip only the contiguous prelude of ``#`` lines at the top of the file.
+    start = 0
+    while start < len(raw) and raw[start][1].lstrip().startswith("#"):
+        start += 1
+    body = raw[start:]
+    if not body:
         return [], [], []
-    lines = [ln for _, ln in kept]
-    data_line_numbers = [phys for phys, _ in kept[1:]]  # row 1 of `kept` is header
+    lines = [text for _, text in body]
+    # body[0] is the header; data rows begin at the next physical line.
+    data_line_numbers = [phys for phys, _ in body[1:]]
     reader = csv.DictReader(lines, delimiter=delim)
     return list(reader.fieldnames or []), list(reader), data_line_numbers
 
@@ -229,9 +265,22 @@ def iter_tabular(path: Path, fmt: str, pairs: list[list[str]]) -> Iterator[tuple
     # so an id present without its label still gets an EMPTY_LABEL verdict
     # rather than being silently dropped.
     usable = [(i, l) for (i, l) in pairs if i in field_set]
+    # RISK: a configured pair whose ID column is absent must NOT vanish silently.
+    # Warn loudly when the file has rows but a configured pair can't be applied
+    # at all. (A missing LABEL column alone is fine — it yields EMPTY_LABEL.)
+    if rows:
+        for (i, l) in pairs:
+            if i not in field_set or l not in field_set:
+                missing = [c for c in (i, l) if c not in field_set]
+                print(
+                    f"  ! {_safe_rel(path)}: configured id/label pair "
+                    f"[{i}/{l}] — missing column(s) {missing}; "
+                    f"present columns: {sorted(field_set)}",
+                    file=sys.stderr,
+                )
     for idx, row in enumerate(rows):
-        # Physical line number when available (a quoted multiline field could
-        # desync the count); else fall back to the post-header ordinal.
+        # True physical line number when available (a quoted multiline field
+        # could desync the count); else fall back to the post-header ordinal.
         line_no = line_numbers[idx] if idx < len(line_numbers) else idx + 2
         for id_col, label_col in usable:
             curie = (row.get(id_col) or "").strip()
@@ -241,7 +290,12 @@ def iter_tabular(path: Path, fmt: str, pairs: list[list[str]]) -> Iterator[tuple
             yield f"line {line_no} [{id_col}/{label_col}]", curie, label
 
 
-def _walk_yaml(node: Any, pairs: list[tuple[str, str]], path: str) -> Iterator[tuple[str, str, str]]:
+def _walk_yaml(
+    node: Any,
+    pairs: list[tuple[str, str]],
+    path: str,
+    exclude_keys: frozenset[str] = frozenset(),
+) -> Iterator[tuple[str, str, str]]:
     if isinstance(node, dict):
         for id_key, label_key in pairs:
             # An id present without its sibling label must still be checked
@@ -253,21 +307,28 @@ def _walk_yaml(node: Any, pairs: list[tuple[str, str]], path: str) -> Iterator[t
                     label = label if isinstance(label, str) else ""
                     yield f"{path}.{id_key}", curie.strip(), (label or "").strip()
         for k, v in node.items():
-            yield from _walk_yaml(v, pairs, f"{path}.{k}")
+            # Skip excluded grounding blocks (e.g. mediaingredientmech_chebi_term,
+            # whose label is intentionally MIM's preferred_term, not the OBO
+            # canonical label, so a `canonical` policy would false-MISMATCH it).
+            if k in exclude_keys:
+                continue
+            yield from _walk_yaml(v, pairs, f"{path}.{k}", exclude_keys)
     elif isinstance(node, list):
         for idx, item in enumerate(node):
-            yield from _walk_yaml(item, pairs, f"{path}[{idx}]")
+            yield from _walk_yaml(item, pairs, f"{path}[{idx}]", exclude_keys)
 
 
-def iter_yaml(path: Path, pairs: list[list[str]]) -> Iterator[tuple[str, str, str]]:
+def iter_yaml(
+    path: Path, pairs: list[list[str]], exclude_keys: frozenset[str] = frozenset()
+) -> Iterator[tuple[str, str, str]]:
     """Yield (locator, id, label) from a YAML doc by recursively finding dicts
-    that carry BOTH an id key and its sibling label key."""
+    that carry an id key (and, when present, its sibling label key)."""
     try:
         doc = yaml.safe_load(path.read_text())
     except Exception as exc:  # pragma: no cover
         print(f"  ! failed to parse {path}: {exc}", file=sys.stderr)
         return
-    yield from _walk_yaml(doc, [(a, b) for a, b in pairs], path.name)
+    yield from _walk_yaml(doc, [(a, b) for a, b in pairs], path.name, exclude_keys)
 
 
 # -- driver ---------------------------------------------------------------
@@ -295,6 +356,7 @@ def run(config_path: Path, report_path: Path | None) -> int:
         policy = target.get("policy", "canonical_or_synonym")
         scope = target.get("synonym_scope", default_scope)
         pairs = target.get("pairs", [])
+        exclude_keys = frozenset(target.get("exclude_keys", []) or [])
         globs = target.get("glob")
         glob_list = globs if isinstance(globs, list) else [globs]
         paths: list[Path] = []
@@ -306,15 +368,18 @@ def run(config_path: Path, report_path: Path | None) -> int:
         for path in paths:
             rel = _safe_rel(path)
             if kind == "yaml":
-                pairs_iter = iter_yaml(path, pairs)
+                pairs_iter = iter_yaml(path, pairs, exclude_keys)
             else:
                 pairs_iter = iter_tabular(path, target.get("format", "tsv"), pairs)
             for locator, curie, label in pairs_iter:
                 prefix = prefix_of(curie)
                 adapter = pool.get(prefix)
                 if adapter is None:
-                    verdict = "SKIPPED_NO_ADAPTER"
-                    rec = {"id": curie, "label": label, "canonical": "", "verdict": verdict}
+                    rec = {"id": curie, "label": label, "canonical": "",
+                           "verdict": "SKIPPED_NO_ADAPTER"}
+                elif adapter is LOAD_FAILED:
+                    rec = {"id": curie, "label": label, "canonical": "",
+                           "verdict": "ADAPTER_ERROR"}
                 else:
                     # Rewrite the CURIE prefix to the canonical allowlist case
                     # (e.g. mesh: -> MESH:) so OAK, which keys on uppercase OBO
@@ -345,6 +410,7 @@ def run(config_path: Path, report_path: Path | None) -> int:
         "MISMATCH",
         "ID_NOT_FOUND",
         "EMPTY_LABEL",
+        "ADAPTER_ERROR",
         "SKIPPED_NO_ADAPTER",
     ):
         if verdict in counts:

--- a/scripts/validate_id_label_correspondence.py
+++ b/scripts/validate_id_label_correspondence.py
@@ -33,7 +33,14 @@ repos already use, and classifies the pair:
                         tabular target that has data rows — without this the
                         pair silently drops and enforce false-greens on drift
     ADAPTER_ERROR       a CONFIGURED adapter failed to load                 (ERROR)
-    SKIPPED_NO_ADAPTER  prefix has no configured OAK adapter (cas:, MIM:, …)
+    UNKNOWN_PREFIX      CURIE prefix is neither a configured ontology       (ERROR)
+                        adapter NOR an explicitly ``ignored_prefixes`` entry —
+                        i.e. a typo (``CHBEI:``) or an unexpected new prefix.
+                        Without this such ids silently fell through as
+                        SKIPPED_NO_ADAPTER and enforce false-greened on them.
+    SKIPPED_NO_ADAPTER  prefix is an explicitly ignored non-ontology prefix
+                        (``cas:``, ``MIM:``, ``kgmicrobe.compound:`` …) or the
+                        id has no CURIE prefix at all (e.g. ``UNMAPPED_0001``)
     SKIPPED_EMPTY_ADAPTER  configured adapter loaded but holds no terms (e.g. a
                         0-byte sqlite stub); db needs populating, data isn't wrong
 
@@ -109,6 +116,7 @@ _ERROR_VERDICTS = {
     "MISSING_COLUMN",
     "MISSING_GLOB",
     "ADAPTER_ERROR",
+    "UNKNOWN_PREFIX",
 }
 
 # Verdicts that are accepted (do NOT get recorded as findings and never fail
@@ -215,20 +223,57 @@ class AdapterPool:
     def _is_empty(adapter: Any, key: str) -> bool:
         """True if the adapter loaded but holds no terms (e.g. a 0-byte sqlite).
 
-        Peeks a single entity (O(1)) rather than counting. Two empty shapes:
-        a valid-but-termless db (``entities()`` yields nothing), and an
-        uninitialized 0-byte sqlite stub whose tables don't exist yet
-        (``entities()`` raises ``no such table`` — OAK's ``sqlite:obo:micro``
-        points at exactly such a stub). Any *other* probe error is treated as
-        non-empty so a genuinely broken adapter still surfaces per-id verdicts
-        rather than being masked as an empty skip.
+        Peeks a single entity (O(1)) rather than counting.
+
+        When ``entities()`` yields nothing the db is a clean empty (valid schema,
+        no rows) and is treated as an empty stub. When ``entities()`` *raises*
+        (e.g. ``no such table: node``) we do NOT trust the error text alone —
+        a partially-migrated or corrupt LIVE ontology (real tables, one missing)
+        raises the same way, and masking it as a benign skip would let real drift
+        pass an enforce run (the exact false-pass this guards against). We only
+        return True when ``_is_uninitialized_stub`` POSITIVELY confirms the
+        backing sqlite is an uninitialized stub (0 bytes / 0 tables); otherwise
+        return False so the prefix's rows surface as ID_NOT_FOUND/error verdicts.
         """
         try:
             return next(iter(adapter.entities()), None) is None
         except Exception as exc:  # pragma: no cover - environment dependent
-            if "no such table" in str(exc).lower():  # uninitialized/0-byte stub
+            if AdapterPool._is_uninitialized_stub(adapter):
                 return True
             print(f"  ! emptiness probe failed for {key}: {exc}", file=sys.stderr)
+            return False
+
+    @staticmethod
+    def _is_uninitialized_stub(adapter: Any) -> bool:
+        """Positively confirm the adapter's sqlite backing store is an
+        uninitialized stub — a 0-byte file or a sqlite with NO tables at all.
+
+        Anything that has tables is a real (possibly broken/partial) db, not a
+        benign stub, and must not be masked. Returns False on any uncertainty
+        (path unresolvable, non-sqlite backend, probe error) so the caller never
+        silently downgrades a real defect to a skip.
+        """
+        url = getattr(getattr(adapter, "engine", None), "url", None)
+        db_path = getattr(url, "database", None)
+        if not db_path:
+            return False  # not a resolvable sqlite file → don't risk masking
+        try:
+            p = Path(db_path)
+            if not p.exists():
+                return False
+            if p.stat().st_size == 0:
+                return True  # 0-byte stub (OAK's sqlite:obo:micro shape)
+            import sqlite3
+
+            con = sqlite3.connect(f"file:{p}?mode=ro", uri=True)
+            try:
+                n = con.execute(
+                    "SELECT count(*) FROM sqlite_master WHERE type='table'"
+                ).fetchone()[0]
+            finally:
+                con.close()
+            return n == 0
+        except Exception:  # pragma: no cover - environment dependent
             return False
 
 
@@ -461,6 +506,7 @@ def load_config(config_path: Path) -> dict[str, Any]:
     if not isinstance(cfg, dict):
         raise SystemExit(f"Config is not a mapping: {config_path}")
     cfg.setdefault("adapters", {})
+    cfg.setdefault("ignored_prefixes", [])
     cfg.setdefault("synonym_scope", "exact_related")
     cfg.setdefault("targets", [])
     return cfg
@@ -470,6 +516,10 @@ def run(config_path: Path, report_path: Path | None) -> int:
     cfg = load_config(config_path)
     pool = AdapterPool(cfg["adapters"])
     default_scope = cfg["synonym_scope"]
+    # Explicitly-ignored non-ontology prefixes (cas:, MIM:, kgmicrobe.compound: …).
+    # A prefixed id whose prefix is neither a configured adapter NOR listed here
+    # is a typo / unexpected prefix → UNKNOWN_PREFIX (ERROR), not a silent skip.
+    ignored_prefixes_cf = {str(p).casefold() for p in cfg["ignored_prefixes"]}
 
     findings: list[dict[str, Any]] = []
     counts: dict[str, int] = {}
@@ -520,8 +570,17 @@ def run(config_path: Path, report_path: Path | None) -> int:
                     prefix = prefix_of(curie)
                     adapter = pool.get(prefix)
                     if adapter is None:
+                        # No configured adapter for this prefix. Distinguish an
+                        # explicitly-ignored non-ontology prefix (benign skip)
+                        # from an unexpected/typoed ontology prefix (ERROR). An
+                        # id with no CURIE prefix at all (UNMAPPED_0001) stays a
+                        # benign skip — it isn't claiming to be an ontology term.
+                        if prefix is not None and prefix.casefold() not in ignored_prefixes_cf:
+                            verdict = "UNKNOWN_PREFIX"
+                        else:
+                            verdict = "SKIPPED_NO_ADAPTER"
                         rec = {"id": curie, "label": label, "canonical": "",
-                               "verdict": "SKIPPED_NO_ADAPTER"}
+                               "verdict": verdict}
                     elif adapter is LOAD_FAILED:
                         rec = {"id": curie, "label": label, "canonical": "",
                                "verdict": "ADAPTER_ERROR"}
@@ -563,6 +622,7 @@ def run(config_path: Path, report_path: Path | None) -> int:
         "MISSING_COLUMN",
         "MISSING_GLOB",
         "ADAPTER_ERROR",
+        "UNKNOWN_PREFIX",
         "SKIPPED_NO_ADAPTER",
         "SKIPPED_EMPTY_ADAPTER",
     ):

--- a/scripts/validate_id_label_correspondence.py
+++ b/scripts/validate_id_label_correspondence.py
@@ -23,9 +23,15 @@ repos already use, and classifies the pair:
 
     OK_CANONICAL        label == canonical OBO label
     OK_SYNONYM          label is an accepted synonym (policy-dependent)
+    OK_ID_ONLY          id resolves; label match WAIVED for this slot (the slot
+                        carries a curator-intended formula/common name, e.g.
+                        CHEBI:15377 "Distilled water" — see ``label_waived_keys``)
     MISMATCH            label is neither canonical nor an accepted synonym  (ERROR)
     ID_NOT_FOUND        id has an adapter but is absent from the ontology   (ERROR)
     EMPTY_LABEL         id present, label blank                             (ERROR)
+    MISSING_COLUMN      a CONFIGURED id/label column is absent from a       (ERROR)
+                        tabular target that has data rows — without this the
+                        pair silently drops and enforce false-greens on drift
     ADAPTER_ERROR       a CONFIGURED adapter failed to load                 (ERROR)
     SKIPPED_NO_ADAPTER  prefix has no configured OAK adapter (cas:, MIM:, …)
     SKIPPED_EMPTY_ADAPTER  configured adapter loaded but holds no terms (e.g. a
@@ -36,6 +42,25 @@ Policy (per target, ``conf/id_label_targets.yaml``)
                              mirrors the linkml-term-validator schema gate).
     ``canonical_or_synonym`` accept canonical OR a synonym within
                              ``synonym_scope`` (exact | exact_related | all).
+
+Per-target knobs (in addition to ``policy``/``synonym_scope``/``pairs``)
+    ``required: true``       fail enforce when the target's glob matches NO
+                             files (an expected artifact, e.g. an SSSOM export,
+                             wasn't built). Default false preserves the prior
+                             "skip-with-exit-0" behaviour for optional targets.
+    ``label_waived_keys``    slots that carry curator-intended labels (formula /
+                             common names) and so are EXEMPT from canonical-label
+                             matching but STILL id-existence checked (OK_ID_ONLY
+                             when the id resolves, ID_NOT_FOUND when it doesn't).
+                             For YAML targets the entries match the *parent key*
+                             of the id/label dict (e.g. ``term``, ``chebi_term``);
+                             for tabular targets they match the *id column name*
+                             (e.g. ``ontology_id``). This implements the product
+                             decision to KEEP labels like "D-glucose" / "NaCl"
+                             rather than relabel them to the OBO canonical form.
+                             Unlike ``exclude_keys`` (which prunes the whole
+                             subtree and checks nothing), label-waived slots are
+                             still validated for id existence.
 
 Modes
     ``--report PATH``  write a TSV of every non-OK pair and exit 0 (baseline).
@@ -72,8 +97,26 @@ def _safe_rel(path: Path) -> str:
 # Verdict classes that should fail an --enforce run.
 # ADAPTER_ERROR is fatal: a configured adapter that fails to LOAD must never be
 # silently downgraded to SKIPPED_NO_ADAPTER (which would let an enforce run pass
-# while checking nothing).
-_ERROR_VERDICTS = {"MISMATCH", "ID_NOT_FOUND", "EMPTY_LABEL", "ADAPTER_ERROR"}
+# while checking nothing). MISSING_COLUMN is likewise fatal: a configured
+# id/label column that is absent from a populated tabular target used to be a
+# stderr-only warning, so enforce exited 0 even though the pair was never
+# checked (Engine-B false-green). MISSING_GLOB is emitted for a ``required: true``
+# target whose glob matched no files (an expected artifact wasn't built).
+_ERROR_VERDICTS = {
+    "MISMATCH",
+    "ID_NOT_FOUND",
+    "EMPTY_LABEL",
+    "MISSING_COLUMN",
+    "MISSING_GLOB",
+    "ADAPTER_ERROR",
+}
+
+# Verdicts that are accepted (do NOT get recorded as findings and never fail
+# enforce). OK_ID_ONLY is a pass: the id resolved and the slot's label was
+# intentionally waived (curator-intended formula/common name).
+_OK_VERDICTS = {"OK_CANONICAL", "OK_SYNONYM", "OK_ID_ONLY"}
+# Benign skips: not OK (still surfaced in the report) but never fail enforce.
+_SKIP_VERDICTS = {"SKIPPED_NO_ADAPTER", "SKIPPED_EMPTY_ADAPTER"}
 
 _CURIE_RE = re.compile(r"^([A-Za-z][A-Za-z0-9.]*):(.+)$")
 _WS_RE = re.compile(r"\s+")
@@ -228,6 +271,7 @@ def classify(
     policy: str,
     scope: str,
     lookup_curie: str | None = None,
+    label_waived: bool = False,
 ) -> dict[str, Any]:
     """Classify one (id, label) pair into a verdict dict.
 
@@ -235,14 +279,24 @@ def classify(
     case-normalized CURIE actually passed to the adapter so that, e.g., a
     lowercase ``mesh:`` row resolves against OAK's uppercase ``MESH:`` ids.
     Synonyms are only built when the policy actually consults them.
+
+    ``label_waived`` marks slots that carry curator-intended formula/common
+    names (e.g. CHEBI:15377 "Distilled water"): id existence is still
+    enforced (ID_NOT_FOUND fires for a bogus id) but the canonical-label
+    match is skipped — a resolvable id yields OK_ID_ONLY regardless of label.
     """
-    include_synonyms = policy != "canonical"
+    # When the label is waived we never consult synonyms (the label isn't
+    # being compared at all), so skip the potentially expensive alias lookup.
+    include_synonyms = (policy != "canonical") and not label_waived
     canonical, accepted, found = accepted_labels(
         adapter, lookup_curie or curie, scope, include_synonyms=include_synonyms
     )
     base = {"id": curie, "label": label, "canonical": canonical or ""}
     if not found:
         return {**base, "verdict": "ID_NOT_FOUND"}
+    if label_waived:
+        # Id resolved; the curator label is intentional, so accept it as-is.
+        return {**base, "verdict": "OK_ID_ONLY"}
     if label is None or str(label).strip() == "":
         return {**base, "verdict": "EMPTY_LABEL"}
     norm_label = normalize(label)
@@ -288,26 +342,47 @@ def _read_tabular_rows(
     return list(reader.fieldnames or []), list(reader), data_line_numbers
 
 
-def iter_tabular(path: Path, fmt: str, pairs: list[list[str]]) -> Iterator[tuple[str, str, str]]:
-    """Yield (locator, id, label) for each configured id/label column pair."""
+def iter_tabular(
+    path: Path,
+    fmt: str,
+    pairs: list[list[str]],
+    label_waived_cols: frozenset[str] = frozenset(),
+) -> Iterator[tuple[str, str, str, bool, str | None]]:
+    """Yield (locator, id, label, label_waived, verdict_override) for each pair.
+
+    ``verdict_override`` is normally ``None`` (the caller classifies the pair).
+    For a configured id column that is ABSENT from a populated file it is
+    ``"MISSING_COLUMN"`` — an ERROR-class verdict, so enforce no longer
+    false-greens on column drift (it used to be a stderr-only warning that the
+    caller never saw as a finding). ``label_waived`` is True when the pair's id
+    column is listed in ``label_waived_cols`` (curator-intended label slot).
+    """
     fields, rows, line_numbers = _read_tabular_rows(path, fmt)
     field_set = set(fields)
     # Keep any pair whose id column exists; a missing label column is allowed
     # so an id present without its label still gets an EMPTY_LABEL verdict
     # rather than being silently dropped.
     usable = [(i, l) for (i, l) in pairs if i in field_set]
-    # RISK: a configured pair whose ID column is absent must NOT vanish silently.
-    # Warn loudly when the file has rows but a configured pair can't be applied
-    # at all. (A missing LABEL column alone is fine — it yields EMPTY_LABEL.)
+    # RISK (fixed): a configured pair whose ID or LABEL column is absent must
+    # NOT vanish silently. When the file has data rows, emit a MISSING_COLUMN
+    # ERROR finding per absent column so an enforce run FAILS instead of
+    # passing while checking nothing. (Still also warn to stderr for context.)
     if rows:
         for (i, l) in pairs:
-            if i not in field_set or l not in field_set:
-                missing = [c for c in (i, l) if c not in field_set]
+            missing = [c for c in (i, l) if c not in field_set]
+            if missing:
                 print(
                     f"  ! {_safe_rel(path)}: configured id/label pair "
                     f"[{i}/{l}] — missing column(s) {missing}; "
                     f"present columns: {sorted(field_set)}",
                     file=sys.stderr,
+                )
+                yield (
+                    f"columns [{i}/{l}]",
+                    f"missing:{','.join(missing)}",
+                    f"present:{sorted(field_set)}",
+                    False,
+                    "MISSING_COLUMN",
                 )
     for idx, row in enumerate(rows):
         # True physical line number when available (a quoted multiline field
@@ -318,7 +393,8 @@ def iter_tabular(path: Path, fmt: str, pairs: list[list[str]]) -> Iterator[tuple
             if not curie:
                 continue
             label = (row.get(label_col) or "").strip()
-            yield f"line {line_no} [{id_col}/{label_col}]", curie, label
+            waived = id_col in label_waived_cols
+            yield f"line {line_no} [{id_col}/{label_col}]", curie, label, waived, None
 
 
 def _walk_yaml(
@@ -326,7 +402,9 @@ def _walk_yaml(
     pairs: list[tuple[str, str]],
     path: str,
     exclude_keys: frozenset[str] = frozenset(),
-) -> Iterator[tuple[str, str, str]]:
+    label_waived_keys: frozenset[str] = frozenset(),
+    waived: bool = False,
+) -> Iterator[tuple[str, str, str, bool, str | None]]:
     if isinstance(node, dict):
         for id_key, label_key in pairs:
             # An id present without its sibling label must still be checked
@@ -336,30 +414,44 @@ def _walk_yaml(
                 if isinstance(curie, str) and curie.strip():
                     label = node.get(label_key)
                     label = label if isinstance(label, str) else ""
-                    yield f"{path}.{id_key}", curie.strip(), (label or "").strip()
+                    yield f"{path}.{id_key}", curie.strip(), (label or "").strip(), waived, None
         for k, v in node.items():
-            # Skip excluded grounding blocks (e.g. mediaingredientmech_chebi_term,
-            # whose label is intentionally MIM's preferred_term, not the OBO
-            # canonical label, so a `canonical` policy would false-MISMATCH it).
+            # Skip excluded grounding blocks entirely (no checks at all).
             if k in exclude_keys:
                 continue
-            yield from _walk_yaml(v, pairs, f"{path}.{k}", exclude_keys)
+            # label_waived_keys: descend, but mark everything under this key as
+            # label-waived so its id/label dicts get id-existence-only checking
+            # (curator-intended formula/common names, e.g. CHEBI:15377
+            # "Distilled water" under a `term:` block). ``waived`` is sticky
+            # for the subtree so a nested id/label pair stays waived.
+            child_waived = waived or (k in label_waived_keys)
+            yield from _walk_yaml(
+                v, pairs, f"{path}.{k}", exclude_keys, label_waived_keys, child_waived
+            )
     elif isinstance(node, list):
         for idx, item in enumerate(node):
-            yield from _walk_yaml(item, pairs, f"{path}[{idx}]", exclude_keys)
+            yield from _walk_yaml(
+                item, pairs, f"{path}[{idx}]", exclude_keys, label_waived_keys, waived
+            )
 
 
 def iter_yaml(
-    path: Path, pairs: list[list[str]], exclude_keys: frozenset[str] = frozenset()
-) -> Iterator[tuple[str, str, str]]:
-    """Yield (locator, id, label) from a YAML doc by recursively finding dicts
-    that carry an id key (and, when present, its sibling label key)."""
+    path: Path,
+    pairs: list[list[str]],
+    exclude_keys: frozenset[str] = frozenset(),
+    label_waived_keys: frozenset[str] = frozenset(),
+) -> Iterator[tuple[str, str, str, bool, str | None]]:
+    """Yield (locator, id, label, label_waived, verdict_override) from a YAML
+    doc by recursively finding dicts that carry an id key (and, when present,
+    its sibling label key)."""
     try:
         doc = yaml.safe_load(path.read_text())
     except Exception as exc:  # pragma: no cover
         print(f"  ! failed to parse {path}: {exc}", file=sys.stderr)
         return
-    yield from _walk_yaml(doc, [(a, b) for a, b in pairs], path.name, exclude_keys)
+    yield from _walk_yaml(
+        doc, [(a, b) for a, b in pairs], path.name, exclude_keys, label_waived_keys
+    )
 
 
 # -- driver ---------------------------------------------------------------
@@ -388,47 +480,69 @@ def run(config_path: Path, report_path: Path | None) -> int:
         scope = target.get("synonym_scope", default_scope)
         pairs = target.get("pairs", [])
         exclude_keys = frozenset(target.get("exclude_keys", []) or [])
+        label_waived_keys = frozenset(target.get("label_waived_keys", []) or [])
+        required = bool(target.get("required", False))
         globs = target.get("glob")
         glob_list = globs if isinstance(globs, list) else [globs]
         paths: list[Path] = []
         for g in glob_list:
             paths.extend(sorted(REPO_ROOT.glob(g)))
         if not paths:
-            print(f"  - {name}: no files match {glob_list}")
+            # RISK (fixed): a `required: true` target whose glob matches NO
+            # files means an expected artifact (e.g. output/*.sssom.tsv) was
+            # never built. That used to skip with exit 0, so validate-products
+            # greened on a missing product. Emit a MISSING_GLOB ERROR finding.
+            if required:
+                print(f"  ! {name}: REQUIRED target — no files match {glob_list}")
+                rec = {"id": ",".join(str(g) for g in glob_list), "label": "",
+                       "canonical": "", "verdict": "MISSING_GLOB"}
+                counts["MISSING_GLOB"] = counts.get("MISSING_GLOB", 0) + 1
+                findings.append({
+                    "surface": name, "file": "(no match)",
+                    "locator": f"glob {glob_list}", "policy": policy, **rec,
+                })
+            else:
+                print(f"  - {name}: no files match {glob_list}")
             continue
         for path in paths:
             rel = _safe_rel(path)
             if kind == "yaml":
-                pairs_iter = iter_yaml(path, pairs, exclude_keys)
+                pairs_iter = iter_yaml(path, pairs, exclude_keys, label_waived_keys)
             else:
-                pairs_iter = iter_tabular(path, target.get("format", "tsv"), pairs)
-            for locator, curie, label in pairs_iter:
-                prefix = prefix_of(curie)
-                adapter = pool.get(prefix)
-                if adapter is None:
+                pairs_iter = iter_tabular(
+                    path, target.get("format", "tsv"), pairs, label_waived_keys
+                )
+            for locator, curie, label, label_waived, verdict_override in pairs_iter:
+                if verdict_override is not None:
                     rec = {"id": curie, "label": label, "canonical": "",
-                           "verdict": "SKIPPED_NO_ADAPTER"}
-                elif adapter is LOAD_FAILED:
-                    rec = {"id": curie, "label": label, "canonical": "",
-                           "verdict": "ADAPTER_ERROR"}
-                elif adapter is EMPTY_ADAPTER:
-                    rec = {"id": curie, "label": label, "canonical": "",
-                           "verdict": "SKIPPED_EMPTY_ADAPTER"}
+                           "verdict": verdict_override}
                 else:
-                    # Rewrite the CURIE prefix to the canonical allowlist case
-                    # (e.g. mesh: -> MESH:) so OAK, which keys on uppercase OBO
-                    # prefixes, resolves the label instead of returning None.
-                    canonical_prefix = pool.canonical_prefix(prefix)
-                    lookup_curie = curie
-                    if canonical_prefix and prefix != canonical_prefix:
-                        lookup_curie = f"{canonical_prefix}:{curie.split(':', 1)[1]}"
-                    rec = classify(
-                        curie=curie, label=label, adapter=adapter, policy=policy,
-                        scope=scope, lookup_curie=lookup_curie,
-                    )
+                    prefix = prefix_of(curie)
+                    adapter = pool.get(prefix)
+                    if adapter is None:
+                        rec = {"id": curie, "label": label, "canonical": "",
+                               "verdict": "SKIPPED_NO_ADAPTER"}
+                    elif adapter is LOAD_FAILED:
+                        rec = {"id": curie, "label": label, "canonical": "",
+                               "verdict": "ADAPTER_ERROR"}
+                    elif adapter is EMPTY_ADAPTER:
+                        rec = {"id": curie, "label": label, "canonical": "",
+                               "verdict": "SKIPPED_EMPTY_ADAPTER"}
+                    else:
+                        # Rewrite the CURIE prefix to the canonical allowlist case
+                        # (e.g. mesh: -> MESH:) so OAK, which keys on uppercase OBO
+                        # prefixes, resolves the label instead of returning None.
+                        canonical_prefix = pool.canonical_prefix(prefix)
+                        lookup_curie = curie
+                        if canonical_prefix and prefix != canonical_prefix:
+                            lookup_curie = f"{canonical_prefix}:{curie.split(':', 1)[1]}"
+                        rec = classify(
+                            curie=curie, label=label, adapter=adapter, policy=policy,
+                            scope=scope, lookup_curie=lookup_curie,
+                            label_waived=label_waived,
+                        )
                 counts[rec["verdict"]] = counts.get(rec["verdict"], 0) + 1
-                if rec["verdict"] not in ("OK_CANONICAL", "OK_SYNONYM",
-                                          "SKIPPED_NO_ADAPTER", "SKIPPED_EMPTY_ADAPTER"):
+                if rec["verdict"] not in _OK_VERDICTS | _SKIP_VERDICTS:
                     findings.append({
                         "surface": name,
                         "file": str(rel),
@@ -442,9 +556,12 @@ def run(config_path: Path, report_path: Path | None) -> int:
     for verdict in (
         "OK_CANONICAL",
         "OK_SYNONYM",
+        "OK_ID_ONLY",
         "MISMATCH",
         "ID_NOT_FOUND",
         "EMPTY_LABEL",
+        "MISSING_COLUMN",
+        "MISSING_GLOB",
         "ADAPTER_ERROR",
         "SKIPPED_NO_ADAPTER",
         "SKIPPED_EMPTY_ADAPTER",

--- a/scripts/validate_id_label_correspondence.py
+++ b/scripts/validate_id_label_correspondence.py
@@ -106,28 +106,44 @@ class AdapterPool:
 
     def __init__(self, adapters: dict[str, str]):
         self._selectors = adapters
+        # Case-insensitive prefix lookup: data carries lowercase `mesh:` while
+        # the allowlist (and OAK's OBO CURIEs) use uppercase `MESH:`. Map any
+        # casing of a data prefix back to its canonical allowlist key.
+        self._canonical: dict[str, str] = {key.casefold(): key for key in adapters}
         self._cache: dict[str, Any] = {}
 
-    def get(self, prefix: str | None):
-        if not prefix or prefix not in self._selectors:
+    def canonical_prefix(self, prefix: str | None) -> str | None:
+        """Return the allowlist key matching ``prefix`` case-insensitively."""
+        if not prefix:
             return None
-        if prefix not in self._cache:
+        return self._canonical.get(prefix.casefold())
+
+    def get(self, prefix: str | None):
+        key = self.canonical_prefix(prefix)
+        if key is None:
+            return None
+        if key not in self._cache:
             try:
                 from oaklib import get_adapter
 
-                self._cache[prefix] = get_adapter(self._selectors[prefix])
+                self._cache[key] = get_adapter(self._selectors[key])
             except Exception as exc:  # pragma: no cover - environment dependent
-                print(f"  ! failed to load adapter for {prefix}: {exc}", file=sys.stderr)
-                self._cache[prefix] = None
-        return self._cache[prefix]
+                print(f"  ! failed to load adapter for {key}: {exc}", file=sys.stderr)
+                self._cache[key] = None
+        return self._cache[key]
 
 
-def accepted_labels(adapter: Any, curie: str, scope: str) -> tuple[str | None, set[str], bool]:
+def accepted_labels(
+    adapter: Any, curie: str, scope: str, include_synonyms: bool = True
+) -> tuple[str | None, set[str], bool]:
     """Return (canonical_label, accepted_normalized_set, id_found).
 
-    ``accepted_normalized_set`` always contains the canonical label; with a
-    non-``canonical`` policy the caller widens it via ``scope`` synonyms.
-    ``id_found`` is False when the id is absent from the ontology.
+    ``accepted_normalized_set`` always contains the canonical label; when
+    ``include_synonyms`` is set it is widened via ``scope`` synonyms. Callers
+    using a ``canonical`` policy never consult synonyms, so they pass
+    ``include_synonyms=False`` to skip the (potentially expensive)
+    ``entity_alias_map`` lookup entirely. ``id_found`` is False when the id is
+    absent from the ontology.
     """
     try:
         canonical = adapter.label(curie)
@@ -136,14 +152,15 @@ def accepted_labels(adapter: Any, curie: str, scope: str) -> tuple[str | None, s
     if canonical is None:
         return None, set(), False
     accepted = {normalize(canonical)}
-    alias_map: dict[str, list[str]] = {}
-    try:
-        alias_map = adapter.entity_alias_map(curie) or {}
-    except Exception:
-        alias_map = {}
-    for pred in _SYNONYM_PREDICATES.get(scope, _SYNONYM_PREDICATES["exact"]):
-        for alias in alias_map.get(pred, []) or []:
-            accepted.add(normalize(alias))
+    if include_synonyms:
+        alias_map: dict[str, list[str]] = {}
+        try:
+            alias_map = adapter.entity_alias_map(curie) or {}
+        except Exception:
+            alias_map = {}
+        for pred in _SYNONYM_PREDICATES.get(scope, _SYNONYM_PREDICATES["exact"]):
+            for alias in alias_map.get(pred, []) or []:
+                accepted.add(normalize(alias))
     return canonical, accepted, True
 
 
@@ -154,9 +171,18 @@ def classify(
     adapter: Any,
     policy: str,
     scope: str,
+    lookup_curie: str | None = None,
 ) -> dict[str, Any]:
-    """Classify one (id, label) pair into a verdict dict."""
-    canonical, accepted, found = accepted_labels(adapter, curie, scope)
+    """Classify one (id, label) pair into a verdict dict.
+
+    ``curie`` is reported verbatim; ``lookup_curie`` (when given) is the
+    case-normalized CURIE actually passed to the adapter so that, e.g., a
+    lowercase ``mesh:`` row resolves against OAK's uppercase ``MESH:`` ids.
+    """
+    include_synonyms = policy == "canonical_or_synonym"
+    canonical, accepted, found = accepted_labels(
+        adapter, lookup_curie or curie, scope, include_synonyms
+    )
     base = {"id": curie, "label": label, "canonical": canonical or ""}
     if not found:
         return {**base, "verdict": "ID_NOT_FOUND"}
@@ -172,35 +198,55 @@ def classify(
 
 # -- target readers -------------------------------------------------------
 
-def _read_tabular_rows(path: Path, fmt: str) -> tuple[list[str], list[dict[str, str]]]:
-    """Read a TSV/CSV, skipping SSSOM ``#`` comment-prelude lines."""
+def _read_tabular_rows(
+    path: Path, fmt: str
+) -> tuple[list[str], list[dict[str, str]], list[int]]:
+    """Read a TSV/CSV, skipping SSSOM ``#`` comment-prelude lines.
+
+    Also returns the *physical* (1-based) file line number of each data row so
+    the report can point at the real line, not a post-strip ordinal.
+    """
     delim = "," if fmt == "csv" else "\t"
+    kept: list[tuple[int, str]] = []
     with path.open(newline="", encoding="utf-8") as fh:
-        lines = [ln for ln in fh if not ln.lstrip().startswith("#")]
-    if not lines:
-        return [], []
+        for phys, ln in enumerate(fh, start=1):
+            if ln.lstrip().startswith("#"):
+                continue
+            kept.append((phys, ln))
+    if not kept:
+        return [], [], []
+    lines = [ln for _, ln in kept]
+    data_line_numbers = [phys for phys, _ in kept[1:]]  # row 1 of `kept` is header
     reader = csv.DictReader(lines, delimiter=delim)
-    return list(reader.fieldnames or []), list(reader)
+    return list(reader.fieldnames or []), list(reader), data_line_numbers
 
 
 def iter_tabular(path: Path, fmt: str, pairs: list[list[str]]) -> Iterator[tuple[str, str, str]]:
     """Yield (locator, id, label) for each configured id/label column pair."""
-    fields, rows = _read_tabular_rows(path, fmt)
+    fields, rows, line_numbers = _read_tabular_rows(path, fmt)
     field_set = set(fields)
-    usable = [(i, l) for (i, l) in pairs if i in field_set and l in field_set]
-    for n, row in enumerate(rows, start=2):  # row 1 is the header
+    # Keep any pair whose id column exists; a missing label column is allowed
+    # so an id present without its label still gets an EMPTY_LABEL verdict
+    # rather than being silently dropped.
+    usable = [(i, l) for (i, l) in pairs if i in field_set]
+    for idx, row in enumerate(rows):
+        # Physical line number when available (a quoted multiline field could
+        # desync the count); else fall back to the post-header ordinal.
+        line_no = line_numbers[idx] if idx < len(line_numbers) else idx + 2
         for id_col, label_col in usable:
             curie = (row.get(id_col) or "").strip()
             if not curie:
                 continue
             label = (row.get(label_col) or "").strip()
-            yield f"row {n} [{id_col}/{label_col}]", curie, label
+            yield f"line {line_no} [{id_col}/{label_col}]", curie, label
 
 
 def _walk_yaml(node: Any, pairs: list[tuple[str, str]], path: str) -> Iterator[tuple[str, str, str]]:
     if isinstance(node, dict):
         for id_key, label_key in pairs:
-            if id_key in node and label_key in node:
+            # An id present without its sibling label must still be checked
+            # (yields EMPTY_LABEL), so we do NOT require label_key to exist.
+            if id_key in node:
                 curie = node.get(id_key)
                 if isinstance(curie, str) and curie.strip():
                     label = node.get(label_key)
@@ -270,8 +316,16 @@ def run(config_path: Path, report_path: Path | None) -> int:
                     verdict = "SKIPPED_NO_ADAPTER"
                     rec = {"id": curie, "label": label, "canonical": "", "verdict": verdict}
                 else:
+                    # Rewrite the CURIE prefix to the canonical allowlist case
+                    # (e.g. mesh: -> MESH:) so OAK, which keys on uppercase OBO
+                    # prefixes, resolves the label instead of returning None.
+                    canonical_prefix = pool.canonical_prefix(prefix)
+                    lookup_curie = curie
+                    if canonical_prefix and prefix != canonical_prefix:
+                        lookup_curie = f"{canonical_prefix}:{curie.split(':', 1)[1]}"
                     rec = classify(
-                        curie=curie, label=label, adapter=adapter, policy=policy, scope=scope
+                        curie=curie, label=label, adapter=adapter, policy=policy,
+                        scope=scope, lookup_curie=lookup_curie,
                     )
                 counts[rec["verdict"]] = counts.get(rec["verdict"], 0) + 1
                 if rec["verdict"] not in ("OK_CANONICAL", "OK_SYNONYM", "SKIPPED_NO_ADAPTER"):

--- a/src/mediaingredientmech/schema/mediaingredientmech.yaml
+++ b/src/mediaingredientmech/schema/mediaingredientmech.yaml
@@ -19,6 +19,7 @@ prefixes:
   MESH: http://id.nlm.nih.gov/mesh/
   UBERON: http://purl.obolibrary.org/obo/UBERON_
   ENVO: http://purl.obolibrary.org/obo/ENVO_
+  rdfs: http://www.w3.org/2000/01/rdf-schema#
 
 default_prefix: mediaingredientmech
 default_range: string
@@ -84,6 +85,14 @@ classes:
       ontology_mapping:
         range: OntologyMapping
         description: Ontology term mapping (CHEBI/FOODON)
+        # id↔label gate: makes `linkml-term-validator validate-data --labels`
+        # verify ontology_label is the canonical OBO label for ontology_id.
+        # No `range:` on purpose — a range-less binding triggers the label
+        # check without an enum-membership check (which would need per-ontology
+        # tree expansion). Id existence is covered by Engine B / OAK lookup.
+        bindings:
+          - binds_value_of: ontology_id
+            obligation_level: REQUIRED
       synonyms:
         range: IngredientSynonym
         multivalued: true
@@ -214,6 +223,9 @@ classes:
           CommunityMech (`environment_term`) and CultureMech
           (`source_environment`). Optional; ubiquitous ingredients
           (water, glucose) typically have no entries.
+        bindings:
+          - binds_value_of: environment_term
+            obligation_level: REQUIRED
 
   EnvironmentContext:
     description: >-
@@ -232,7 +244,10 @@ classes:
       environment_label:
         required: false
         range: string
-        description: Human-readable label for the ENVO term
+        slot_uri: rdfs:label
+        description: >-
+          Canonical ENVO label for environment_term. Verified against the
+          ontology by the id↔label gate; the free/relevance name lives in notes.
       relevance:
         required: true
         range: EnvironmentRelevanceEnum
@@ -258,7 +273,12 @@ classes:
         pattern: "^[A-Za-z][A-Za-z0-9.]*:[A-Za-z0-9][A-Za-z0-9._~-]*$"
       ontology_label:
         required: true
-        description: Human-readable label for the term
+        slot_uri: rdfs:label
+        description: >-
+          Canonical OBO label for ontology_id (e.g. "sodium chloride" for
+          CHEBI:26710). The id↔label gate verifies this equals the ontology's
+          canonical label; abbreviations/formulas/free names (e.g. "NaCl")
+          belong in preferred_term / synonyms, not here.
       ontology_source:
         range: OntologySourceEnum
         required: true

--- a/tests/test_id_label_empty_adapter.py
+++ b/tests/test_id_label_empty_adapter.py
@@ -1,16 +1,21 @@
 """Tests for the id-label validator's empty-adapter detection.
 
-A configured OAK adapter that loads but holds no terms (e.g. OAK's
-``sqlite:obo:micro`` selector points at a 0-byte stub whose tables don't exist)
-must NOT flag every id under that prefix as a false ``ID_NOT_FOUND``. It is
-reclassified as the benign ``SKIPPED_EMPTY_ADAPTER``. These pin that logic with
-fake adapters so it stays CI-safe (no OAK / network).
+A configured OAK adapter that loads but holds no terms (OAK's ``sqlite:obo:micro``
+selector points at a 0-byte stub whose tables don't exist) must NOT flag every id
+under that prefix as a false ``ID_NOT_FOUND`` — it is reclassified as the benign
+``SKIPPED_EMPTY_ADAPTER``.
+
+Crucially, a PARTIALLY-MIGRATED or corrupt LIVE ontology (real tables, one
+missing) raises the same ``no such table`` error but must NOT be masked as a
+benign skip — that would let real drift pass an enforce run. So "empty" is
+decided by a POSITIVE stub check (0-byte / 0-table backing sqlite), never by the
+error text alone. These pin that distinction with fake adapters + tiny on-disk
+sqlite files (CI-safe, no OAK / network).
 """
 
 import importlib.util
+import sqlite3
 from pathlib import Path
-
-import pytest
 
 _spec = importlib.util.spec_from_file_location(
     "validate_id_label_correspondence",
@@ -20,11 +25,23 @@ mod = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(mod)
 
 
-class _Adapter:
-    """Fake OAK adapter: entities() yields `items` or raises `exc`."""
+class _URL:
+    def __init__(self, database):
+        self.database = database
 
-    def __init__(self, items=(), exc=None):
+
+class _Engine:
+    def __init__(self, database):
+        self.url = _URL(database)
+
+
+class _Adapter:
+    """Fake OAK adapter: entities() yields `items` or raises `exc`; optional
+    `db` path exposed via .engine.url.database (mimics OAK's SqlImplementation)."""
+
+    def __init__(self, items=(), exc=None, db=None):
         self._items, self._exc = list(items), exc
+        self.engine = _Engine(db) if db is not None else None
 
     def entities(self):
         if self._exc:
@@ -32,34 +49,94 @@ class _Adapter:
         return iter(self._items)
 
 
+_NO_SUCH_TABLE = Exception("(sqlite3.OperationalError) no such table: node")
+
+
+# -- _is_uninitialized_stub: the positive empty-stub check ------------------
+
+def test_stub_true_for_zero_byte_file(tmp_path):
+    p = tmp_path / "micro.db"
+    p.touch()  # 0 bytes
+    assert mod.AdapterPool._is_uninitialized_stub(_Adapter(db=str(p))) is True
+
+
+def test_stub_true_for_tableless_sqlite(tmp_path):
+    p = tmp_path / "empty.db"
+    sqlite3.connect(str(p)).close()  # valid sqlite, no tables
+    assert mod.AdapterPool._is_uninitialized_stub(_Adapter(db=str(p))) is True
+
+
+def test_stub_false_for_sqlite_with_tables(tmp_path):
+    p = tmp_path / "live.db"
+    con = sqlite3.connect(str(p))
+    con.execute("CREATE TABLE statements (subject TEXT)")
+    con.commit()
+    con.close()
+    # has tables → a real (possibly broken) db, never a benign stub
+    assert mod.AdapterPool._is_uninitialized_stub(_Adapter(db=str(p))) is False
+
+
+def test_stub_false_for_missing_path(tmp_path):
+    assert mod.AdapterPool._is_uninitialized_stub(_Adapter(db=str(tmp_path / "nope.db"))) is False
+
+
+def test_stub_false_when_no_engine():
+    assert mod.AdapterPool._is_uninitialized_stub(_Adapter()) is False
+
+
+# -- _is_empty: combines the probe with the positive stub check -------------
+
 def test_empty_when_no_entities():
-    assert mod.AdapterPool._is_empty(_Adapter(items=[]), "micro") is True
+    assert mod.AdapterPool._is_empty(_Adapter(items=[]), "x") is True
 
 
-def test_empty_when_no_such_table():
-    # uninitialized / 0-byte sqlite stub (OAK's sqlite:obo:micro shape)
-    exc = Exception("(sqlite3.OperationalError) no such table: node")
-    assert mod.AdapterPool._is_empty(_Adapter(exc=exc), "micro") is True
+def test_empty_when_probe_raises_and_db_is_zero_byte(tmp_path):
+    p = tmp_path / "micro.db"
+    p.touch()
+    assert mod.AdapterPool._is_empty(_Adapter(exc=_NO_SUCH_TABLE, db=str(p)), "micro") is True
 
 
-def test_not_empty_when_populated():
+def test_NOT_empty_when_probe_raises_but_db_has_tables(tmp_path):
+    # THE REGRESSION GUARD: partially-migrated live db (tables present, one
+    # missing) raises "no such table" yet must NOT be masked as empty.
+    p = tmp_path / "chebi.db"
+    con = sqlite3.connect(str(p))
+    con.execute("CREATE TABLE statements (subject TEXT)")
+    con.commit()
+    con.close()
+    assert mod.AdapterPool._is_empty(_Adapter(exc=_NO_SUCH_TABLE, db=str(p)), "chebi") is False
+
+
+def test_NOT_empty_on_no_such_table_without_resolvable_db():
+    # error text alone is never enough — no path to confirm a stub → not empty.
+    assert mod.AdapterPool._is_empty(_Adapter(exc=_NO_SUCH_TABLE), "chebi") is False
+
+
+def test_empty_vs_nonempty_with_arbitrary_error(tmp_path):
+    p = tmp_path / "x.db"
+    p.touch()  # 0-byte stub still wins regardless of error text
+    assert mod.AdapterPool._is_empty(_Adapter(exc=Exception("disk I/O error"), db=str(p)), "x") is True
+    con = sqlite3.connect(str(p))  # now give it a table
+    con.execute("CREATE TABLE t (x)")
+    con.commit()
+    con.close()
+    # non-stub db + arbitrary probe error → stays non-empty (not masked)
+    assert mod.AdapterPool._is_empty(_Adapter(exc=Exception("disk I/O error"), db=str(p)), "x") is False
+
+
+def test_populated_adapter_not_empty():
     assert mod.AdapterPool._is_empty(_Adapter(items=["CHEBI:15377"]), "chebi") is False
 
 
-def test_not_empty_on_other_error():
-    # a genuinely broken adapter must NOT be masked as an empty skip.
-    assert mod.AdapterPool._is_empty(_Adapter(exc=Exception("disk I/O error")), "chebi") is False
-
-
-def test_pool_get_returns_empty_sentinel(monkeypatch):
+def test_pool_get_returns_empty_sentinel(monkeypatch, tmp_path):
+    p = tmp_path / "micro.db"
+    p.touch()  # 0-byte stub
     import oaklib
 
-    exc = Exception("(sqlite3.OperationalError) no such table: rdfs_label_statement")
-    monkeypatch.setattr(oaklib, "get_adapter", lambda selector: _Adapter(exc=exc))
+    monkeypatch.setattr(oaklib, "get_adapter", lambda sel: _Adapter(exc=_NO_SUCH_TABLE, db=str(p)))
     pool = mod.AdapterPool({"MICRO": "sqlite:obo:micro"})
     assert pool.get("MICRO") is mod.EMPTY_ADAPTER
-    # case-insensitive: data carries lowercase `micro:`
-    assert pool.get("micro") is mod.EMPTY_ADAPTER
+    assert pool.get("micro") is mod.EMPTY_ADAPTER  # case-insensitive
 
 
 def test_empty_adapter_not_an_error_verdict():

--- a/tests/test_id_label_empty_adapter.py
+++ b/tests/test_id_label_empty_adapter.py
@@ -1,0 +1,66 @@
+"""Tests for the id-label validator's empty-adapter detection.
+
+A configured OAK adapter that loads but holds no terms (e.g. OAK's
+``sqlite:obo:micro`` selector points at a 0-byte stub whose tables don't exist)
+must NOT flag every id under that prefix as a false ``ID_NOT_FOUND``. It is
+reclassified as the benign ``SKIPPED_EMPTY_ADAPTER``. These pin that logic with
+fake adapters so it stays CI-safe (no OAK / network).
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_spec = importlib.util.spec_from_file_location(
+    "validate_id_label_correspondence",
+    Path(__file__).parent.parent / "scripts" / "validate_id_label_correspondence.py",
+)
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)
+
+
+class _Adapter:
+    """Fake OAK adapter: entities() yields `items` or raises `exc`."""
+
+    def __init__(self, items=(), exc=None):
+        self._items, self._exc = list(items), exc
+
+    def entities(self):
+        if self._exc:
+            raise self._exc
+        return iter(self._items)
+
+
+def test_empty_when_no_entities():
+    assert mod.AdapterPool._is_empty(_Adapter(items=[]), "micro") is True
+
+
+def test_empty_when_no_such_table():
+    # uninitialized / 0-byte sqlite stub (OAK's sqlite:obo:micro shape)
+    exc = Exception("(sqlite3.OperationalError) no such table: node")
+    assert mod.AdapterPool._is_empty(_Adapter(exc=exc), "micro") is True
+
+
+def test_not_empty_when_populated():
+    assert mod.AdapterPool._is_empty(_Adapter(items=["CHEBI:15377"]), "chebi") is False
+
+
+def test_not_empty_on_other_error():
+    # a genuinely broken adapter must NOT be masked as an empty skip.
+    assert mod.AdapterPool._is_empty(_Adapter(exc=Exception("disk I/O error")), "chebi") is False
+
+
+def test_pool_get_returns_empty_sentinel(monkeypatch):
+    import oaklib
+
+    exc = Exception("(sqlite3.OperationalError) no such table: rdfs_label_statement")
+    monkeypatch.setattr(oaklib, "get_adapter", lambda selector: _Adapter(exc=exc))
+    pool = mod.AdapterPool({"MICRO": "sqlite:obo:micro"})
+    assert pool.get("MICRO") is mod.EMPTY_ADAPTER
+    # case-insensitive: data carries lowercase `micro:`
+    assert pool.get("micro") is mod.EMPTY_ADAPTER
+
+
+def test_empty_adapter_not_an_error_verdict():
+    assert "SKIPPED_EMPTY_ADAPTER" not in mod._ERROR_VERDICTS

--- a/tests/test_id_label_unknown_prefix.py
+++ b/tests/test_id_label_unknown_prefix.py
@@ -1,0 +1,69 @@
+"""Tests for the id-label validator's UNKNOWN_PREFIX gate.
+
+A CURIE whose prefix is neither a configured ontology adapter NOR an explicit
+``ignored_prefixes`` entry is a typo (``CHBEI:``) or an unexpected new prefix.
+It must FAIL enforce (UNKNOWN_PREFIX, an ERROR verdict) rather than silently
+passing as SKIPPED_NO_ADAPTER. Legit non-ontology prefixes (cas:, MIM: …) and
+prefix-less ids (UNMAPPED_0001) stay benign skips.
+
+Driven through ``run()`` end-to-end with a temp config + TSV using only
+UNCONFIGURED prefixes, so no real OAK adapter / network is touched.
+"""
+
+import importlib.util
+import textwrap
+from pathlib import Path
+
+_spec = importlib.util.spec_from_file_location(
+    "validate_id_label_correspondence",
+    Path(__file__).parent.parent / "scripts" / "validate_id_label_correspondence.py",
+)
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)
+
+
+def _setup(tmp_path, monkeypatch, rows: str):
+    monkeypatch.setattr(mod, "REPO_ROOT", tmp_path)
+    (tmp_path / "products.tsv").write_text("ontology_id\tontology_label\n" + rows)
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text(textwrap.dedent("""
+        adapters: {}
+        ignored_prefixes: [cas, MIM]
+        synonym_scope: exact
+        targets:
+          - name: products
+            kind: tabular
+            format: tsv
+            glob: products.tsv
+            policy: canonical_or_synonym
+            pairs:
+              - [ontology_id, ontology_label]
+    """))
+    return cfg
+
+
+def test_typoed_prefix_fails_enforce(tmp_path, monkeypatch):
+    # CHBEI: is a typo of CHEBI: — neither adapter nor ignored → UNKNOWN_PREFIX.
+    cfg = _setup(tmp_path, monkeypatch, "CHBEI:15377\twater\n")
+    assert mod.run(cfg, report_path=None) == 2
+
+
+def test_ignored_and_prefixless_pass_enforce(tmp_path, monkeypatch):
+    # cas:/MIM: are explicitly ignored; UNMAPPED_1 has no CURIE prefix at all.
+    cfg = _setup(
+        tmp_path, monkeypatch,
+        "cas:50-00-0\tformaldehyde\nMIM:000123\tfoo\nUNMAPPED_1\tmystery\n",
+    )
+    assert mod.run(cfg, report_path=None) == 0
+
+
+def test_report_mode_still_exit_zero_but_records_unknown(tmp_path, monkeypatch):
+    cfg = _setup(tmp_path, monkeypatch, "CHBEI:15377\twater\n")
+    report = tmp_path / "drift.tsv"
+    assert mod.run(cfg, report_path=report) == 0  # baseline mode never fails
+    body = report.read_text()
+    assert "UNKNOWN_PREFIX" in body and "CHBEI:15377" in body
+
+
+def test_unknown_prefix_is_error_verdict():
+    assert "UNKNOWN_PREFIX" in mod._ERROR_VERDICTS

--- a/uv.lock
+++ b/uv.lock
@@ -2022,6 +2022,23 @@ wheels = [
 ]
 
 [[package]]
+name = "linkml-term-validator"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "linkml" },
+    { name = "linkml-runtime" },
+    { name = "oaklib" },
+    { name = "pydantic" },
+    { name = "ruamel-yaml" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4b/84/e25d7cf7155087747ceb9bcdbdc55f8c12f6c21b3769ff57549f31578107/linkml_term_validator-0.3.0.tar.gz", hash = "sha256:08b405adedddf75613a926c29648127604b8c82c3e033e4ab7c057b6eb7de9a6", size = 389004 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/c7/3703848cb5339a1046f29001a622228994a942346cc815dcfe517c47cf6c/linkml_term_validator-0.3.0-py3-none-any.whl", hash = "sha256:59eda4ba64c1bda24a6e76f497fb52632c4d62efc36e6277f17a6b9fef04a19d", size = 41208 },
+]
+
+[[package]]
 name = "litellm"
 version = "1.83.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2314,6 +2331,7 @@ dependencies = [
     { name = "click" },
     { name = "linkml" },
     { name = "linkml-runtime" },
+    { name = "linkml-term-validator" },
     { name = "oaklib" },
     { name = "pyyaml" },
     { name = "requests" },
@@ -2325,9 +2343,11 @@ dependencies = [
 dev = [
     { name = "black" },
     { name = "deep-research-client", extra = ["cyberian"], marker = "python_full_version >= '3.12'" },
+    { name = "edison-client", marker = "python_full_version >= '3.12'" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "python-dotenv" },
     { name = "ruff" },
 ]
 
@@ -2336,12 +2356,15 @@ requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
     { name = "click", specifier = ">=8.1.0" },
     { name = "deep-research-client", extras = ["cyberian"], marker = "python_full_version >= '3.12' and extra == 'dev'", specifier = ">=0.2.4" },
+    { name = "edison-client", marker = "python_full_version >= '3.12' and extra == 'dev'", specifier = ">=0.11.0" },
     { name = "linkml", specifier = ">=1.7.0,<1.10" },
     { name = "linkml-runtime", specifier = ">=1.7.0,<1.10" },
+    { name = "linkml-term-validator", specifier = ">=0.1.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.5.0" },
     { name = "oaklib", specifier = ">=0.5.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
+    { name = "python-dotenv", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "requests", specifier = ">=2.28.0" },
     { name = "rich", specifier = ">=13.0.0" },
@@ -4121,6 +4144,15 @@ wheels = [
 ]
 
 [[package]]
+name = "ruamel-yaml"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102 },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.6"
 source = { registry = "https://pypi.org/simple" }
@@ -4946,10 +4978,10 @@ name = "typer"
 version = "0.25.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "annotated-doc", marker = "python_full_version >= '3.12'" },
-    { name = "click", marker = "python_full_version >= '3.12'" },
-    { name = "rich", marker = "python_full_version >= '3.12'" },
-    { name = "shellingham", marker = "python_full_version >= '3.12'" },
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276 }
 wheels = [


### PR DESCRIPTION
## Summary

Makes **id↔label correspondence** a checked invariant: every ontology ID must carry its **correct** ontology label — not just exist. Today `linkml-term-validator validate-data --labels` silently passes wrong labels because `--labels` only fires for slots with a LinkML `binding`, and the schema had none (corrupting a valid id's label still reported "✅ Validation passed").

## Two engines

**Engine A — LinkML-native gate (YAML data).** `mediaingredientmech.yaml` now marks `ontology_label`/`environment_label` `slot_uri: rdfs:label` and gives `ontology_mapping`/`environmental_context` a **range-less** `binding` (`binds_value_of: ontology_id` / `environment_term`). A range-less binding triggers the OAK label check *without* an enum-membership check (which would need per-ontology tree expansion). `linkml-term-validator validate-data --labels` now **fails** on label drift. Adds `linkml-term-validator` to deps.

**Engine B — shared OAK validator (data products).** `scripts/validate_id_label_correspondence.py` (config-driven; **vendored byte-identical** across the Mech repos — same convention as `_edison_capture.py`) checks `(id, label)` columns in SSSOM / CSV / review TSVs against the canonical label + exact/related synonyms. `conf/id_label_targets.yaml` lists the surfaces + the OAK adapter allowlist (unknown prefixes like `cas:`, `kgmicrobe.compound:` → `SKIPPED_NO_ADAPTER`).

## Policy (Hybrid)

Schema `label`/`ontology_label` fields must equal the **canonical** OBO label (free names live in `preferred_term`); product `*_label` columns accept canonical **or** an exact/related synonym.

## Rollout = report → baseline → enforce

- Recipes: `validate-terms[-all]`, `validate-products`, `report-label-drift`.
- CI workflow `label-correspondence.yaml` is **report-only / non-blocking** — uploads `reports/label_drift.tsv`. The gates are intentionally **not** in `qc` yet.
- **Baseline already ran: 1010 real problems** (735 MISMATCH, 230 ID_NOT_FOUND, 45 EMPTY_LABEL) — e.g. `ontology_label: NaCl` for `CHEBI:26710` (canonical "sodium chloride"). Triage (wrong-label vs wrong-id) precedes flipping CI to blocking.

## Testing

- Schema passes plain `linkml-validate` (structural).
- `validate-data --labels`: real file passes; a corrupted label (`CHEBI:43796` → garbage) **fails (exit 1)** with "Label mismatch".
- Engine B unit: `NaCl`/`CHEBI:26710` passes under `canonical_or_synonym`, fails under `canonical`; garbage always fails; enforce exits 2.

Docs: `docs/ID_LABEL_CORRESPONDENCE.md` + `.claude/skills/id-label-correspondence/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)