### PR TITLE
Cobamide cluster confirmed-unmapped + enriched; mesh.db refresh verdict (keep exceptions)

### DIFF
--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -110,8 +110,10 @@ flavonoids, natural products, element placeholders, and mixtures.
   - Confirms the residual is genuinely hard: like the cobamide in batch 1, these
     specialized natural products / ambiguous-form compounds lack clean ontology
     grounding. "Confirmed unmapped + enriched" is the correct, defensible outcome.
-  - Remaining candidates for future batches: the cobamide cluster (5-methoxy/
-    5-methyl/adeninyl/benzimidazolyl cobamide — likely all confirmed-unmapped).
+  - **Cobamide cluster closed (2026-06-17)** — the remaining 4 (5-methoxy-/
+    5-methyl-benzimidazolyl, adeninyl, benzimidazolyl cobamide) deep-researched;
+    **all confirmed UNMAPPED** + enriched (Factor IIIm; 5-MeBza-Cba; pseudocobalamin;
+    underspecified — no stable CHEBI/CAS, upper-ligand ambiguity, must not map to B12).
 - **Batch 3 done (2026-06-16, `feat/mim-map-inorganic-batch3`)** — a different angle:
   not deep research but a **mappability triage** of the 396 residual. Most is
   genuinely unmappable (commercial media/broths/agars, trace-element & vitamin
@@ -162,10 +164,16 @@ flavonoids, natural products, element placeholders, and mixtures.
     7783-08-6 = selen**ous** acid (CHEBI:26642) but its `formula` field `H2O4Se` =
     selen**ic** acid; the conflict blocks a confident call.
 
-## 4. mesh.db refresh → drop the 4 SCR exceptions (low priority)
+## 4. mesh.db refresh → keep the 4 SCR exceptions (verified 2026-06-17)
 
 `conf/id_label_targets.yaml` carries 4 `exceptions` for valid MeSH supplementary-
 concept records (avocatin B, cholinium lysinate, sodium glutarate, plicacetin)
-absent from the cached `sqlite:obo:mesh`. If a newer mesh.db that includes these
-SCRs becomes available, drop the matching `exceptions` entries and re-run
-`just validate-products` to confirm they resolve as OK_CANONICAL.
+absent from the cached `sqlite:obo:mesh`.
+
+**Refresh tested 2026-06-17 — does NOT help.** Forced a clean re-download of
+`sqlite:obo:mesh` (394 MB, byte-identical to the prior cache): the 4 SCRs are
+**still absent** while older SCRs (e.g. C016600) are present — the upstream semsql
+MeSH build excludes these recent (2020/2024) supplementary-concept records.
+**Keep the exceptions.** Only revisit if the semsql/obo MeSH build starts shipping
+C-prefix SCRs from 2020+; then drop the matching entries and re-run
+`just validate-products` to confirm OK_CANONICAL.

--- a/data/curated/unmapped_ingredients.yaml
+++ b/data/curated/unmapped_ingredients.yaml
@@ -260,6 +260,9 @@ ingredients:
   - synonym_text: 5-methoxybenzimidazolyl cobamide
     synonym_type: RAW_TEXT
     source: culturebotht
+  - synonym_text: Factor IIIm
+    synonym_type: COMMON_NAME
+    source: edison_deep_research
   mapping_status: UNMAPPED
   occurrence_statistics:
     total_occurrences: 0
@@ -281,6 +284,15 @@ ingredients:
     previous_status: UNMAPPED
     new_status: UNMAPPED
     llm_assisted: true
+  - timestamp: '2026-06-17T00:00:00+00:00'
+    curator: deep-research-ingredient-edison
+    action: RESEARCHED_IDENTITY
+    new_status: UNMAPPED
+    llm_assisted: true
+    changes: 'Edison/PaperQA3 deep research: a real, discrete cobamide variant (lower
+      ligand = 5-methoxybenzimidazole; legacy name "Factor IIIm"), but no stable exact
+      CHEBI/CAS identifier; label may cover multiple upper-ligand forms. Do NOT exact-map
+      to cobalamin/vitamin B12 (different lower ligand). Kept UNMAPPED.'
   notes: Imported from CultureBotHT (compounds_to_cas.csv (no CAS-RN)). No CAS-RN
     or CHEBI mapping available; curator review needed. Reviewed on 2026-05-11 as a
     specific cobamide variant; not identity-mapped to generic cobamide or cobalamin.
