### PR TITLE
Repair chemical-properties enricher (OLS4 key drift) + gap-fill missing formula

### DIFF
--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -7,23 +7,28 @@ deferrals here. Keep the cross-Mech items in sync with the sibling repos'
 
 Last reconciled: 2026-06-14.
 
-## 1. Chemical-properties enrichment (89 CHEBI records missing `molecular_formula`)
+## 1. Chemical-properties enrichment — enricher repaired, residual is the ceiling
 
-89 CHEBI-mapped records have no `molecular_formula` (and likely no SMILES/InChI).
-Run the existing enricher to backfill from ChEBI OLS4 + PubChem:
+**Done (2026-06-15, `feat/enrich-chemical-properties`)** — the enricher had silently
+broken: OLS4 renamed its annotation keys (`formula` → `generalized_empirical_formula`;
+SMILES/InChI → `*_string`), so every fetch returned None. Fixed
+`chemical_properties_client.py` to read the current keys (legacy fallback kept),
+broadened the enricher to target records *missing `molecular_formula`* (not just
+those with no `chemical_properties` block) with a gap-filling **merge** (never
+clobbers `cas_rn`), and made the `Enriched` counter report net changes. Re-ran:
+**3 records gained formula/SMILES** (diaminopimelic acid, sodium L-lactate,
+isobutyramide+mass).
 
-```bash
-python scripts/enrich_chemical_properties.py        # auto-fetches formula/SMILES/InChI
-```
+The remaining ~83 missing-formula records are the **genuine ceiling** — abstract
+CHEBI classes (aromatic compound, bile salt, hydrocarbon), polymers (glycogen,
+carboxymethylcellulose, chondroitin sulfate, DNA), proteins (elastin, LL-37),
+complexes (kanamycin), and minerals (ferrihydrite) — which legitimately have no
+single empirical formula in ChEBI. Not failures; leave them.
 
