### PR TITLE
Deep-research batch 2: 5 hard unmapped records confirmed UNMAPPED + enriched

### DIFF
--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -95,8 +95,23 @@ flavonoids, natural products, element placeholders, and mixtures.
   - Takeaway: deep research resolves identities that string-matching can't, but most
     of the residual is genuinely hard. The 2 "ready to map" records still await the
     multi-surface migration above. Edison reports live under `research/` (gitignored).
-  - Next batch candidates: the cobamide cluster (5-methoxy/5-methyl/adeninyl/
-    benzimidazolyl cobamide), `6-methylnicotinate`, `Amphotericin`, flavonoids.
+- **Batch 2 done (2026-06-16, `feat/deep-research-batch2-enrich`)** — 5 records
+  deep-researched (Edison/PaperQA3); **all confirmed UNMAPPED** (0 mappings, 0
+  merges) and enriched in place with the findings + provenance:
+  - `6-methylnicotinate` — ambiguous (carboxylate/anion vs methyl ester); +synonym
+    `6-methylnicotinic acid` (related).
+  - `Amphotericin` — spans A/B + formulations; do NOT exact-map to amphotericin B
+    (CHEBI:2682); +related synonyms `amphotericin B`/`AmB`.
+  - `7,2'-Dimethoxyflavone`, `7,4'-Dimethoxyisoflavone` — specific positional
+    isomers, no source-backed CAS/CHEBI; closeMatch to a flavone parent would lose
+    isomer specificity.
+  - `2',2'-Bisepigallocatechin Digallate` — polyphenol; no CAS/formula/CHEBI;
+    naming-variant instability prevents grounding.
+  - Confirms the residual is genuinely hard: like the cobamide in batch 1, these
+    specialized natural products / ambiguous-form compounds lack clean ontology
+    grounding. "Confirmed unmapped + enriched" is the correct, defensible outcome.
+  - Remaining candidates for future batches: the cobamide cluster (5-methoxy/
+    5-methyl/adeninyl/benzimidazolyl cobamide — likely all confirmed-unmapped).
 
 ## 4. mesh.db refresh → drop the 4 SCR exceptions (low priority)
 

--- a/data/curated/unmapped_ingredients.yaml
+++ b/data/curated/unmapped_ingredients.yaml
@@ -146,6 +146,15 @@ ingredients:
     previous_status: UNMAPPED
     new_status: UNMAPPED
     llm_assisted: true
+  - timestamp: '2026-06-16T00:00:00+00:00'
+    curator: deep-research-ingredient-edison
+    action: RESEARCHED_IDENTITY
+    new_status: UNMAPPED
+    llm_assisted: true
+    changes: 'Edison/PaperQA3 deep research: a single polyphenolic small molecule,
+      but no source-backed CAS/molecular formula/CHEBI; naming-variant instability
+      (digallate vs gallate; position/punctuation) prevents confident grounding. Kept
+      UNMAPPED.'
   notes: Imported from CultureBotHT (compounds_to_cas.csv (no CAS-RN)). No CAS-RN
     or CHEBI mapping available; curator review needed. Reviewed on 2026-05-11; retained
     as unmapped pending exact source-backed identity.
@@ -313,6 +322,9 @@ ingredients:
   - synonym_text: 6-methylnicotinate
     synonym_type: RAW_TEXT
     source: mim-queue
+  - synonym_text: 6-methylnicotinic acid
+    synonym_type: RELATED_SYNONYM
+    source: edison_deep_research
   mapping_status: UNMAPPED
   occurrence_statistics:
     total_occurrences: 0
@@ -333,6 +345,15 @@ ingredients:
     previous_status: UNMAPPED
     new_status: UNMAPPED
     llm_assisted: true