@@ -291,6 +303,9 @@ ingredients:
   - synonym_text: 5-methylbenzimidazolyl cobamide
     synonym_type: RAW_TEXT
     source: culturebotht
+  - synonym_text: 5-MeBza-Cba
+    synonym_type: ABBREVIATION
+    source: edison_deep_research
   mapping_status: UNMAPPED
   occurrence_statistics:
     total_occurrences: 0
@@ -312,6 +327,14 @@ ingredients:
     previous_status: UNMAPPED
     new_status: UNMAPPED
     llm_assisted: true
+  - timestamp: '2026-06-17T00:00:00+00:00'
+    curator: deep-research-ingredient-edison
+    action: RESEARCHED_IDENTITY
+    new_status: UNMAPPED
+    llm_assisted: true
+    changes: 'Edison/PaperQA3 deep research: discrete cobamide variant (lower ligand
+      = 5-methylbenzimidazole; "5-MeBza-Cba"); no stable CHEBI/CAS, and mapping to
+      cobalamin would be chemically incorrect at the lower-ligand level. Kept UNMAPPED.'
   notes: Imported from CultureBotHT (compounds_to_cas.csv (no CAS-RN)). No CAS-RN
     or CHEBI mapping available; curator review needed. Reviewed on 2026-05-11 as a
     specific cobamide variant; not identity-mapped to generic cobamide or cobalamin.
@@ -660,6 +683,9 @@ ingredients:
   - synonym_text: adeninyl cobamide
     synonym_type: RAW_TEXT
     source: culturebotht
+  - synonym_text: pseudocobalamin
+    synonym_type: COMMON_NAME
+    source: edison_deep_research
   mapping_status: UNMAPPED
   occurrence_statistics:
     total_occurrences: 0
@@ -680,6 +706,14 @@ ingredients:
     previous_status: UNMAPPED
     new_status: UNMAPPED
     llm_assisted: true
+  - timestamp: '2026-06-17T00:00:00+00:00'
+    curator: deep-research-ingredient-edison
+    action: RESEARCHED_IDENTITY
+    new_status: UNMAPPED
+    llm_assisted: true
+    changes: 'Edison/PaperQA3 deep research: adenine-lower-ligand cobamide ("pseudocobalamin";
+      cyano form = cyano-(adenin-7-yl)cobamide); upper-ligand ambiguous and no stable
+      CHEBI/CAS identifier recovered. Do NOT map to cobalamin/B12. Kept UNMAPPED.'
   notes: Imported from CultureBotHT (compounds_to_cas.csv (no CAS-RN)). No CAS-RN
     or CHEBI mapping available; curator review needed. Reviewed on 2026-05-11 as a
     specific cobamide variant; not identity-mapped to generic cobamide or cobalamin.
@@ -1453,6 +1487,14 @@ ingredients:
     previous_status: UNMAPPED
     new_status: UNMAPPED
     llm_assisted: true
+  - timestamp: '2026-06-17T00:00:00+00:00'
+    curator: deep-research-ingredient-edison
+    action: RESEARCHED_IDENTITY
+    new_status: UNMAPPED
+    llm_assisted: true
+    changes: 'Edison/PaperQA3 deep research: underspecified — "benzimidazolyl cobamide"
+      can denote multiple distinct cobamides (different lower ligands) and forms (CN-/Ado-);
+      no stable CHEBI/CAS identifier. Kept UNMAPPED.'
   notes: Imported from CultureBotHT (compounds_to_cas.csv (no CAS-RN)). No CAS-RN
     or CHEBI mapping available; curator review needed. Reviewed on 2026-05-11 as a
     specific cobamide variant; not identity-mapped to generic cobamide or cobalamin.

