### PR TITLE
Deep-research batch 1: enrich 3 unmapped records with resolved identities

### DIFF
--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -53,7 +53,23 @@ flavonoids, natural products, element placeholders, and mixtures.
   `mapped_ingredients.yaml`, regenerate both per-record dirs, **hand-add the SSSOM
   row(s)** (`reconcile_sssom` reports the GAP but won't synthesize new-row
   provenance), and regenerate docs. Budget for per-record curation, not a sweep.
-- A first batch is being run in `feat/deep-research-unmapped-batch`.
+- **Batch 1 done (2026-06-14, `feat/deep-research-unmapped-batch`)** — 3 records
+  deep-researched (Edison/PaperQA3) and **enriched in place** (synonyms / CAS-RN /
+  provenance; left UNMAPPED — no risky migration yet):
+  - `1-Naphtylacetic Acid` (UNMAPPED_0316) → identity resolved to **1-naphthaleneacetic
+    acid (NAA), CAS 86-87-3, CHEBI:32918** (a "naphtyl" misspelling string-matching
+    missed). **Ready to map** — CAS-RN added enables the CAS→CHEBI pipeline.
+  - `alpha-ketoglutamate` (UNMAPPED_0323) → resolved to alpha-ketoglutarate /
+    2-oxoglutarate; free acid **CHEBI:30915**, anion CHEBI:16810. Ready to map once
+    the acid-vs-anion form is chosen.
+  - `2-methyladeninyl cobamide` (UNMAPPED_0182) → **stays UNMAPPED, confirmed**: a
+    specific corrinoid ("Factor A") with no source-backed CHEBI/CAS; do NOT map to
+    cobalamin/B12. Validates the prior curator call; enriched with synonyms.
+  - Takeaway: deep research resolves identities that string-matching can't, but most
+    of the residual is genuinely hard. The 2 "ready to map" records still await the
+    multi-surface migration above. Edison reports live under `research/` (gitignored).
+  - Next batch candidates: the cobamide cluster (5-methoxy/5-methyl/adeninyl/
+    benzimidazolyl cobamide), `6-methylnicotinate`, `Amphotericin`, flavonoids.
 
 ## 4. mesh.db refresh → drop the 4 SCR exceptions (low priority)
 

--- a/data/curated/unmapped_ingredients.yaml
+++ b/data/curated/unmapped_ingredients.yaml
@@ -9,6 +9,15 @@ ingredients:
   - synonym_text: 1-Naphtylacetic Acid
     synonym_type: RAW_TEXT
     source: mim-queue
+  - synonym_text: 1-naphthaleneacetic acid
+    synonym_type: SYSTEMATIC_NAME
+    source: edison_deep_research
+  - synonym_text: 1-naphthylacetic acid
+    synonym_type: EXACT_SYNONYM
+    source: edison_deep_research
+  - synonym_text: NAA
+    synonym_type: ABBREVIATION
+    source: edison_deep_research
   mapping_status: UNMAPPED
   occurrence_statistics:
     total_occurrences: 0
@@ -30,9 +39,23 @@ ingredients:
     previous_status: UNMAPPED
     new_status: UNMAPPED
     llm_assisted: true
-  notes: Imported from mim-queue (source_id=mediadive.ingredient:2436); no CAS-RN
-    or CHEBI/NCIT match. Reviewed on 2026-05-11; retained as unmapped pending exact
-    spelling and identity evidence.
+  - timestamp: '2026-06-14T00:00:00+00:00'
+    curator: deep-research-ingredient-edison
+    action: RESEARCHED_IDENTITY
+    changes: 'Edison/PaperQA3 deep research resolved the source spelling: "1-Naphtylacetic
+      Acid" is 1-naphthaleneacetic acid (NAA), CAS-RN 86-87-3 (CHEBI:32918) — the
+      blocker flagged in the 2026-05-11 review (unverified spelling) is cleared.
+      Identity-resolved; ontology mapping deferred pending unmapped→mapped migration.'
+    new_status: UNMAPPED
+    llm_assisted: true
+  chemical_properties:
+    cas_rn: 86-87-3
+    data_source: Edison/PaperQA3 deep research (janikova2020; henneberger; donnelly1990)
+    retrieval_date: '2026-06-14T00:00:00+00:00'
+  notes: Imported from mim-queue (source_id=mediadive.ingredient:2436). Identity
+    resolved 2026-06-14 to 1-naphthaleneacetic acid (NAA, CAS 86-87-3, CHEBI:32918)
+    via Edison deep research; a misspelling of "naphthyl". Ready to map pending the
+    unmapped→mapped migration.
   ingredient_type: SINGLE_INGREDIENT
 - identifier: UNMAPPED_0196
   preferred_term: 2-Carene-3-One