+  - timestamp: '2026-06-16T00:00:00+00:00'
+    curator: deep-research-ingredient-edison
+    action: RESEARCHED_IDENTITY
+    new_status: UNMAPPED
+    llm_assisted: true
+    changes: 'Edison/PaperQA3 deep research: "6-methylnicotinate" is not uniquely
+      grounded — it can denote the carboxylate/anion OR the methyl ester (no source-backed
+      CAS/CHEBI). 6-methylnicotinic acid is the likely intended free acid but not
+      exact-equivalent. Kept UNMAPPED pending the intended chemical form.'
   notes: Imported from mim-queue (source_id=mediadive.ingredient:2119); no CAS-RN
     or CHEBI/NCIT match. Reviewed on 2026-05-11; retained as unmapped pending exact
     ontology evidence.
@@ -363,6 +384,15 @@ ingredients:
     previous_status: UNMAPPED
     new_status: UNMAPPED
     llm_assisted: true
+  - timestamp: '2026-06-16T00:00:00+00:00'
+    curator: deep-research-ingredient-edison
+    action: RESEARCHED_IDENTITY
+    new_status: UNMAPPED
+    llm_assisted: true
+    changes: 'Edison/PaperQA3 deep research: a specific flavone positional isomer
+      (7,2''-dimethoxyflavone); no source-backed CAS/CHEBI/PubChem identifier found.
+      closeMatch to a "flavone"/"dimethoxyflavone" parent would collapse isomer specificity
+      — inappropriate for ingredient identity. Kept UNMAPPED.'
   notes: Imported from CultureBotHT (compounds_to_cas.csv (no CAS-RN)). No CAS-RN
     or CHEBI mapping available; curator review needed. Reviewed on 2026-05-11; retained
     as unmapped pending exact source-backed identity.
@@ -393,6 +423,14 @@ ingredients:
     previous_status: UNMAPPED
     new_status: UNMAPPED
     llm_assisted: true
+  - timestamp: '2026-06-16T00:00:00+00:00'
+    curator: deep-research-ingredient-edison
+    action: RESEARCHED_IDENTITY
+    new_status: UNMAPPED
+    llm_assisted: true
+    changes: 'Edison/PaperQA3 deep research: a specific isoflavone positional isomer
+      (7,4''-dimethoxyisoflavone); no source-backed CAS/CHEBI identifier found. Kept
+      UNMAPPED pending a validated identifier.'
   notes: Imported from CultureBotHT (compounds_to_cas.csv (no CAS-RN)). No CAS-RN
     or CHEBI mapping available; curator review needed. Reviewed on 2026-05-11; retained
     as unmapped pending exact source-backed identity.
@@ -772,6 +810,12 @@ ingredients:
   - synonym_text: Amphotericin
     synonym_type: RAW_TEXT
     source: mim-queue
+  - synonym_text: amphotericin B
+    synonym_type: RELATED_SYNONYM
+    source: edison_deep_research
+  - synonym_text: AmB
+    synonym_type: ABBREVIATION
+    source: edison_deep_research
   mapping_status: UNMAPPED
   occurrence_statistics:
     total_occurrences: 0
@@ -794,6 +838,16 @@ ingredients:
     previous_status: UNMAPPED
     new_status: UNMAPPED
     llm_assisted: true
+  - timestamp: '2026-06-16T00:00:00+00:00'
+    curator: deep-research-ingredient-edison
+    action: RESEARCHED_IDENTITY
+    new_status: UNMAPPED
+    llm_assisted: true
+    changes: 'Edison/PaperQA3 deep research: "amphotericin" spans amphotericin A and
+      B and is frequently used at the formulation level (deoxycholate/lipid). Commonly
+      means amphotericin B (CHEBI:2682, CAS 1397-89-3), but the label is not locally
+      evidenced as B specifically — do NOT exact-map to amphotericin B. Kept UNMAPPED
+      pending source evidence the label means amphotericin B.'
   notes: Imported from mim-queue (source_id=mediadive.ingredient:1140); no CAS-RN
     or CHEBI/NCIT match. Reviewed on 2026-05-11 and left unmapped pending source evidence
     that the intended ingredient is Amphotericin B.