--- a/data/ingredients/unmapped/5-methoxybenzimidazolyl_Cobamide.yaml
+++ b/data/ingredients/unmapped/5-methoxybenzimidazolyl_Cobamide.yaml
@@ -4,6 +4,9 @@ synonyms:
 - synonym_text: 5-methoxybenzimidazolyl cobamide
   synonym_type: RAW_TEXT
   source: culturebotht
+- synonym_text: Factor IIIm
+  synonym_type: COMMON_NAME
+  source: edison_deep_research
 mapping_status: UNMAPPED
 occurrence_statistics:
   total_occurrences: 0
@@ -25,6 +28,15 @@ curation_history:
   previous_status: UNMAPPED
   new_status: UNMAPPED
   llm_assisted: true
+- timestamp: '2026-06-17T00:00:00+00:00'
+  curator: deep-research-ingredient-edison
+  action: RESEARCHED_IDENTITY
+  new_status: UNMAPPED
+  llm_assisted: true
+  changes: 'Edison/PaperQA3 deep research: a real, discrete cobamide variant (lower
+    ligand = 5-methoxybenzimidazole; legacy name "Factor IIIm"), but no stable exact
+    CHEBI/CAS identifier; label may cover multiple upper-ligand forms. Do NOT exact-map
+    to cobalamin/vitamin B12 (different lower ligand). Kept UNMAPPED.'
 notes: Imported from CultureBotHT (compounds_to_cas.csv (no CAS-RN)). No CAS-RN or
   CHEBI mapping available; curator review needed. Reviewed on 2026-05-11 as a specific
   cobamide variant; not identity-mapped to generic cobamide or cobalamin.

--- a/data/ingredients/unmapped/5-methylbenzimidazolyl_Cobamide.yaml
+++ b/data/ingredients/unmapped/5-methylbenzimidazolyl_Cobamide.yaml
@@ -4,6 +4,9 @@ synonyms:
 - synonym_text: 5-methylbenzimidazolyl cobamide
   synonym_type: RAW_TEXT
   source: culturebotht
+- synonym_text: 5-MeBza-Cba
+  synonym_type: ABBREVIATION
+  source: edison_deep_research
 mapping_status: UNMAPPED
 occurrence_statistics:
   total_occurrences: 0
@@ -25,6 +28,14 @@ curation_history:
   previous_status: UNMAPPED
   new_status: UNMAPPED
   llm_assisted: true
+- timestamp: '2026-06-17T00:00:00+00:00'
+  curator: deep-research-ingredient-edison
+  action: RESEARCHED_IDENTITY
+  new_status: UNMAPPED
+  llm_assisted: true
+  changes: 'Edison/PaperQA3 deep research: discrete cobamide variant (lower ligand
+    = 5-methylbenzimidazole; "5-MeBza-Cba"); no stable CHEBI/CAS, and mapping to cobalamin
+    would be chemically incorrect at the lower-ligand level. Kept UNMAPPED.'
 notes: Imported from CultureBotHT (compounds_to_cas.csv (no CAS-RN)). No CAS-RN or
   CHEBI mapping available; curator review needed. Reviewed on 2026-05-11 as a specific
   cobamide variant; not identity-mapped to generic cobamide or cobalamin.

--- a/data/ingredients/unmapped/Adeninyl_Cobamide.yaml
+++ b/data/ingredients/unmapped/Adeninyl_Cobamide.yaml
@@ -4,6 +4,9 @@ synonyms:
 - synonym_text: adeninyl cobamide
   synonym_type: RAW_TEXT
   source: culturebotht
+- synonym_text: pseudocobalamin
+  synonym_type: COMMON_NAME
+  source: edison_deep_research
 mapping_status: UNMAPPED
 occurrence_statistics:
   total_occurrences: 0
@@ -24,6 +27,14 @@ curation_history:
   previous_status: UNMAPPED
   new_status: UNMAPPED
   llm_assisted: true