@@ -70,6 +93,18 @@ ingredients:
   - synonym_text: 2-methyladeninyl cobamide
     synonym_type: RAW_TEXT
     source: culturebotht
+  - synonym_text: 2-methyladeninylcobamide
+    synonym_type: EXACT_SYNONYM
+    source: edison_deep_research
+  - synonym_text: '[2-MeAde]Cba'
+    synonym_type: ABBREVIATION
+    source: edison_deep_research
+  - synonym_text: Factor A
+    synonym_type: COMMON_NAME
+    source: edison_deep_research
+  - synonym_text: Co-cyano-(2-methyladenin-7-yl)cobamide
+    synonym_type: SYSTEMATIC_NAME
+    source: edison_deep_research
   mapping_status: UNMAPPED
   occurrence_statistics:
     total_occurrences: 0
@@ -89,6 +124,17 @@ ingredients:
       no exact local ontology identity for the 2-methyladeninyl lower-ligand variant
       was verified.
     previous_status: UNMAPPED
+    new_status: UNMAPPED
+    llm_assisted: true
+  - timestamp: '2026-06-14T00:00:00+00:00'
+    curator: deep-research-ingredient-edison
+    action: RESEARCHED_IDENTITY
+    changes: 'Edison/PaperQA3 deep research (8 citations) confirms this is a specific
+      cobamide corrinoid with lower ligand = 2-methyladenine (legacy name "Factor A",
+      cyano form Co-cyano-(2-methyladenin-7-yl)cobamide, CCDC:217275). No source-backed
+      CHEBI/CAS identifier exists, and the generic label is upper-ligand-ambiguous —
+      KEEP UNMAPPED (do NOT map to cobalamin/B12: different lower ligand). Enriched
+      with source-backed synonyms.'
     new_status: UNMAPPED
     llm_assisted: true
   notes: Imported from CultureBotHT (compounds_to_cas.csv (no CAS-RN)). No CAS-RN
@@ -718,6 +764,18 @@ ingredients:
   - synonym_text: alpha-ketoglutamate
     synonym_type: RAW_TEXT
     source: mim-queue
+  - synonym_text: alpha-ketoglutarate
+    synonym_type: EXACT_SYNONYM
+    source: edison_deep_research
+  - synonym_text: 2-oxoglutarate
+    synonym_type: SYSTEMATIC_NAME
+    source: edison_deep_research
+  - synonym_text: 2-oxoglutaric acid
+    synonym_type: SYSTEMATIC_NAME
+    source: edison_deep_research
+  - synonym_text: 2-oxopentanedioic acid
+    synonym_type: SYSTEMATIC_NAME
+    source: edison_deep_research
   mapping_status: UNMAPPED
   occurrence_statistics:
     total_occurrences: 0
@@ -738,6 +796,18 @@ ingredients:
       because alpha-ketoglutamate appears to be a source spelling ambiguity and is
       not safely identical to the existing local identities.
     previous_status: UNMAPPED
+    new_status: UNMAPPED
+    llm_assisted: true
+  - timestamp: '2026-06-14T00:00:00+00:00'
+    curator: deep-research-ingredient-edison
+    action: RESEARCHED_IDENTITY
+    changes: 'Edison/PaperQA3 deep research (9 citations) resolves the lexical
+      ambiguity: "alpha-ketoglutamate" is a nonstandard spelling of alpha-ketoglutarate
+      = 2-oxoglutarate (2-oxopentanedioic acid), NOT alpha-ketoglutamic acid
+      (MESH:C088956). Free-acid form is CHEBI:30915 "2-oxoglutaric acid"; the
+      conjugate base 2-oxoglutarate(2-) is CHEBI:16810. Identity resolved to the
+      2-oxoglutarate species; ontology mapping deferred pending the acid-vs-anion
+      form decision + unmapped→mapped migration.'
     new_status: UNMAPPED
     llm_assisted: true
   notes: Imported from mim-queue (source_id=mediadive.ingredient:2384); no CAS-RN

--- a/data/ingredients/unmapped/1-Naphtylacetic_Acid.yaml
+++ b/data/ingredients/unmapped/1-Naphtylacetic_Acid.yaml
@@ -4,6 +4,15 @@ synonyms:
 - synonym_text: 1-Naphtylacetic Acid
   synonym_type: RAW_TEXT
   source: mim-queue
+- synonym_text: 1-naphthaleneacetic acid
+  synonym_type: SYSTEMATIC_NAME
+  source: edison_deep_research
+- synonym_text: 1-naphthylacetic acid
+  synonym_type: EXACT_SYNONYM
+  source: edison_deep_research
+- synonym_text: NAA
+  synonym_type: ABBREVIATION
+  source: edison_deep_research
 mapping_status: UNMAPPED
 occurrence_statistics:
   total_occurrences: 0