-- Source of truth is `data/curated/mapped_ingredients.yaml`; regenerate per-record
-  files with `just export-individual` after.
-- Watch the known ceiling: abstract CHEBI classes (e.g. "phosphatidylinositol",
-  added in #55), polymers, proteins, and obsolete terms legitimately have no
-  formula — don't treat those as failures.
-- Gotcha (fixed before, keep an eye out): OLS4 needs **double** URL-encoding of
-  ChEBI IRIs; obsolete terms return the IRI fragment as `label`.
-- Find them: `grep -rL molecular_formula data/ingredients/mapped/*.yaml | xargs grep -l 'ontology_source: CHEBI'`
+- Run again any time with `python scripts/enrich_chemical_properties.py` (idempotent);
+  regenerate per-record files with `just export-individual` after.
+- Gotcha still live: OLS4 needs **double** URL-encoding of ChEBI IRIs (handled).
+- Find remaining: `grep -rL molecular_formula data/ingredients/mapped/*.yaml | xargs grep -l 'ontology_source: CHEBI'`
 
 ## 2. Cross-Mech validator pin guard covers only the .py (cross-repo)
 

--- a/data/ingredients/mapped/Diaminopimelic_Acid.yaml
+++ b/data/ingredients/mapped/Diaminopimelic_Acid.yaml
@@ -51,6 +51,10 @@ chemical_properties:
   cas_rn: 583-93-7
   data_source: PubChem API
   retrieval_date: '2026-04-05T19:51:49.581961+00:00'
+  molecular_formula: C7H14N2O4
+  smiles: NC(CCCC(N)C(=O)O)C(=O)O
+  inchi: InChI=1S/C7H14N2O4/c8-4(6(10)11)2-1-3-5(9)7(12)13/h4-5H,1-3,8-9H2,(H,10,11)(H,12,13)
+  molecular_weight: 190.199
 ingredient_type: SINGLE_INGREDIENT
 media_roles:
 - role: AMINO_ACID_SOURCE

--- a/data/ingredients/mapped/Isobutyramide.yaml
+++ b/data/ingredients/mapped/Isobutyramide.yaml
@@ -42,3 +42,5 @@ chemical_properties:
   inchi: InChI=1S/C4H9NO/c1-3(2)4(5)6/h3H,1-2H3,(H2,5,6)
   smiles: CC(C)C(N)=O
   data_source: CHEBI sqlite (oaklib)
+  molecular_weight: 87.12
+  retrieval_date: '2026-06-15T03:55:13.171366+00:00'

--- a/data/ingredients/mapped/Sodium_L-lactate.yaml
+++ b/data/ingredients/mapped/Sodium_L-lactate.yaml
@@ -73,6 +73,10 @@ chemical_properties:
   cas_rn: 867-56-1
   data_source: CultureBotHT compounds_to_cas.csv
   retrieval_date: '2026-04-05T21:48:45.780434+00:00'
+  molecular_formula: C3H5O3.Na
+  smiles: '[H][C@@](C)(O)C(=O)[O-].[Na+]'
+  inchi: InChI=1S/C3H6O3.Na/c1-2(4)3(5)6;/h2,4H,1H3,(H,5,6);/q;+1/p-1/t2-;/m0./s1
+  molecular_weight: 112.06
 kg_microbe_node_id: CHEBI:867561
 ingredient_type: SINGLE_INGREDIENT
 media_roles:

--- a/scripts/enrich_chemical_properties.py
+++ b/scripts/enrich_chemical_properties.py
@@ -55,8 +55,10 @@ def filter_chebi_without_properties(data: dict) -> list[dict]:
 
     candidates = []
     for record in records:
-        # Check if already has chemical_properties
-        if record.get("chemical_properties"):
+        # Target records still missing a molecular_formula — including those that
+        # already carry a partial chemical_properties block (e.g. a cas_rn but no
+        # formula). The apply step MERGES (fills gaps), so existing fields are kept.
+        if (record.get("chemical_properties") or {}).get("molecular_formula"):
             continue
 
         # Check if mapped to CHEBI
@@ -179,9 +181,21 @@ def main(
             # Get properties
             props = client.get_properties(ontology_id, label, source)
 
+            # MERGE into any existing chemical_properties: fill gaps only, so a
+            # record's existing cas_rn / data_source is never clobbered when we
+            # add the freshly-fetched molecular_formula / SMILES / InChI / mass.
+            # `enriched` counts only records that GAINED a field (props can come
+            # back with only fields the record already has — that is a no-op, not
+            # an enrichment, so it must not inflate the count).
+            added = []
             if props:
-                # Add to record
-                record["chemical_properties"] = props.to_dict()
+                existing = record.get("chemical_properties") or {}
+                for key, value in props.to_dict().items():
+                    if value and not existing.get(key):
+                        existing[key] = value
+                        added.append(key)
+                record["chemical_properties"] = existing
+            if added:
                 enriched_count += 1
                 results.append(
                     {

--- a/src/mediaingredientmech/utils/chemical_properties_client.py
+++ b/src/mediaingredientmech/utils/chemical_properties_client.py
@@ -150,29 +150,38 @@ class ChemicalPropertiesClient:
 
             data = response.json()
 
-            # Extract annotation fields
+            # Extract annotation fields. OLS4 renamed the chemical-property keys —
+            # formula -> generalized_empirical_formula, and SMILES/InChI are now
+            # *_string (smiles_string / inchi_string) — and dropped the legacy
+            # `formula` key entirely, which silently broke formula/SMILES/InChI
+            # enrichment. Read the current names first, falling back to the legacy
+            # ones for resilience. (Abstract classes / polymers carry none of these,
+            # which is the expected "no formula" ceiling, not a failure.)
             annotation = data.get("annotation", {})
-            formula = None
+
+            def _first(*keys):
+                for k in keys:
+                    vals = annotation.get(k)
+                    if vals:
+                        return vals[0]
+                return None
+
+            formula = _first("generalized_empirical_formula", "formula", "has_molecular_formula")
+            smiles = _first("smiles_string", "smiles", "SMILES")
+            inchi = _first("inchi_string", "inchi", "InChI")
             molecular_weight = None
+            mass = _first("mass")
+            if mass is not None:
+                try:
+                    molecular_weight = float(mass)
+                except (ValueError, TypeError):
+                    pass
 
-            # Look for formula in annotation
-            if "formula" in annotation:
-                formula_list = annotation["formula"]
-                if formula_list and len(formula_list) > 0:
-                    formula = formula_list[0]
-
-            # Look for mass/molecular weight
-            if "mass" in annotation:
-                mass_list = annotation["mass"]
-                if mass_list and len(mass_list) > 0:
-                    try:
-                        molecular_weight = float(mass_list[0])
-                    except (ValueError, TypeError):
-                        pass
-
-            if formula or molecular_weight:
+            if formula or smiles or inchi or molecular_weight:
                 return ChemicalProperties(
                     molecular_formula=formula,
+                    smiles=smiles,
+                    inchi=inchi,
                     molecular_weight=molecular_weight,
                     data_source="ChEBI",
                     retrieval_date=datetime.now(timezone.utc).isoformat(),

--- a/tests/test_chemical_properties_client.py
+++ b/tests/test_chemical_properties_client.py
@@ -1,0 +1,78 @@
+"""Tests for ChemicalPropertiesClient's OLS4 response parsing.
+
+Regression: OLS4 renamed its chemical-property annotation keys
+(formula -> generalized_empirical_formula; SMILES/InChI -> *_string) and dropped
+the legacy `formula` key, which silently broke formula/SMILES/InChI enrichment
+(every fetch returned None). These pin the current keys, the legacy fallback, and
+the formula-less ceiling. `requests.get` is monkeypatched — CI-safe, no network.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+from mediaingredientmech.utils import chemical_properties_client as mod  # noqa: E402
+
+
+class _FakeResp:
+    def __init__(self, payload, status=200):
+        self._p, self.status_code = payload, status
+        self.ok = status == 200
+
+    def json(self):
+        return self._p
+
+    def raise_for_status(self):
+        if not self.ok:
+            raise mod.requests.HTTPError(str(self.status_code))
+
+
+def _patch(monkeypatch, ols_payload, ols_status=200):
+    """Route OLS4 calls to ols_payload; make every PubChem call a clean miss."""
+    def fake_get(url, timeout=10, **kw):
+        if "ols4" in url:
+            return _FakeResp(ols_payload, ols_status)
+        return _FakeResp({}, 404)  # PubChem fallback returns nothing
+    monkeypatch.setattr(mod.requests, "get", fake_get)
+    return mod.ChemicalPropertiesClient(cache_enabled=False)
+
+
+CURRENT_KEYS = {
+    "annotation": {
+        "generalized_empirical_formula": ["C6H12O6"],
+        "mass": ["180.156"],
+        "smiles_string": ["OC[C@H]1OC(O)[C@H](O)[C@@H](O)[C@@H]1O"],
+        "inchi_string": ["InChI=1S/C6H12O6/c7-1-2-3(8)4(9)5(10)6(11)12-2/h2-11H,1H2"],
+    }
+}
+
+
+def test_parses_current_ols4_keys(monkeypatch):
+    c = _patch(monkeypatch, CURRENT_KEYS)
+    p = c.get_properties("CHEBI:17234", "glucose", "CHEBI")
+    assert p is not None
+    assert p.molecular_formula == "C6H12O6"
+    assert p.smiles.startswith("OC[C@H]")
+    assert p.inchi.startswith("InChI=1S/C6H12O6")
+    assert abs(p.molecular_weight - 180.156) < 0.01
+
+
+def test_legacy_formula_key_still_works(monkeypatch):
+    # resilience: if OLS4 ever serves the old `formula` key again, still parse it
+    c = _patch(monkeypatch, {"annotation": {"formula": ["NaCl"], "mass": ["58.44"]}})
+    p = c.get_properties("CHEBI:26710", "sodium chloride", "CHEBI")
+    assert p is not None and p.molecular_formula == "NaCl"
+
+
+def test_no_chem_keys_returns_none(monkeypatch):
+    # abstract class / polymer: no formula/smiles/inchi/mass -> None (the ceiling,
+    # not a failure). This is what kept the 75 class/polymer targets unenriched.
+    c = _patch(monkeypatch, {"annotation": {"has_obo_namespace": ["chebi_ontology"], "id": ["CHEBI:33655"]}})
+    assert c.get_properties("CHEBI:33655", "aromatic compound", "CHEBI") is None
+
+
+def test_non_chebi_source_skipped(monkeypatch):
+    c = _patch(monkeypatch, CURRENT_KEYS)
+    assert c.get_properties("FOODON:03411448", "yeast extract", "FOODON") is None


### PR DESCRIPTION
## Summary

The chemical-properties enricher had **silently broken**: OLS4 renamed its annotation keys, so every fetch returned `None` (the last run reported Enriched 0 / Failed 23, which looked like "nothing left to enrich" but was actually a total fetch failure). Fixed the API drift, broadened the enricher to fill partial records, and added tests.

## Root cause

`chemical_properties_client.py` read `annotation["formula"]`, but OLS4 now serves:
- `generalized_empirical_formula` (was `formula` — **dropped entirely**)
- `smiles_string` / `inchi_string` (the client never read SMILES/InChI from OLS4 at all — it relied on a PubChem-by-CHEBI-name path that also fails)
- `mass` (still works)

Verified live: glucose returns `generalized_empirical_formula: [C6H12O6]`, but the client found nothing under `formula`.

## Fixes

- **Client:** read the current OLS4 keys (legacy names kept as fallback), and populate `molecular_formula` / `smiles` / `inchi` / `molecular_weight` directly from OLS4.
- **Enricher:** target records *missing `molecular_formula`* (not just those with no `chemical_properties` block — that missed ~66 records carrying a `cas_rn` but no formula), and apply as a **gap-filling merge** so existing `cas_rn` / `data_source` is never clobbered. The `Enriched` counter now reports net changes, not raw fetch hits.
- **Tests:** `tests/test_chemical_properties_client.py` (monkeypatched `requests` — CI-safe) pins the current keys, the legacy fallback, and the formula-less ceiling.

## Result

Re-ran the enricher (idempotent — a second run changes 0 records):
- **3 records gained chemistry:** diaminopimelic acid (`C7H14N2O4` + SMILES + mass), sodium L-lactate (`C3H5O3.Na` + SMILES + mass), isobutyramide (+ mass).
- The remaining **~83** missing-formula records are the **genuine ceiling** — abstract CHEBI classes (aromatic compound, bile salt, hydrocarbon), polymers (glycogen, carboxymethylcellulose, chondroitin sulfate, DNA), proteins (elastin, LL-37), complexes (kanamycin), minerals (ferrihydrite). No single empirical formula exists for these in ChEBI; correctly skipped.

## Safety

- **No deletions**; all **1465 `cas_rn`** values preserved (verified before/after).
- `validate-strict` clean; full suite **359 passed** (4 new client tests).
- Source collection edited; 3 per-record files regenerated.

Updates `NEXT_TASKS.md` item 1 (enricher repaired; residual documented as the ceiling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)