### PR TITLE
Restore exceptions allow-list in shared id-label validator (CommunityMech#134)

### DIFF
--- a/scripts/.validate_id_label_correspondence.sha256
+++ b/scripts/.validate_id_label_correspondence.sha256
@@ -1,1 +1,1 @@
-4b66a268f0ba982df4314c0c0e218ab9a9bff4c7b3e2c36b9f8151e2d000f1b8  scripts/validate_id_label_correspondence.py
+142bbe1ed020d64554e6787e0adf126003a4179e8b74198b226dd6097263542a  scripts/validate_id_label_correspondence.py

--- a/scripts/validate_id_label_correspondence.py
+++ b/scripts/validate_id_label_correspondence.py
@@ -26,6 +26,13 @@ repos already use, and classifies the pair:
     OK_ID_ONLY          id resolves; label match WAIVED for this slot (the slot
                         carries a curator-intended formula/common name, e.g.
                         CHEBI:15377 "Distilled water" — see ``label_waived_keys``)
+    OK_EXCEPTION        the exact (id, label) pair is on the target's
+                        ``exceptions`` allow-list — a curator-accepted residual
+                        (obsolete-no-successor, no clean term yet, or id absent
+                        from the current ontology snapshot) carrying a documented
+                        ``reason``. Overrides MISMATCH / ID_NOT_FOUND only; the
+                        match is exact, so a different wrong label on the same id
+                        still fails as MISMATCH.
     MISMATCH            label is neither canonical nor an accepted synonym  (ERROR)
     ID_NOT_FOUND        id has an adapter but is absent from the ontology   (ERROR)
     EMPTY_LABEL         id present, label blank                             (ERROR)
@@ -131,8 +138,11 @@ _CANONICAL_LABEL_CONTEXTS = (
 
 # Verdicts that are accepted (do NOT get recorded as findings and never fail
 # enforce). OK_ID_ONLY is a pass: the id resolved and the slot's label was
-# intentionally waived (curator-intended formula/common name).
-_OK_VERDICTS = {"OK_CANONICAL", "OK_SYNONYM", "OK_ID_ONLY"}
+# intentionally waived (curator-intended formula/common name). OK_EXCEPTION is a
+# pass: the exact (id, label) pair is on the target's ``exceptions`` allow-list —
+# a curator-accepted residual (obsolete-no-successor, no clean term yet, id
+# absent from the current ontology snapshot) with a documented ``reason``.
+_OK_VERDICTS = {"OK_CANONICAL", "OK_SYNONYM", "OK_ID_ONLY", "OK_EXCEPTION"}
 # Benign skips: not OK (still surfaced in the report) but never fail enforce.
 _SKIP_VERDICTS = {"SKIPPED_NO_ADAPTER", "SKIPPED_EMPTY_ADAPTER"}
 
@@ -526,6 +536,27 @@ def iter_yaml(
     )
 
 
+# -- exceptions allow-list ------------------------------------------------
+
+def load_exceptions(target: dict[str, Any]) -> set[tuple[str, str]]:
+    """Return the (curie, normalized_label) pairs the target accepts as-is.
+
+    The ``exceptions`` field on a target is a list of mappings, each with at
+    least ``id`` and ``label``. Optional ``reason`` is documentation only;
+    pairs are matched on (id, normalized(label)) so a missing or alternative
+    casing for ``reason`` doesn't affect matching. A target with no
+    ``exceptions`` key yields an empty set (no-op), so repos that don't use the
+    allow-list are unaffected.
+    """
+    out: set[tuple[str, str]] = set()
+    for entry in target.get("exceptions") or []:
+        curie = str(entry.get("id", "")).strip()
+        label = str(entry.get("label", ""))
+        if curie:
+            out.add((curie, normalize(label)))
+    return out
+
+
 # -- driver ---------------------------------------------------------------
 
 def load_config(config_path: Path) -> dict[str, Any]:
@@ -558,6 +589,7 @@ def run(config_path: Path, report_path: Path | None) -> int:
         pairs = target.get("pairs", [])
         exclude_keys = frozenset(target.get("exclude_keys", []) or [])
         label_waived_keys = frozenset(target.get("label_waived_keys", []) or [])
+        exceptions = load_exceptions(target)
         required = bool(target.get("required", False))
         globs = target.get("glob")
         glob_list = globs if isinstance(globs, list) else [globs]
@@ -627,6 +659,19 @@ def run(config_path: Path, report_path: Path | None) -> int:
                             scope=scope, lookup_curie=lookup_curie,
                             label_waived=label_waived,
                         )
+                # Curator-accepted residual: an EXACT (id, label) pair on the
+                # target's ``exceptions`` allow-list is accepted as OK_EXCEPTION
+                # (non-error, documented ``reason``). Applies ONLY to label/id
+                # residuals (MISMATCH / ID_NOT_FOUND) — never to structural
+                # errors (UNKNOWN_PREFIX, ADAPTER_ERROR, MISSING_COLUMN,
+                # MISSING_GLOB, EMPTY_LABEL), which signal real defects rather
+                # than a knowingly-accepted label. The match is exact, so a
+                # different wrong label on the same id still fails as MISMATCH.
+                if rec["verdict"] in ("MISMATCH", "ID_NOT_FOUND") and (
+                    curie,
+                    normalize(label),
+                ) in exceptions:
+                    rec["verdict"] = "OK_EXCEPTION"
                 counts[rec["verdict"]] = counts.get(rec["verdict"], 0) + 1
                 if rec["verdict"] not in _OK_VERDICTS | _SKIP_VERDICTS:
                     findings.append({
@@ -643,6 +688,7 @@ def run(config_path: Path, report_path: Path | None) -> int:
         "OK_CANONICAL",
         "OK_SYNONYM",
         "OK_ID_ONLY",
+        "OK_EXCEPTION",
         "MISMATCH",
         "ID_NOT_FOUND",
         "EMPTY_LABEL",

--- a/tests/test_id_label_exceptions.py
+++ b/tests/test_id_label_exceptions.py
@@ -1,0 +1,103 @@
+"""Tests for the id-label validator's ``exceptions`` allow-list (OK_EXCEPTION).
+
+A curator-accepted residual — an exact ``(id, label)`` pair the ontology
+disagrees with because the canonical term is wrong/obsolete/unminted, or the id
+is absent from the current snapshot — is listed under a target's ``exceptions``
+and accepted as ``OK_EXCEPTION`` (non-error). The match is EXACT, so:
+
+* a residual on the list overrides MISMATCH and ID_NOT_FOUND → enforce passes;
+* a DIFFERENT wrong label on the same id is NOT on the list → still MISMATCH
+  (the allow-list can't mask drift it didn't explicitly accept);
+* with no ``exceptions`` configured the residual fails as before.
+
+Driven through ``run()`` end-to-end with a fake adapter + temp config, so no
+real OAK adapter / network is touched.
+"""
+
+import importlib.util
+import textwrap
+from pathlib import Path
+
+_spec = importlib.util.spec_from_file_location(
+    "validate_id_label_correspondence",
+    Path(__file__).parent.parent / "scripts" / "validate_id_label_correspondence.py",
+)
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)
+
+
+class _Adapter:
+    """Fake OAK adapter: CHEBI:33104 resolves to a canonical label that differs
+    from the curator's; everything else is absent (label() -> None)."""
+
+    _LABELS = {"CHEBI:33104": "chromium hydroxide"}
+
+    def label(self, curie):
+        return self._LABELS.get(curie)
+
+    def entities(self):
+        return iter(self._LABELS)
+
+    def entity_alias_map(self, curie):
+        return {}
+
+
+def _setup(tmp_path, monkeypatch, body_yaml, exceptions_block):
+    import oaklib
+
+    monkeypatch.setattr(oaklib, "get_adapter", lambda sel: _Adapter())
+    monkeypatch.setattr(mod, "REPO_ROOT", tmp_path)
+    (tmp_path / "f.yaml").write_text(body_yaml)
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text(textwrap.dedent("""
+            adapters: {CHEBI: 'sqlite:obo:chebi'}
+            ignored_prefixes: []
+            synonym_scope: exact
+            targets:
+              - name: t
+                kind: yaml
+                glob: f.yaml
+                policy: canonical
+                pairs: [[id, label]]
+                exceptions:
+            """) + exceptions_block)
+    return cfg
+
+
+_EXC = "      - { id: 'CHEBI:33104', label: 'chromium(III) hydroxide', reason: 'no clean term' }\n"
+
+
+def test_residual_on_allowlist_passes_enforce(tmp_path, monkeypatch):
+    # id resolves but canonical != curator label; pair IS on the allow-list.
+    cfg = _setup(
+        tmp_path, monkeypatch, "x:\n  id: CHEBI:33104\n  label: chromium(III) hydroxide\n", _EXC
+    )
+    assert mod.run(cfg, report_path=None) == 0
+
+
+def test_different_wrong_label_same_id_still_fails(tmp_path, monkeypatch):
+    # same id, a DIFFERENT label that is NOT on the list -> must still MISMATCH.
+    cfg = _setup(tmp_path, monkeypatch, "x:\n  id: CHEBI:33104\n  label: totally wrong\n", _EXC)
+    assert mod.run(cfg, report_path=None) == 2
+
+
+def test_absent_id_on_allowlist_passes_enforce(tmp_path, monkeypatch):
+    # id absent from the snapshot (ID_NOT_FOUND) but on the list -> OK_EXCEPTION.
+    exc = "      - { id: 'CHEBI:99999', label: 'absent thing', reason: 'absent from snapshot' }\n"
+    cfg = _setup(tmp_path, monkeypatch, "x:\n  id: CHEBI:99999\n  label: absent thing\n", exc)
+    assert mod.run(cfg, report_path=None) == 0
+
+
+def test_no_exceptions_residual_fails(tmp_path, monkeypatch):
+    cfg = _setup(
+        tmp_path,
+        monkeypatch,
+        "x:\n  id: CHEBI:33104\n  label: chromium(III) hydroxide\n",
+        "      []\n",
+    )
+    assert mod.run(cfg, report_path=None) == 2
+
+
+def test_ok_exception_is_not_an_error_verdict():
+    assert "OK_EXCEPTION" not in mod._ERROR_VERDICTS
+    assert "OK_EXCEPTION" in mod._OK_VERDICTS


### PR DESCRIPTION
Re-syncs the vendored `scripts/validate_id_label_correspondence.py` to byte-identical across the Mech repos (sha `142bbe1e…`) and restores the per-`(id,label)` `exceptions`/`OK_EXCEPTION` allow-list. No-op here unless a target declares `exceptions:`; keeps the cross-repo pin guard meaningful. Companion to CommunityMech#134. Adds `tests/test_id_label_exceptions.py` (5 tests). Validator tests + pin verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)