@@ -25,7 +34,21 @@ curation_history:
   previous_status: UNMAPPED
   new_status: UNMAPPED
   llm_assisted: true
-notes: Imported from mim-queue (source_id=mediadive.ingredient:2436); no CAS-RN or
-  CHEBI/NCIT match. Reviewed on 2026-05-11; retained as unmapped pending exact spelling
-  and identity evidence.
+- timestamp: '2026-06-14T00:00:00+00:00'
+  curator: deep-research-ingredient-edison
+  action: RESEARCHED_IDENTITY
+  changes: 'Edison/PaperQA3 deep research resolved the source spelling: "1-Naphtylacetic
+    Acid" is 1-naphthaleneacetic acid (NAA), CAS-RN 86-87-3 (CHEBI:32918) — the blocker
+    flagged in the 2026-05-11 review (unverified spelling) is cleared. Identity-resolved;
+    ontology mapping deferred pending unmapped→mapped migration.'
+  new_status: UNMAPPED
+  llm_assisted: true
+chemical_properties:
+  cas_rn: 86-87-3
+  data_source: Edison/PaperQA3 deep research (janikova2020; henneberger; donnelly1990)
+  retrieval_date: '2026-06-14T00:00:00+00:00'
+notes: Imported from mim-queue (source_id=mediadive.ingredient:2436). Identity resolved
+  2026-06-14 to 1-naphthaleneacetic acid (NAA, CAS 86-87-3, CHEBI:32918) via Edison
+  deep research; a misspelling of "naphthyl". Ready to map pending the unmapped→mapped
+  migration.
 ingredient_type: SINGLE_INGREDIENT

--- a/data/ingredients/unmapped/2-methyladeninyl_Cobamide.yaml
+++ b/data/ingredients/unmapped/2-methyladeninyl_Cobamide.yaml
@@ -4,6 +4,18 @@ synonyms:
 - synonym_text: 2-methyladeninyl cobamide
   synonym_type: RAW_TEXT
   source: culturebotht
+- synonym_text: 2-methyladeninylcobamide
+  synonym_type: EXACT_SYNONYM
+  source: edison_deep_research
+- synonym_text: '[2-MeAde]Cba'
+  synonym_type: ABBREVIATION
+  source: edison_deep_research
+- synonym_text: Factor A
+  synonym_type: COMMON_NAME
+  source: edison_deep_research
+- synonym_text: Co-cyano-(2-methyladenin-7-yl)cobamide
+  synonym_type: SYSTEMATIC_NAME
+  source: edison_deep_research
 mapping_status: UNMAPPED
 occurrence_statistics:
   total_occurrences: 0
@@ -23,6 +35,17 @@ curation_history:
     no exact local ontology identity for the 2-methyladeninyl lower-ligand variant
     was verified.
   previous_status: UNMAPPED
+  new_status: UNMAPPED
+  llm_assisted: true
+- timestamp: '2026-06-14T00:00:00+00:00'
+  curator: deep-research-ingredient-edison
+  action: RESEARCHED_IDENTITY
+  changes: 'Edison/PaperQA3 deep research (8 citations) confirms this is a specific
+    cobamide corrinoid with lower ligand = 2-methyladenine (legacy name "Factor A",
+    cyano form Co-cyano-(2-methyladenin-7-yl)cobamide, CCDC:217275). No source-backed
+    CHEBI/CAS identifier exists, and the generic label is upper-ligand-ambiguous —
+    KEEP UNMAPPED (do NOT map to cobalamin/B12: different lower ligand). Enriched
+    with source-backed synonyms.'
   new_status: UNMAPPED
   llm_assisted: true
 notes: Imported from CultureBotHT (compounds_to_cas.csv (no CAS-RN)). No CAS-RN or

--- a/data/ingredients/unmapped/Alpha-ketoglutamate.yaml
+++ b/data/ingredients/unmapped/Alpha-ketoglutamate.yaml
@@ -4,6 +4,18 @@ synonyms:
 - synonym_text: alpha-ketoglutamate
   synonym_type: RAW_TEXT
   source: mim-queue
+- synonym_text: alpha-ketoglutarate
+  synonym_type: EXACT_SYNONYM
+  source: edison_deep_research
+- synonym_text: 2-oxoglutarate
+  synonym_type: SYSTEMATIC_NAME
+  source: edison_deep_research
+- synonym_text: 2-oxoglutaric acid
+  synonym_type: SYSTEMATIC_NAME
+  source: edison_deep_research
+- synonym_text: 2-oxopentanedioic acid
+  synonym_type: SYSTEMATIC_NAME
+  source: edison_deep_research
 mapping_status: UNMAPPED
 occurrence_statistics:
   total_occurrences: 0