--- a/data/ingredients/unmapped/22-Bisepigallocatechin_Digallate.yaml
+++ b/data/ingredients/unmapped/22-Bisepigallocatechin_Digallate.yaml
@@ -24,6 +24,14 @@ curation_history:
   previous_status: UNMAPPED
   new_status: UNMAPPED
   llm_assisted: true
+- timestamp: '2026-06-16T00:00:00+00:00'
+  curator: deep-research-ingredient-edison
+  action: RESEARCHED_IDENTITY
+  new_status: UNMAPPED
+  llm_assisted: true
+  changes: 'Edison/PaperQA3 deep research: a single polyphenolic small molecule, but
+    no source-backed CAS/molecular formula/CHEBI; naming-variant instability (digallate
+    vs gallate; position/punctuation) prevents confident grounding. Kept UNMAPPED.'
 notes: Imported from CultureBotHT (compounds_to_cas.csv (no CAS-RN)). No CAS-RN or
   CHEBI mapping available; curator review needed. Reviewed on 2026-05-11; retained
   as unmapped pending exact source-backed identity.

--- a/data/ingredients/unmapped/6-methylnicotinate.yaml
+++ b/data/ingredients/unmapped/6-methylnicotinate.yaml
@@ -4,6 +4,9 @@ synonyms:
 - synonym_text: 6-methylnicotinate
   synonym_type: RAW_TEXT
   source: mim-queue
+- synonym_text: 6-methylnicotinic acid
+  synonym_type: RELATED_SYNONYM
+  source: edison_deep_research
 mapping_status: UNMAPPED
 occurrence_statistics:
   total_occurrences: 0
@@ -24,6 +27,15 @@ curation_history:
   previous_status: UNMAPPED
   new_status: UNMAPPED
   llm_assisted: true
+- timestamp: '2026-06-16T00:00:00+00:00'
+  curator: deep-research-ingredient-edison
+  action: RESEARCHED_IDENTITY
+  new_status: UNMAPPED
+  llm_assisted: true
+  changes: 'Edison/PaperQA3 deep research: "6-methylnicotinate" is not uniquely grounded
+    — it can denote the carboxylate/anion OR the methyl ester (no source-backed CAS/CHEBI).
+    6-methylnicotinic acid is the likely intended free acid but not exact-equivalent.
+    Kept UNMAPPED pending the intended chemical form.'
 notes: Imported from mim-queue (source_id=mediadive.ingredient:2119); no CAS-RN or
   CHEBI/NCIT match. Reviewed on 2026-05-11; retained as unmapped pending exact ontology
   evidence.

--- a/data/ingredients/unmapped/72-Dimethoxyflavone.yaml
+++ b/data/ingredients/unmapped/72-Dimethoxyflavone.yaml
@@ -24,6 +24,15 @@ curation_history:
   previous_status: UNMAPPED
   new_status: UNMAPPED
   llm_assisted: true
+- timestamp: '2026-06-16T00:00:00+00:00'
+  curator: deep-research-ingredient-edison
+  action: RESEARCHED_IDENTITY
+  new_status: UNMAPPED
+  llm_assisted: true
+  changes: 'Edison/PaperQA3 deep research: a specific flavone positional isomer (7,2''-dimethoxyflavone);
+    no source-backed CAS/CHEBI/PubChem identifier found. closeMatch to a "flavone"/"dimethoxyflavone"
+    parent would collapse isomer specificity — inappropriate for ingredient identity.
+    Kept UNMAPPED.'
 notes: Imported from CultureBotHT (compounds_to_cas.csv (no CAS-RN)). No CAS-RN or
   CHEBI mapping available; curator review needed. Reviewed on 2026-05-11; retained
   as unmapped pending exact source-backed identity.

--- a/data/ingredients/unmapped/74-Dimethoxyisoflavone.yaml
+++ b/data/ingredients/unmapped/74-Dimethoxyisoflavone.yaml
@@ -24,6 +24,14 @@ curation_history:
   previous_status: UNMAPPED
   new_status: UNMAPPED
   llm_assisted: true
