### PR TITLE
reconcile_sssom: fix registry→OBO remap that --apply could not sync

### DIFF
--- a/scripts/reconcile_sssom.py
+++ b/scripts/reconcile_sssom.py
@@ -52,6 +52,24 @@ PREDICATE = {
     "BROAD_MATCH": "skos:broadMatch",
 }
 
+# Object-id prefixes that denote an ONTOLOGY mapping row (vs a registry/identity
+# row such as cas: / kgmicrobe.*). The stale ontology row must be recognised by
+# its object_id PREFIX, not by an `obo:` object_source: MeSH is an ontology
+# source here but its object_source is `registry:mesh`, so a MeSH→OBO parent
+# remap (e.g. mesh:D013025 → CHEBI:28874) was previously invisible to --apply —
+# Pass 1 only captured `obo:`-sourced rows, so the stale mesh row was never
+# rewritten (`synced 0`). Matched case-insensitively: data carries lowercase
+# `mesh:` while the OBJECT_SOURCE keys (and OBO CURIEs) are uppercase.
+ONTOLOGY_PREFIXES = frozenset(
+    p.casefold()
+    for p in ([k for k, v in OBJECT_SOURCE.items() if v.startswith("obo:")] + ["MESH"])
+)
+
+
+def _is_ontology_row(object_id: str) -> bool:
+    """True if ``object_id``'s CURIE prefix is an ontology (not a registry id)."""
+    return object_id.split(":", 1)[0].casefold() in ONTOLOGY_PREFIXES
+
 
 def expected_mappings(curated: dict) -> dict[str, dict]:
     """preferred_term -> ontology_mapping for MAPPED records carrying an ontology_id."""
@@ -132,7 +150,7 @@ def apply_reconcile(curated: dict, date: str) -> tuple[int, int]:
     remap: dict[str, tuple[str, str]] = {}
     for r in rows:
         term = r["subject_label"]
-        if term in expected and r["object_source"].startswith("obo:"):
+        if term in expected and _is_ontology_row(r["object_id"]):
             new_id = expected[term]["ontology_id"]
             if r["object_id"] != new_id:
                 remap[term] = (r["object_id"], new_id)
@@ -150,7 +168,7 @@ def apply_reconcile(curated: dict, date: str) -> tuple[int, int]:
             continue
         if term in remap:
             old_id, new_id = remap[term]
-            if f[idx["object_source"]].startswith("obo:") and f[idx["object_id"]] == old_id:
+            if _is_ontology_row(f[idx["object_id"]]) and f[idx["object_id"]] == old_id:
                 # The stale ontology row: sync to the current curated mapping.
                 om = expected[term]
                 f[idx["object_id"]] = new_id

