### PR TITLE
Synonym-review enrichment: +2 canonical CHEBI exact-synonyms

### DIFF
--- a/data/ingredients/mapped/1-naphtylacetic_Acid.yaml
+++ b/data/ingredients/mapped/1-naphtylacetic_Acid.yaml
@@ -21,6 +21,9 @@ synonyms:
 - synonym_text: NAA
   synonym_type: ABBREVIATION
   source: edison_deep_research
+- synonym_text: naphthalen-1-ylacetic acid
+  synonym_type: EXACT_SYNONYM
+  source: chebi_synonym_review
 mapping_status: MAPPED
 occurrence_statistics:
   total_occurrences: 0

--- a/data/ingredients/mapped/Diaminopimelic_Acid.yaml
+++ b/data/ingredients/mapped/Diaminopimelic_Acid.yaml
@@ -9,7 +9,10 @@ ontology_mapping:
   - evidence_type: DATABASE_MATCH
     source: CultureMech
     notes: Imported from CultureMech pipeline, quality=DIRECT_MATCH
-synonyms: []
+synonyms:
+- synonym_text: 2,6-diaminoheptanedioic acid
+  synonym_type: EXACT_SYNONYM
+  source: chebi_synonym_review
 mapping_status: MAPPED
 occurrence_statistics:
   total_occurrences: 4


### PR DESCRIPTION
From the synonym-review cross-check of this session's CHEBI-mapped changes (labels all canonical, synonyms all CHEBI-consistent), the only two missing CHEBI exact-synonyms worth adding:

- `CHEBI:32918` (1-Naphtylacetic Acid / NAA) → **`naphthalen-1-ylacetic acid`**
- `CHEBI:23673` (Diaminopimelic acid) → **`2,6-diaminoheptanedioic acid`**

The third reviewed candidate (`sodium;(2S)-2-hydroxypropanoate` for `CHEBI:232798`) is **already present** on the survivor record — the cross-check had matched the dead-id tombstone, which doesn't need it. Skipped.

`validate-strict`: 0 errors; full suite **359 passed**. Synonyms don't affect the id↔label gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)