+- timestamp: '2026-06-16T00:00:00+00:00'
+  curator: deep-research-ingredient-edison
+  action: RESEARCHED_IDENTITY
+  new_status: UNMAPPED
+  llm_assisted: true
+  changes: 'Edison/PaperQA3 deep research: a specific isoflavone positional isomer
+    (7,4''-dimethoxyisoflavone); no source-backed CAS/CHEBI identifier found. Kept
+    UNMAPPED pending a validated identifier.'
 notes: Imported from CultureBotHT (compounds_to_cas.csv (no CAS-RN)). No CAS-RN or
   CHEBI mapping available; curator review needed. Reviewed on 2026-05-11; retained
   as unmapped pending exact source-backed identity.

--- a/data/ingredients/unmapped/Amphotericin.yaml
+++ b/data/ingredients/unmapped/Amphotericin.yaml
@@ -4,6 +4,12 @@ synonyms:
 - synonym_text: Amphotericin
   synonym_type: RAW_TEXT
   source: mim-queue
+- synonym_text: amphotericin B
+  synonym_type: RELATED_SYNONYM
+  source: edison_deep_research
+- synonym_text: AmB
+  synonym_type: ABBREVIATION
+  source: edison_deep_research
 mapping_status: UNMAPPED
 occurrence_statistics:
   total_occurrences: 0
@@ -26,6 +32,16 @@ curation_history:
   previous_status: UNMAPPED
   new_status: UNMAPPED
   llm_assisted: true
+- timestamp: '2026-06-16T00:00:00+00:00'
+  curator: deep-research-ingredient-edison
+  action: RESEARCHED_IDENTITY
+  new_status: UNMAPPED
+  llm_assisted: true
+  changes: 'Edison/PaperQA3 deep research: "amphotericin" spans amphotericin A and
+    B and is frequently used at the formulation level (deoxycholate/lipid). Commonly
+    means amphotericin B (CHEBI:2682, CAS 1397-89-3), but the label is not locally
+    evidenced as B specifically — do NOT exact-map to amphotericin B. Kept UNMAPPED
+    pending source evidence the label means amphotericin B.'
 notes: Imported from mim-queue (source_id=mediadive.ingredient:1140); no CAS-RN or
   CHEBI/NCIT match. Reviewed on 2026-05-11 and left unmapped pending source evidence
   that the intended ingredient is Amphotericin B.


### PR DESCRIPTION
Second deep-research batch (NEXT_TASKS #3) on the queued candidates. **Result: all 5 confirmed UNMAPPED** — 0 new mappings, 0 merges. None have source-backed clean CHEBI grounding, so the correct, defensible action is enrich-in-place (like the cobamide in batch 1), not force a mapping.

| Record | Edison verdict | Applied |
|---|---|---|
| `6-methylnicotinate` | Ambiguous — carboxylate/anion vs methyl ester; not uniquely grounded | +related synonym `6-methylnicotinic acid` |
| `Amphotericin` | Spans amphotericin A/B + formulations; **do NOT exact-map to amphotericin B** (CHEBI:2682) | +related synonyms `amphotericin B`, `AmB` |
| `7,2'-Dimethoxyflavone` | Specific positional isomer, no CAS/CHEBI; parent closeMatch loses isomer specificity | provenance note |
| `7,4'-Dimethoxyisoflavone` | Specific isoflavone isomer, no CAS/CHEBI | provenance note |
| `2',2'-Bisepigallocatechin Digallate` | Polyphenol; no CAS/formula/CHEBI; naming-variant instability | provenance note |

Each gets a `RESEARCHED_IDENTITY` curation-history entry so it isn't re-researched. **Confirms the residual is genuinely hard** — these specialized natural products / ambiguous-form compounds lack clean ontology grounding; "confirmed unmapped + enriched" is the right outcome.

All stay UNMAPPED (count unchanged, 396); `validate-strict` 0 errors; suite **359 passed**. Edison reports live under `research/` (gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)