--- a/tests/test_reconcile_sssom.py
+++ b/tests/test_reconcile_sssom.py
@@ -1,0 +1,162 @@
+"""Tests for scripts/reconcile_sssom.py — in particular the registry→OBO parent
+remap that --apply previously could not fix.
+
+The reconciler used to identify the stale ontology row by an ``obo:`` object_source.
+MeSH is an ontology source here but its object_source is ``registry:mesh``, so a
+mesh→CHEBI parent remap was detected as drift yet ``--apply`` synced 0 rows. The
+fix recognises the ontology row by its object_id PREFIX instead. These pin that.
+
+OAK is stubbed (``_canonical_label_resolver`` monkeypatched) so the tests are
+CI-safe — no chebi.db / network.
+"""
+
+import importlib.util
+from pathlib import Path
+
+_spec = importlib.util.spec_from_file_location(
+    "reconcile_sssom",
+    Path(__file__).parent.parent / "scripts" / "reconcile_sssom.py",
+)
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)
+
+COLS = [
+    "subject_id", "subject_label", "predicate_id", "object_id", "object_label",
+    "object_source", "mapping_justification", "source", "mapping_date",
+    "confidence", "comment", "other", "validation_method",
+]
+
+
+def _row(**kw):
+    return "\t".join(str(kw.get(c, "")) for c in COLS)
+
+
+def _write_sssom(path, rows):
+    head = ['# mapping_set_version: "2026-01-01"', '# mapping_date: "2026-01-01"']
+    path.write_text("\n".join(head + ["\t".join(COLS)] + rows) + "\n")
+
+
+def _curated(term, oid, label, source, quality):
+    return {"ingredients": [{
+        "preferred_term": term, "mapping_status": "MAPPED",
+        "ontology_mapping": {
+            "ontology_id": oid, "ontology_label": label,
+            "ontology_source": source, "mapping_quality": quality,
+        },
+    }]}
+
+
+def _stub_resolver(monkeypatch, labels):
+    monkeypatch.setattr(mod, "_canonical_label_resolver", lambda: (lambda oid: labels.get(oid)))
+
+
+# -- _is_ontology_row -------------------------------------------------------
+
+def test_is_ontology_row_recognises_ontology_vs_registry_prefixes():
+    assert mod._is_ontology_row("CHEBI:28874")
+    assert mod._is_ontology_row("FOODON:03315720")
+    assert mod._is_ontology_row("mesh:D013025")        # lowercase mesh — the bug case
+    assert mod._is_ontology_row("MESH:C016600")        # uppercase too
+    assert not mod._is_ontology_row("cas:97281-52-2")
+    assert not mod._is_ontology_row("kgmicrobe.compound:foo")
+    assert not mod._is_ontology_row("registry:bar")
+
+
+# -- the registry(mesh)→OBO remap that used to sync 0 -----------------------
+
+def _mesh_parent_fixture(tmp_path):
+    sssom = tmp_path / "m.sssom.tsv"
+    rows = [
+        _row(subject_id="MIM:Foo", subject_label="Foo", predicate_id="skos:narrowMatch",
+             object_id="mesh:D013025", object_label="Glycine max", object_source="registry:mesh",
+             mapping_justification="semapv:ManualMappingCuration", source="MIM:x",
+             mapping_date="2026-01-01", confidence="0.9", comment="", other="",
+             validation_method="none"),
+        _row(subject_id="MIM:Foo", subject_label="Foo", predicate_id="skos:exactMatch",
+             object_id="cas:1-1-1", object_label="Foo", object_source="registry:cas",
+             mapping_justification="semapv:ManualMappingCuration", source="MIM:x",
+             mapping_date="2026-01-01", confidence="0.99",
+             comment="Registry/identity row for narrowMatch subject alongside parent mesh:D013025.",
+             other="", validation_method="none"),
+    ]
+    _write_sssom(sssom, rows)
+    return sssom
+
+
+def test_find_drift_detects_stale_mesh_parent(tmp_path, monkeypatch):
+    sssom = _mesh_parent_fixture(tmp_path)
+    monkeypatch.setattr(mod, "SSSOM", sssom)
+    _, _, _, rows = mod._read_sssom()
+    curated = _curated("Foo", "CHEBI:28874", "phosphatidylinositol", "CHEBI", "BROAD_MATCH")
+    drift = mod.find_drift(curated, rows)
+    assert drift["gaps"] == [] and drift["orphans"] == []
+    assert drift["stale"] and drift["stale"][0][0] == "Foo"
+    assert drift["stale"][0][1] == "CHEBI:28874"  # expected id
+
+
+def test_apply_remaps_mesh_parent_to_chebi(tmp_path, monkeypatch):
+    sssom = _mesh_parent_fixture(tmp_path)
+    monkeypatch.setattr(mod, "SSSOM", sssom)
+    _stub_resolver(monkeypatch, {"CHEBI:28874": "phosphatidylinositol"})
+    curated = _curated("Foo", "CHEBI:28874", "phosphatidylinositol", "CHEBI", "BROAD_MATCH")
+
+    n_stale, n_orphan = mod.apply_reconcile(curated, "2026-06-13")
+    assert (n_stale, n_orphan) == (1, 0)  # before the fix this was (0, 0)
+
+    _, _, _, parsed = mod._read_sssom()
+    onto = [r for r in parsed if r["object_id"] == "CHEBI:28874"][0]
+    assert onto["predicate_id"] == "skos:broadMatch"
+    assert onto["object_label"] == "phosphatidylinositol"
+    assert onto["object_source"] == "obo:chebi.owl"
+    assert onto["mapping_date"] == "2026-06-13"
+    assert "REMAPPED" in onto["validation_method"]
+    assert "reconciled to curated mapping" in onto["comment"]
+    # the registry/identity row's comment is repointed to the new parent
+    ident = [r for r in parsed if r["object_id"] == "cas:1-1-1"][0]
+    assert "CHEBI:28874" in ident["comment"] and "mesh:D013025" not in ident["comment"]
+
+
+# -- regression: obo→obo remap still works ----------------------------------
+
+def test_apply_still_remaps_obo_to_obo(tmp_path, monkeypatch):
+    sssom = tmp_path / "o.sssom.tsv"
+    rows = [
+        _row(subject_id="MIM:Bar", subject_label="Bar", predicate_id="skos:closeMatch",
+             object_id="FOODON:00001", object_label="old", object_source="obo:foodon.owl",
+             mapping_justification="semapv:ManualMappingCuration", source="MIM:x",
+             mapping_date="2026-01-01", confidence="0.8", comment="", other="",
+             validation_method="none"),
+    ]
+    _write_sssom(sssom, rows)
+    monkeypatch.setattr(mod, "SSSOM", sssom)
+    _stub_resolver(monkeypatch, {"CHEBI:28874": "phosphatidylinositol"})
+    curated = _curated("Bar", "CHEBI:28874", "phosphatidylinositol", "CHEBI", "EXACT_MATCH")
+
+    n_stale, n_orphan = mod.apply_reconcile(curated, "2026-06-13")
+    assert (n_stale, n_orphan) == (1, 0)
+    _, _, _, parsed = mod._read_sssom()
+    onto = parsed[0]
+    assert onto["object_id"] == "CHEBI:28874"
+    assert onto["object_source"] == "obo:chebi.owl"
+    assert onto["predicate_id"] == "skos:exactMatch"
+
+
+# -- orphan handling unchanged ----------------------------------------------
+
+def test_apply_drops_orphan_subject(tmp_path, monkeypatch):
+    sssom = tmp_path / "p.sssom.tsv"
+    rows = [
+        _row(subject_id="MIM:Gone", subject_label="Gone", predicate_id="skos:exactMatch",
+             object_id="CHEBI:9", object_label="x", object_source="obo:chebi.owl",
+             mapping_justification="semapv:ManualMappingCuration", source="MIM:x",
+             mapping_date="2026-01-01", confidence="0.9", comment="", other="",
+             validation_method="none"),
+    ]
+    _write_sssom(sssom, rows)
+    monkeypatch.setattr(mod, "SSSOM", sssom)
+    _stub_resolver(monkeypatch, {})
+    curated = {"ingredients": []}  # no record for "Gone" -> orphan
+    n_stale, n_orphan = mod.apply_reconcile(curated, "2026-06-13")
+    assert (n_stale, n_orphan) == (0, 1)
+    _, _, _, parsed = mod._read_sssom()
+    assert parsed == []  # orphan row dropped


