### PR TITLE
Fix Engine-A obo-safe case bug (mesh skipped) + reconciler stale-predicate comments

### DIFF
--- a/scripts/_engine_a_obo_safe.sh
+++ b/scripts/_engine_a_obo_safe.sh
@@ -34,12 +34,17 @@ prefixes=$(
 # No ontology ids -> nothing for OAK to download -> safe to run Engine A.
 [ -z "$prefixes" ] && exit 0
 
-# Build a lookup of allowed prefixes (whitespace-separated).
+# Compare prefixes case-insensitively: the data carries lowercase `mesh:` while
+# the allowlist (and OAK's OBO CURIEs) use uppercase `MESH`, so a case-sensitive
+# `=` test silently classed every mesh record as UNSAFE and skipped Engine A for
+# it — Engine A never validated a single MeSH record despite MESH being in the
+# allowlist. nocasematch fixes `[[ ==  ]]` and works on bash 3.2 (macOS) too.
+shopt -s nocasematch
 while IFS= read -r p; do
     [ -z "$p" ] && continue
     found=1
     for a in $allowed; do
-        if [ "$p" = "$a" ]; then found=0; break; fi
+        if [[ "$p" == "$a" ]]; then found=0; break; fi
     done
     # An id whose prefix is NOT in the OBO allowlist would crash OAK -> unsafe.
     [ "$found" -ne 0 ] && exit 1

--- a/scripts/reconcile_sssom.py
+++ b/scripts/reconcile_sssom.py
@@ -145,15 +145,21 @@ def apply_reconcile(curated: dict, date: str) -> tuple[int, int]:
     expected = expected_mappings(curated)
     canonical_label = _canonical_label_resolver()
 
-    # Pass 1: per stale subject, record (old parent ontology_id -> new id) so we can
-    # also fix registry/identity rows whose comments embed the old parent id.
-    remap: dict[str, tuple[str, str]] = {}
+    # Pass 1: per stale subject, record (old id, new id, old predicate-local,
+    # new predicate-local) so we can also fix registry/identity rows whose
+    # comments embed the old parent id and/or its old predicate word (e.g.
+    # "...for narrowMatch subject ... parent mesh:Dxxx").
+    remap: dict[str, tuple[str, str, str, str]] = {}
     for r in rows:
         term = r["subject_label"]
         if term in expected and _is_ontology_row(r["object_id"]):
             new_id = expected[term]["ontology_id"]
             if r["object_id"] != new_id:
-                remap[term] = (r["object_id"], new_id)
+                old_pred = r["predicate_id"].split(":", 1)[-1]
+                new_pred = PREDICATE.get(
+                    expected[term].get("mapping_quality"), r["predicate_id"]
+                ).split(":", 1)[-1]
+                remap[term] = (r["object_id"], new_id, old_pred, new_pred)
 
     # Pass 2: rewrite.
     out, n_stale, n_orphan = [], 0, 0
@@ -167,7 +173,7 @@ def apply_reconcile(curated: dict, date: str) -> tuple[int, int]:
             n_orphan += 1  # orphan subject: drop all of its rows
             continue
         if term in remap:
-            old_id, new_id = remap[term]
+            old_id, new_id, old_pred, new_pred = remap[term]
             if _is_ontology_row(f[idx["object_id"]]) and f[idx["object_id"]] == old_id:
                 # The stale ontology row: sync to the current curated mapping.
                 om = expected[term]
@@ -182,10 +188,18 @@ def apply_reconcile(curated: dict, date: str) -> tuple[int, int]:
                 if "validation_method" in idx:
                     f[idx["validation_method"]] = f"manual:reconcile_sssom|REMAPPED|{date}"
                 n_stale += 1
-            elif "comment" in idx and old_id in f[idx["comment"]]:
-                # A registry/identity row whose comment still names the old parent:
-                # point it at the new parent so the file stays internally consistent.
-                f[idx["comment"]] = f[idx["comment"]].replace(old_id, new_id)
+            elif "comment" in idx and (
+                old_id in f[idx["comment"]]
+                or (old_pred != new_pred and old_pred in f[idx["comment"]])
+            ):
+                # A registry/identity row whose comment still names the old parent
+                # id and/or its old predicate word: update both so the file stays
+                # internally consistent (predicate names like narrowMatch/broadMatch
+                # are distinctive enough that a plain replace is safe).
+                c = f[idx["comment"]].replace(old_id, new_id)
+                if old_pred != new_pred:
+                    c = c.replace(old_pred, new_pred)
+                f[idx["comment"]] = c
         out.append("\t".join(f) + "\n")
 
     new_header = []

--- a/tests/test_engine_a_obo_safe.py
+++ b/tests/test_engine_a_obo_safe.py
@@ -1,0 +1,48 @@
+"""Tests for scripts/_engine_a_obo_safe.sh — the Engine-A OBO-safety gate.
+
+Exit 0 = SAFE (caller runs linkml-term-validator --labels); exit 1 = UNSAFE
+(non-OBO prefix would crash OAK, so the caller skips Engine A). Regression focus:
+prefix matching must be case-insensitive — the data carries lowercase `mesh:`
+while the allowlist uses uppercase `MESH`, and a case-sensitive test previously
+classed every mesh record as UNSAFE, so Engine A never validated a MeSH record.
+"""
+
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).parent.parent / "scripts" / "_engine_a_obo_safe.sh"
+ALLOWED = "CHEBI FOODON NCIT MESH UBERON ENVO BTO PATO"
+
+
+def _rc(tmp_path, content):
+    f = tmp_path / "r.yaml"
+    f.write_text(content)
+    return subprocess.run(["bash", str(SCRIPT), str(f), ALLOWED]).returncode
+
+
+def test_lowercase_mesh_is_safe(tmp_path):
+    # The bug: lowercase `mesh:` != uppercase `MESH` -> used to return 1 (skip).
+    assert _rc(tmp_path, "ontology_id: mesh:C016600\n") == 0
+
+
+def test_uppercase_obo_prefixes_are_safe(tmp_path):
+    assert _rc(tmp_path, "ontology_id: CHEBI:15377\n") == 0
+    assert _rc(tmp_path, "ontology_id: FOODON:03315720\n") == 0
+    assert _rc(tmp_path, "environment_term: ENVO:00002149\n") == 0
+
+
+def test_non_obo_prefixes_are_unsafe(tmp_path):
+    assert _rc(tmp_path, "ontology_id: cas:50-00-0\n") == 1
+    assert _rc(tmp_path, 'ontology_id: "kgmicrobe.compound:foo"\n') == 1
+    # MICRO is deliberately omitted from obo_prefixes (0-byte stub, no remote db),
+    # so a MICRO id is unsafe for Engine A -> deferred to Engine B.
+    assert _rc(tmp_path, "ontology_id: MICRO:0000114\n") == 1
+
+
+def test_mixed_obo_and_non_obo_is_unsafe(tmp_path):
+    # any non-OBO prefix in the file makes the whole file unsafe for Engine A
+    assert _rc(tmp_path, "ontology_id: mesh:C016600\nenvironment_term: cas:1-2-3\n") == 1
+
+
+def test_no_ontology_ids_is_safe(tmp_path):
+    assert _rc(tmp_path, "preferred_term: Foo ingredient\n") == 0

