### PR TITLE
id↔label Phase 2: accept valid MeSH SCRs as exceptions + flip gate to blocking

### DIFF
--- a/.github/workflows/label-correspondence.yaml
+++ b/.github/workflows/label-correspondence.yaml
@@ -1,9 +1,17 @@
 name: label-correspondence
 
-# Phase 1 (report-only): generate the id↔label drift report and upload it as
-# an artifact. This job does NOT fail the build — it surfaces existing label
-# drift so it can be triaged. Phase 2 will switch to the blocking gates
-# (`just validate-terms-all` + `just validate-products`).
+# Phase 2 (BLOCKING): enforce id↔label correspondence. `just validate-products`
+# (Engine B) is a single-pass gate over the curated YAML source (strict
+# canonical) and the data products consumed by KG-Microbe (the SSSOM + docs CSV,
+# canonical-or-synonym). It fails the build (exit 2) on any MISMATCH /
+# ID_NOT_FOUND / structural error. Curator-accepted residuals (e.g. valid MeSH
+# supplementary-concept records absent from the cached mesh.db) are declared in
+# conf/id_label_targets.yaml `exceptions` and pass as OK_EXCEPTION.
+#
+# Engine A (`just validate-terms-all`, linkml-term-validator --labels) is NOT a
+# CI gate: it spawns one validator process per record (~2k+), which is too slow
+# for CI, and Engine B already covers the same YAML ontology_label checks (and
+# more — ID_NOT_FOUND, products). It remains a local LinkML-native cross-check.
 
 on:
   pull_request:
@@ -26,7 +34,7 @@ permissions:
   contents: read
 
 jobs:
-  label-drift-report:
+  id-label-gate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -53,8 +61,14 @@ jobs:
       - name: Verify id↔label validator pin
         run: just verify-validator-pin
 
-      - name: Generate id↔label drift report (non-blocking)
+      # Always generate the drift report first so the artifact is uploaded even
+      # when the blocking gate below fails (report mode never exits non-zero).
+      - name: Generate id↔label drift report
         run: just report-label-drift
+
+      # BLOCKING: enforce id↔label correspondence (exit 2 on any error).
+      - name: Enforce id↔label correspondence
+        run: just validate-products
 
       - name: Upload drift report
         if: always()

--- a/conf/id_label_targets.yaml
+++ b/conf/id_label_targets.yaml
@@ -54,6 +54,20 @@ ignored_prefixes:
 
 synonym_scope: exact_related
 
+# Curator-accepted residuals shared across every surface that carries them.
+# These four are VALID MeSH supplementary-concept records (verified live in MeSH:
+# avocatin B introduced 2020, sodium glutarate 2024) with no CHEBI equivalent. The
+# cached sqlite:obo:mesh adapter predates these SCRs, so they resolve as
+# ID_NOT_FOUND even though the data is correct. Listing the exact (id, label) pair
+# accepts it as OK_EXCEPTION (non-error) so the gate can be enforced/blocking. The
+# match is exact: a *different* label on the same id still fails. Remove an entry
+# once mesh.db includes that SCR.
+mesh_scr_exceptions: &mesh_scr_exceptions
+  - {id: mesh:C000709627, label: avocatin B, reason: "valid MeSH SCR (2020); absent from cached sqlite:obo:mesh; no CHEBI equivalent"}
+  - {id: mesh:C000655964, label: cholinium lysinate, reason: "valid MeSH SCR; absent from cached sqlite:obo:mesh; no CHEBI equivalent"}
+  - {id: mesh:C000730144, label: sodium glutarate, reason: "valid MeSH SCR (2024); absent from cached sqlite:obo:mesh; no CHEBI equivalent"}
+  - {id: mesh:C000633628, label: plicacetin, reason: "valid MeSH SCR; absent from cached sqlite:obo:mesh; no CHEBI equivalent"}
+
 targets:
   # --- data inputs / intermediates (YAML) — strict canonical, mirrors Engine A
   - name: curated_yaml
@@ -63,6 +77,7 @@ targets:
       - "data/ingredients/mapped/*.yaml"
       - "data/ingredients/unmapped/*.yaml"
     policy: canonical
+    exceptions: *mesh_scr_exceptions
     pairs:
       - [ontology_id, ontology_label]
       - [environment_term, environment_label]
@@ -77,6 +92,7 @@ targets:
     glob: "mappings/ingredient_mappings.sssom.tsv"
     required: true
     policy: canonical_or_synonym
+    exceptions: *mesh_scr_exceptions
     pairs:
       - [subject_id, subject_label]
       - [object_id, object_label]
@@ -98,6 +114,7 @@ targets:
     policy: canonical_or_synonym
     label_waived_keys:
       - ontology_id
+    exceptions: *mesh_scr_exceptions
     pairs:
       - [ontology_id, ontology_label]
 

--- a/justfile
+++ b/justfile
@@ -154,10 +154,13 @@ refresh-validator-pin:
 
 # Composite QC: schema validation + strict closed-schema check +
 # evidence reference validation + SSSOM invariants.
-# NOTE: validate-terms-all + validate-products are intentionally NOT in `qc`
-# yet — they enforce id↔label correspondence and will fail on existing label
-# drift. Run `just report-label-drift`, triage reports/label_drift.tsv, then
-# add them here (Phase 2 of the rollout).
+# NOTE: id↔label enforcement (Phase 2) is now BLOCKING, but lives in the
+# dedicated `label-correspondence` CI workflow (`just validate-products`), not
+# here: it loads the OAK sqlite ontologies (CHEBI ~3.7GB etc.) and that workflow
+# already caches them, whereas `qc` is meant to stay fast and OAK-free. Run
+# `just validate-products` locally to reproduce the gate; `just report-label-drift`
+# writes the full drift TSV. Engine A (`just validate-terms-all`) is a local-only
+# LinkML cross-check (one validator process per record → too slow for CI).
 qc: validate-all validate-strict qc-evidence qc-sssom
 
 # Render per-ingredient HTML detail pages from data/ingredients/*.yaml