### PR DESCRIPTION
## Summary

Harden `reconcile_sssom.py --apply` to fix **registry→OBO** ontology-mapping remaps — the gap surfaced in #55, where the soybean-PI record was remapped `mesh:D013025` "Soybeans" → `CHEBI:28874` "phosphatidylinositol" but `--apply` reported the row STALE yet **synced 0**, so it had to be hand-reconciled.

## Root cause

`--apply` identified the stale ontology row to rewrite via `object_source.startswith("obo:")` (both the Pass-1 remap collection and the Pass-2 rewrite). MeSH is an ontology source here, but its `object_source` is `registry:mesh` — the same family as the `cas:` / `kgmicrobe.*` identity rows. So a MeSH-sourced ontology row was indistinguishable from an identity row by source, and a mesh→OBO parent remap was invisible to the apply pass (`find_drift` still *detected* the drift, which is why it reported STALE but changed nothing).

## Fix

Recognise the ontology row by its **object_id CURIE prefix** instead of its `object_source`:

```python
ONTOLOGY_PREFIXES = frozenset(p.casefold() for p in (
    [k for k, v in OBJECT_SOURCE.items() if v.startswith("obo:")] + ["MESH"]))

def _is_ontology_row(object_id):  # case-insensitive: data has `mesh:`, key is `MESH`
    return object_id.split(":", 1)[0].casefold() in ONTOLOGY_PREFIXES
```

- Matching is case-insensitive (data carries lowercase `mesh:`; OBJECT_SOURCE keys/OBO CURIEs are uppercase).
- Registry/identity prefixes (`cas`, `kgmicrobe.compound`, `kgmicrobe.ingredient`, `registry`) are excluded, so identity rows are never mistaken for the ontology row.
- `obo:`-sourced rows are a strict subset of the new predicate, so obo→obo remaps behave exactly as before. `reconcile --check` on current `main` data still reports **0 drift**.

## Tests

Adds `tests/test_reconcile_sssom.py` (first tests for this script), OAK stubbed for CI-safety:
- `test_apply_remaps_mesh_parent_to_chebi` — the regression: `n_stale == 1` (was `0` before the fix); the identity row's comment is repointed to the new parent.
- `_is_ontology_row` prefix classification (incl. lowercase `mesh:`).
- `find_drift` still flags the stale mesh parent.
- obo→obo remap still works; orphan-subject rows still dropped.

Full suite: 348 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
