### PR TITLE
Drop 'autoclaved' process-word stored as a synonym (7 records)

### DIFF
--- a/data/curated/unmapped_ingredients.yaml
+++ b/data/curated/unmapped_ingredients.yaml
@@ -76,10 +76,10 @@ ingredients:
     curator: deep-research-ingredient-edison
     action: RESEARCHED_IDENTITY
     changes: 'Edison/PaperQA3 deep research (8 citations) confirms this is a specific
-      cobamide corrinoid with lower ligand = 2-methyladenine (legacy name "Factor A",
-      cyano form Co-cyano-(2-methyladenin-7-yl)cobamide, CCDC:217275). No source-backed
-      CHEBI/CAS identifier exists, and the generic label is upper-ligand-ambiguous —
-      KEEP UNMAPPED (do NOT map to cobalamin/B12: different lower ligand). Enriched
+      cobamide corrinoid with lower ligand = 2-methyladenine (legacy name "Factor
+      A", cyano form Co-cyano-(2-methyladenin-7-yl)cobamide, CCDC:217275). No source-backed
+      CHEBI/CAS identifier exists, and the generic label is upper-ligand-ambiguous
+      — KEEP UNMAPPED (do NOT map to cobalamin/B12: different lower ligand). Enriched
       with source-backed synonyms.'
     new_status: UNMAPPED
     llm_assisted: true
@@ -1003,10 +1003,7 @@ ingredients:
   ingredient_type: UNDEFINED_MIXTURE
 - identifier: UNMAPPED_0235
   preferred_term: B-glucan from yeast
-  synonyms:
-  - synonym_text: autoclaved
-    synonym_type: RAW_TEXT
-    source: culturebotht
+  synonyms: []
   mapping_status: UNMAPPED
   occurrence_statistics:
     total_occurrences: 0
@@ -2257,10 +2254,7 @@ ingredients:
   solution_type: OTHER
 - identifier: UNMAPPED_0248
   preferred_term: Chitin from shrimp shells
-  synonyms:
-  - synonym_text: autoclaved
-    synonym_type: RAW_TEXT
-    source: culturebotht
+  synonyms: []
   mapping_status: UNMAPPED
   occurrence_statistics:
     total_occurrences: 0
@@ -3234,9 +3228,6 @@ ingredients:
   preferred_term: dextran, Mw ~200,000
   synonyms:
   - synonym_text: filtered, dextran, Mw ~200,000
-    synonym_type: RAW_TEXT
-    source: culturebotht
-  - synonym_text: autoclaved
     synonym_type: RAW_TEXT
     source: culturebotht
   mapping_status: UNMAPPED
@@ -8589,9 +8580,6 @@ ingredients:
   - synonym_text: filtered, Pectic galactan from potato
     synonym_type: RAW_TEXT
     source: culturebotht
-  - synonym_text: autoclaved
-    synonym_type: RAW_TEXT
-    source: culturebotht
   mapping_status: UNMAPPED
   occurrence_statistics:
     total_occurrences: 1
@@ -9302,10 +9290,7 @@ ingredients:
   ingredient_type: UNDEFINED_MIXTURE
 - identifier: UNMAPPED_0175
   preferred_term: Rhamnogalacturonan - from potato
-  synonyms:
-  - synonym_text: autoclaved
-    synonym_type: RAW_TEXT
-    source: culturebotht
+  synonyms: []
   mapping_status: UNMAPPED
   occurrence_statistics:
     total_occurrences: 0

--- a/data/ingredients/mapped/Arabinoxylan_Rye_Flour.yaml
+++ b/data/ingredients/mapped/Arabinoxylan_Rye_Flour.yaml
@@ -1,9 +1,6 @@
 identifier: FOODON:03302492
 preferred_term: Arabinoxylan (Rye Flour)
-synonyms:
-- synonym_text: autoclaved
-  synonym_type: RAW_TEXT
-  source: culturebotht
+synonyms: []
 mapping_status: MAPPED
 occurrence_statistics:
   total_occurrences: 0

--- a/data/ingredients/mapped/Mucin_From_Porcine_Stomach_Type_III.yaml
+++ b/data/ingredients/mapped/Mucin_From_Porcine_Stomach_Type_III.yaml
@@ -17,9 +17,6 @@ synonyms:
     Mucin from porcine stomach type III
   synonym_type: EXACT_SYNONYM
   source: culturebotht
-- synonym_text: autoclaved
-  synonym_type: RAW_TEXT
-  source: culturebotht
 mapping_status: MAPPED
 occurrence_statistics:
   total_occurrences: 1

--- a/data/ingredients/unmapped/B-glucan_From_Yeast.yaml
+++ b/data/ingredients/unmapped/B-glucan_From_Yeast.yaml
@@ -1,9 +1,6 @@
 identifier: UNMAPPED_0235
 preferred_term: B-glucan from yeast
-synonyms:
-- synonym_text: autoclaved
-  synonym_type: RAW_TEXT
-  source: culturebotht
+synonyms: []
 mapping_status: UNMAPPED
 occurrence_statistics:
   total_occurrences: 0

--- a/data/ingredients/unmapped/Chitin_From_Shrimp_Shells.yaml
+++ b/data/ingredients/unmapped/Chitin_From_Shrimp_Shells.yaml
@@ -1,9 +1,6 @@
 identifier: UNMAPPED_0248
 preferred_term: Chitin from shrimp shells
-synonyms:
-- synonym_text: autoclaved
-  synonym_type: RAW_TEXT
-  source: culturebotht
+synonyms: []
 mapping_status: UNMAPPED
 occurrence_statistics:
   total_occurrences: 0

--- a/data/ingredients/unmapped/Dextran_Mw_200000.yaml
+++ b/data/ingredients/unmapped/Dextran_Mw_200000.yaml
@@ -4,9 +4,6 @@ synonyms:
 - synonym_text: filtered, dextran, Mw ~200,000
   synonym_type: RAW_TEXT
   source: culturebotht
-- synonym_text: autoclaved
-  synonym_type: RAW_TEXT
-  source: culturebotht
 mapping_status: UNMAPPED
 occurrence_statistics:
   total_occurrences: 0

--- a/data/ingredients/unmapped/Pectic_Galactan_From_Potato.yaml
+++ b/data/ingredients/unmapped/Pectic_Galactan_From_Potato.yaml
@@ -4,9 +4,6 @@ synonyms:
 - synonym_text: filtered, Pectic galactan from potato
   synonym_type: RAW_TEXT
   source: culturebotht
-- synonym_text: autoclaved
-  synonym_type: RAW_TEXT
-  source: culturebotht
 mapping_status: UNMAPPED
 occurrence_statistics:
   total_occurrences: 1

--- a/data/ingredients/unmapped/Rhamnogalacturonan_-_From_Potato.yaml
+++ b/data/ingredients/unmapped/Rhamnogalacturonan_-_From_Potato.yaml
@@ -1,9 +1,6 @@
 identifier: UNMAPPED_0175
 preferred_term: Rhamnogalacturonan - from potato
-synonyms:
-- synonym_text: autoclaved
-  synonym_type: RAW_TEXT
-  source: culturebotht
+synonyms: []
 mapping_status: UNMAPPED
 occurrence_statistics:
   total_occurrences: 0


### PR DESCRIPTION
Surfaced while scanning the unmapped set for duplicates of mapped ingredients: **`autoclaved`** (a preparation method, not an alternative name) was stored as a synonym on **7 records**. The shared junk synonym also made 5 unrelated polysaccharides (B-glucan, chitin, dextran, pectic galactan, rhamnogalacturonan) falsely match the `FOODON:03302492` "Arabinoxylan" record.

Removed it across both collections; per-record files regenerated. (The scan otherwise found **no genuine unmapped duplicates** — the recent `alpha-ketoglutamate` case was only catchable via the promote helper's PK-collision guard.)

`validate-strict`: 0 errors; full suite **359 passed**. Synonyms-only, no id/label changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)