--- a/tests/test_id_label_exceptions_conf.py
+++ b/tests/test_id_label_exceptions_conf.py
@@ -1,0 +1,52 @@
+"""Guard: the curator-accepted MeSH-SCR exceptions stay wired on every gated
+surface in conf/id_label_targets.yaml.
+
+These four are valid MeSH supplementary-concept records absent from the cached
+sqlite:obo:mesh adapter (see the conf comment). With the id↔label gate now
+BLOCKING (label-correspondence workflow → `just validate-products`), dropping an
+exception would turn the gate red on correct data. This pins the wiring without
+touching OAK (pure YAML/load_config — CI-safe).
+"""
+
+import importlib.util
+from pathlib import Path
+
+_spec = importlib.util.spec_from_file_location(
+    "validate_id_label_correspondence",
+    Path(__file__).parent.parent / "scripts" / "validate_id_label_correspondence.py",
+)
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)
+
+CONF = Path(__file__).parent.parent / "conf" / "id_label_targets.yaml"
+
+# (id, label) pairs that must be accepted as OK_EXCEPTION on every gated surface.
+EXPECTED = {
+    ("mesh:C000709627", "avocatin b"),
+    ("mesh:C000655964", "cholinium lysinate"),
+    ("mesh:C000730144", "sodium glutarate"),
+    ("mesh:C000633628", "plicacetin"),
+}
+GATED_TARGETS = {"curated_yaml", "sssom", "mapped_csv"}
+
+
+def _targets():
+    cfg = mod.load_config(CONF)
+    return {t.get("name"): t for t in cfg["targets"]}
+
+
+def test_gated_targets_declare_all_mesh_scr_exceptions():
+    targets = _targets()
+    for name in GATED_TARGETS:
+        assert name in targets, f"gated target {name!r} missing from conf"
+        got = mod.load_exceptions(targets[name])
+        missing = EXPECTED - got
+        assert not missing, f"{name} is missing exception(s): {sorted(missing)}"
+
+
+def test_exception_label_matching_is_normalized():
+    # load_exceptions normalizes labels, so a different casing/spacing still
+    # matches the same id — but a *different* label is not silently accepted.
+    ex = mod.load_exceptions(_targets()["sssom"])
+    assert ("mesh:C000709627", mod.normalize("Avocatin  B")) in ex
+    assert ("mesh:C000709627", mod.normalize("not the label")) not in ex


### PR DESCRIPTION
## Summary

Closes out the id↔label rollout: **(a)** clear the last residual findings and **(b)** flip the gate from report-only to **blocking** (Phase 2).

## (a) The 4 ID_NOT_FOUND residuals are correct data → accepted as exceptions

The only findings left after #55 were the same 4 **valid MeSH supplementary-concept records** — `avocatin B` (C000709627), `cholinium lysinate` (C000655964), `sodium glutarate` (C000730144), `plicacetin` (C000633628) — verified live in MeSH (avocatin B introduced 2020, sodium glutarate 2024) with **no CHEBI equivalent**. The cached `sqlite:obo:mesh` adapter predates these SCRs, so they resolve as ID_NOT_FOUND even though the data is right.

Rather than a `mesh.db` refresh (uncertain — upstream semsql may not carry 2020/2024 SCRs — and a heavy CI download), I declared them on the validator's `exceptions` allow-list (the mechanism restored in #57): the exact `(id, label)` pair passes as `OK_EXCEPTION`, but a *different* label on the same id still fails. Wired via a shared YAML anchor on the three gated targets (`curated_yaml` / `sssom` / `mapped_csv`).

Verified locally — `just validate-products` now exits 0:

```
OK_CANONICAL: 5000
  OK_SYNONYM: 1
  OK_ID_ONLY: 1656
OK_EXCEPTION: 16        # 4 SCRs × (curated YAML ×2 + SSSOM + CSV)
✅ All id↔label pairs correspond.   EXIT: 0
```

## (b) `label-correspondence` workflow → BLOCKING

The workflow now runs **`just validate-products`** (Engine B) as a blocking step — it fails the build (exit 2) on any MISMATCH / ID_NOT_FOUND / structural error — and still uploads the drift-report artifact (generated first, so it survives a gate failure).

- **Why Engine B alone:** it's a single-pass enforce over the curated YAML source (strict canonical) + the products KG-Microbe consumes (SSSOM + docs CSV). It subsumes Engine A's YAML `ontology_label` coverage *and* adds ID_NOT_FOUND + product checks + the exceptions allow-list.
- **Why not Engine A in CI:** `validate-terms-all` spawns one `linkml-term-validator` process per record (~2k+) → far too slow for a gate. It stays a local LinkML-native cross-check.
- **Not in `qc`:** the gate loads the OAK sqlite ontologies (CHEBI ~3.7 GB); the dedicated workflow already caches them, while `qc` stays fast/OAK-free. The `qc` comment is updated to say so.

## Tests

Adds `tests/test_id_label_exceptions_conf.py` — guards that the 4 SCR exceptions stay declared on every gated target (CI-safe, no OAK). Full suite: **350 passed**.

Note: this PR touches `conf/id_label_targets.yaml` and the workflow, so the now-blocking `label-correspondence` job runs against itself here — green CI on this PR is the end-to-end proof of the Phase-2 gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
