### PR TITLE
Render datasets + knowledge-gap discussions in ingredient pages (claw#7 Phase 1)

### DIFF
--- a/src/mediaingredientmech/templates/_partials/datasets.html.j2
+++ b/src/mediaingredientmech/templates/_partials/datasets.html.j2
@@ -1,0 +1,18 @@
+<section id="datasets">
+<h2>Datasets <span class="muted">({{ ingredient.datasets|length }})</span></h2>
+<table class="datasets">
+<thead>
+<tr><th>Dataset</th><th>Type</th><th>Repository</th><th>Accession</th></tr>
+</thead>
+<tbody>
+{% for ds in ingredient.datasets %}
+<tr>
+  <td>{{ ds.title or ds.accession }}{% if ds.description %}<br><span class="muted small prewrap">{{ ds.description }}</span>{% endif %}</td>
+  <td>{% if ds.dataset_type %}<span class="badge">{{ ds.dataset_type }}</span>{% endif %}</td>
+  <td class="small">{{ ds.repository or '' }}</td>
+  <td class="small">{% if ds.url %}<a href="{{ ds.url }}" rel="nofollow noreferrer">{{ ds.accession or ds.url }}</a>{% else %}{{ ds.accession or '' }}{% endif %}</td>
+</tr>
+{% endfor %}
+</tbody>
+</table>
+</section>

--- a/src/mediaingredientmech/templates/_partials/discussions.html.j2
+++ b/src/mediaingredientmech/templates/_partials/discussions.html.j2
@@ -1,0 +1,41 @@
+<section id="discussions">
+<h2>Knowledge gaps &amp; discussions <span class="muted">({{ ingredient.discussions|length }})</span></h2>
+{% for d in ingredient.discussions %}
+<div class="discussion">
+  <h3>
+    {% if d.kind %}<span class="badge">{{ d.kind }}</span>{% endif %}
+    {% if d.status %}<span class="badge">{{ d.status }}</span>{% endif %}
+    {{ d.prompt }}
+  </h3>
+  {% if d.rationale %}<p class="prewrap">{{ d.rationale }}</p>{% endif %}
+  {% if d.attaches_to %}<p class="muted small">Attaches to: {% for a in d.attaches_to %}<code>{{ a }}</code>{% if not loop.last %}, {% endif %}{% endfor %}</p>{% endif %}
+  {% if d.proposed_experiments %}
+  <details>
+    <summary class="muted small">{{ d.proposed_experiments|length }} proposed experiment(s)</summary>
+    {% for exp in d.proposed_experiments %}
+    <div class="experiment">
+      <strong>{{ exp.name or exp.experiment_id or 'Experiment ' ~ loop.index }}</strong>
+      {% if exp.approach %}<br><span class="small">Approach: {{ exp.approach }}</span>{% endif %}
+      {% if exp.decision_criterion %}<br><span class="small">Decision: {{ exp.decision_criterion }}</span>{% endif %}
+    </div>
+    {% endfor %}
+  </details>
+  {% endif %}
+  {% if d.evidence %}
+  <details class="evidence-list">
+    <summary class="muted small">{{ d.evidence|length }} evidence item(s)</summary>
+    {% for ev in d.evidence %}
+    <div class="evidence">
+      {% if ev.evidence_source %}<span class="badge small">{{ ev.evidence_source }}</span>{% endif %}
+      {% if ev.supports %}<span class="badge small">{{ ev.supports }}</span>{% endif %}
+      {% if ev.reference %}{% set ref = ev.reference %}{% if ref.startswith('PMID:') %}<a href="https://pubmed.ncbi.nlm.nih.gov/{{ ref|replace('PMID:','') }}/" rel="nofollow noreferrer">{{ ref }}</a>{% else %}{{ ref }}{% endif %}{% endif %}
+      {% if ev.snippet %}<p class="snippet small prewrap">{{ ev.snippet }}</p>{% endif %}
+      {% if ev.explanation %}<p class="muted small prewrap">{{ ev.explanation }}</p>{% endif %}
+    </div>
+    {% endfor %}
+  </details>
+  {% endif %}
+  {% if d.resolution_note %}<p class="small"><em>Resolution:</em> {{ d.resolution_note }}</p>{% endif %}
+</div>
+{% endfor %}
+</section>

--- a/src/mediaingredientmech/templates/ingredient.html.j2
+++ b/src/mediaingredientmech/templates/ingredient.html.j2
@@ -47,6 +47,8 @@
 {% if om.evidence %}{% include "_partials/evidence.html.j2" %}{% endif %}
 {% if ingredient.occurrence_statistics %}{% include "_partials/occurrence.html.j2" %}{% endif %}
 {% if ingredient.curation_history %}{% include "_partials/curation_history.html.j2" %}{% endif %}
+{% if ingredient.datasets %}{% include "_partials/datasets.html.j2" %}{% endif %}
+{% if ingredient.discussions %}{% include "_partials/discussions.html.j2" %}{% endif %}
 
 <footer>
   <small class="muted">


### PR DESCRIPTION
Adds guarded `datasets` + `discussions` partials to `ingredient.html.j2` (after curation_history), mirroring CommunityMech/CultureMech. Template-only — no IngredientRecord carries these fields yet (regenerate with `--force` once data lands). Both partials render cleanly with synthetic data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)