@@ -24,6 +36,17 @@ curation_history:
     alpha-ketoglutamate appears to be a source spelling ambiguity and is not safely
     identical to the existing local identities.
   previous_status: UNMAPPED
+  new_status: UNMAPPED
+  llm_assisted: true
+- timestamp: '2026-06-14T00:00:00+00:00'
+  curator: deep-research-ingredient-edison
+  action: RESEARCHED_IDENTITY
+  changes: 'Edison/PaperQA3 deep research (9 citations) resolves the lexical ambiguity:
+    "alpha-ketoglutamate" is a nonstandard spelling of alpha-ketoglutarate = 2-oxoglutarate
+    (2-oxopentanedioic acid), NOT alpha-ketoglutamic acid (MESH:C088956). Free-acid
+    form is CHEBI:30915 "2-oxoglutaric acid"; the conjugate base 2-oxoglutarate(2-)
+    is CHEBI:16810. Identity resolved to the 2-oxoglutarate species; ontology mapping
+    deferred pending the acid-vs-anion form decision + unmapped→mapped migration.'
   new_status: UNMAPPED
   llm_assisted: true
 notes: Imported from mim-queue (source_id=mediadive.ingredient:2384); no CAS-RN or


### PR DESCRIPTION
## Summary

First batch of the hard-unmapped curation effort (NEXT_TASKS #3). Ran the `deep-research-ingredient` skill (Edison/PaperQA3, ~\$0 reported) on 3 records that string-matching couldn't resolve, and applied the **safe, source-backed enrichments in place** — synonyms / CAS-RN / provenance, all **left UNMAPPED** (no risky `unmapped→mapped` migration in this pass; that's the documented multi-surface follow-up).

| Record | Research outcome | Applied |
|---|---|---|
| **1-Naphtylacetic Acid** (UNMAPPED_0316) | Misspelling of **1-naphthaleneacetic acid (NAA)**, **CAS 86-87-3**, **CHEBI:32918** (verified locally). Clears the prior review's "unverified spelling" blocker. | `cas_rn: 86-87-3` + synonyms (NAA, 1-naphthylacetic acid, 1-naphthaleneacetic acid). **Ready to map.** |
| **alpha-ketoglutamate** (UNMAPPED_0323) | Nonstandard spelling of **α-ketoglutarate / 2-oxoglutarate** — *not* ketoglutamic acid (MESH:C088956). Free acid **CHEBI:30915**, anion CHEBI:16810. | Synonyms (2-oxoglutarate, 2-oxoglutaric acid, …). Ready to map once acid-vs-anion form chosen. |
| **2-methyladeninyl cobamide** (UNMAPPED_0182) | A specific corrinoid ("**Factor A**", Co-cyano-(2-methyladenin-7-yl)cobamide, CCDC:217275). **No source-backed CHEBI/CAS exists**; must NOT map to cobalamin/B12 (different lower ligand). | Synonyms (Factor A, [2-MeAde]Cba, …). **Confirmed KEEP UNMAPPED** — validates the prior curator call. |

Each record gets a `RESEARCHED_IDENTITY` `curation_history` entry citing the Edison run. The full Edison reports (answer + citations + agent trace) live under `research/` (gitignored — local audit trail).

**Takeaway:** deep research resolves identities that exact/fuzzy matching can't (the NAA misspelling; the ketoglutarate-vs-glutamate ambiguity), but much of the residual is genuinely hard — and a confirmed-unmapped result (the cobamide) is itself a useful, defensible curation outcome. Adding the CAS-RN to NAA is the key enabling step: the repo's CAS→CHEBI pipeline can finish that mapping cleanly later.

## Why no mapping applied here

Per the skill's design, the research skill produces curator-review artifacts; applying a mapping is a separate step. And mapping an unmapped record is a multi-surface migration the tooling only partly automates (collection move + per-record regen + **hand-added SSSOM row** since `reconcile_sssom` won't synthesize new-row provenance + docs). The 2 "ready to map" records are flagged in `NEXT_TASKS.md` for that follow-up.

## Testing

- Counts unchanged (all 3 still UNMAPPED); `validate-strict`: 0 errors over 2274 files; full suite: **355 passed**.
- Source collection edited; per-record files regenerated.

Also adds **`NEXT_TASKS.md`** — the deferred backlog (chemical-properties enrichment of 89 CHEBI records, cross-Mech validator pin scope, this unmapped-curation effort, mesh.db refresh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)