--- a/tests/test_reconcile_sssom.py
+++ b/tests/test_reconcile_sssom.py
@@ -111,9 +111,11 @@ def test_apply_remaps_mesh_parent_to_chebi(tmp_path, monkeypatch):
     assert onto["mapping_date"] == "2026-06-13"
     assert "REMAPPED" in onto["validation_method"]
     assert "reconciled to curated mapping" in onto["comment"]
-    # the registry/identity row's comment is repointed to the new parent
+    # the registry/identity row's comment is repointed to the new parent id AND
+    # its now-stale predicate word (narrowMatch -> broadMatch) is updated too
     ident = [r for r in parsed if r["object_id"] == "cas:1-1-1"][0]
     assert "CHEBI:28874" in ident["comment"] and "mesh:D013025" not in ident["comment"]
+    assert "broadMatch" in ident["comment"] and "narrowMatch" not in ident["comment"]
 
 
 # -- regression: obo→obo remap still works ----------------------------------


### PR DESCRIPTION
Two loose ends from the id↔label thread.

## 1. `_engine_a_obo_safe.sh` matched prefixes case-sensitively

The data carries lowercase `mesh:` while the obo allowlist (and OAK's OBO CURIEs) use uppercase `MESH`. The `[ "$p" = "$a" ]` test never matched, so `just validate-terms-all` **silently skipped every MeSH record** from Engine A — even though `MESH` is in `obo_prefixes` and `mesh.db` is resolvable. Fixed with `shopt -s nocasematch` + `[[ == ]]` (portable to macOS bash 3.2). Verified: `mesh:` now runs Engine A; `cas:` / `kgmicrobe.*` / `MICRO` still correctly skip (deferred to Engine B).

## 2. Reconciler left stale predicate words in registry-row comments

`reconcile_sssom.py --apply` repointed the old parent **id** in registry/identity-row comments but left the old **predicate word** (e.g. `...for narrowMatch subject` after a narrow→broad remap — exactly what happened to the soybean-PI row in #55, which I had to hand-edit). Pass 1 now also captures the old/new predicate-local names, and the comment fixer updates both.

## Tests
- `tests/test_engine_a_obo_safe.py` (first tests for the gate): lowercase `mesh:` is SAFE; non-OBO prefixes UNSAFE; mixed → UNSAFE; no-ids → SAFE.
- Extended the reconcile test to assert `narrowMatch → broadMatch` in the identity-row comment.
- `reconcile --check` on current `main` data still reports 0 drift. Full suite: 355 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)