+- timestamp: '2026-06-17T00:00:00+00:00'
+  curator: deep-research-ingredient-edison
+  action: RESEARCHED_IDENTITY
+  new_status: UNMAPPED
+  llm_assisted: true
+  changes: 'Edison/PaperQA3 deep research: adenine-lower-ligand cobamide ("pseudocobalamin";
+    cyano form = cyano-(adenin-7-yl)cobamide); upper-ligand ambiguous and no stable
+    CHEBI/CAS identifier recovered. Do NOT map to cobalamin/B12. Kept UNMAPPED.'
 notes: Imported from CultureBotHT (compounds_to_cas.csv (no CAS-RN)). No CAS-RN or
   CHEBI mapping available; curator review needed. Reviewed on 2026-05-11 as a specific
   cobamide variant; not identity-mapped to generic cobamide or cobalamin.

--- a/data/ingredients/unmapped/Benzimidazolyl_Cobamide.yaml
+++ b/data/ingredients/unmapped/Benzimidazolyl_Cobamide.yaml
@@ -25,6 +25,14 @@ curation_history:
   previous_status: UNMAPPED
   new_status: UNMAPPED
   llm_assisted: true
+- timestamp: '2026-06-17T00:00:00+00:00'
+  curator: deep-research-ingredient-edison
+  action: RESEARCHED_IDENTITY
+  new_status: UNMAPPED
+  llm_assisted: true
+  changes: 'Edison/PaperQA3 deep research: underspecified — "benzimidazolyl cobamide"
+    can denote multiple distinct cobamides (different lower ligands) and forms (CN-/Ado-);
+    no stable CHEBI/CAS identifier. Kept UNMAPPED.'
 notes: Imported from CultureBotHT (compounds_to_cas.csv (no CAS-RN)). No CAS-RN or
   CHEBI mapping available; curator review needed. Reviewed on 2026-05-11 as a specific
   cobamide variant; not identity-mapped to generic cobamide or cobalamin.


### PR DESCRIPTION
Closes the last two open backlog items.

## #3 — cobamide cluster (closed)
Deep-researched the remaining 4 cobamides; **all confirmed UNMAPPED** and enriched in place:

| Record | Identity | Synonym added |
|---|---|---|
| 5-methoxybenzimidazolyl cobamide | "Factor IIIm" (5-methoxybenzimidazole lower ligand) | `Factor IIIm` |
| 5-methylbenzimidazolyl cobamide | "5-MeBza-Cba" | `5-MeBza-Cba` |
| adeninyl cobamide | "pseudocobalamin" / cyano-(adenin-7-yl)cobamide | `pseudocobalamin` |
| benzimidazolyl cobamide | underspecified (multiple lower ligands/forms) | — |

None have a stable CHEBI/CAS; all have upper-ligand ambiguity; must not map to cobalamin/B12. Each gets a `RESEARCHED_IDENTITY` provenance entry. The cobamide cluster is now formally closed.

**Net of the whole deep-research effort** (batches 1–2 + cobamides + ketoglutamate): out of ~13 hard records researched → exactly **1 clean mapping (NAA)** + **1 merge (ketoglutamate)**; the rest legitimately lack ontology terms. The ~396 residual isn't a curation gap — it's compounds without CHEBI/FOODON terms.

## #4 — mesh.db refresh (verdict: keep exceptions)
Tested it: forced a clean re-download of `sqlite:obo:mesh` (394 MB, **byte-identical** to the prior cache). The 4 valid MeSH SCRs (avocatin B, cholinium lysinate, sodium glutarate, plicacetin) are **still absent**, while older SCRs (C016600) are present — upstream semsql MeSH excludes these recent 2020/2024 supplementary-concept records. A refresh does **not** help, so the 4 `exceptions` stay. Documented in `NEXT_TASKS.md` #4 (no conf change).

`validate-strict` 0 errors; full suite **359 passed**; all records stay UNMAPPED (count 396).

🤖 Generated with [Claude Code](https://claude.com/claude-code)