### PR TITLE
Resync shared module to canonical 1a5e21eb (evidence_source + BIOMODELS/KBASE)

### DIFF
--- a/src/mediaingredientmech/schema/.mech_shared.sha256
+++ b/src/mediaingredientmech/schema/.mech_shared.sha256
@@ -1,1 +1,1 @@
-4cf0ce5c07edbc4c82f629b828db35d2e8d9488808884e8decaff57ad0cd0ce8  src/mediaingredientmech/schema/mech_shared.yaml
+1a5e21eb2ee9f3584ff6af3a6906b1d442e18c41de405b1bf907c20f44eafa2a  src/mediaingredientmech/schema/mech_shared.yaml

--- a/src/mediaingredientmech/schema/mech_shared.yaml
+++ b/src/mediaingredientmech/schema/mech_shared.yaml
@@ -183,6 +183,10 @@ enums:
         description: Figshare general-purpose research data archive.
       ZENODO:
         description: Zenodo general-purpose research data archive.
+      BIOMODELS:
+        description: EBI BioModels repository of computational models.
+      KBASE:
+        description: DOE Systems Biology Knowledgebase (KBase).
       OTHER:
         description: A repository not covered by the above.
 
@@ -202,6 +206,10 @@ classes:
         description: Title of the cited source (optional; populated by tooling).
       supports:
         range: SupportLevelEnum
+      evidence_source:
+        description: >-
+          How the snippet was obtained (e.g. abstract, full_text, figure,
+          supplement, database). Free-form to stay self-contained.
       snippet:
         description: Verbatim quote from the source supporting the attached claim.
       explanation:


### PR DESCRIPTION
Re-vendors the byte-identical canonical `mech_shared.yaml` (TraitMech #120 — adds `SupportingReference.evidence_source` + `BIOMODELS`/`KBASE`). The initial adoption PR picked up a stale pre-#120 copy due to a fetch race. Re-pinned; gen-pydantic clean. Restores the cross-Mech byte-identical invariant. claw#7.