### PR TITLE
skills: add merge-ingredients frontmatter; sharpen manage-identifiers description

### DIFF
--- a/.claude/skills/manage-identifiers/skill.md
+++ b/.claude/skills/manage-identifiers/skill.md
@@ -1,6 +1,6 @@
 ---
 name: manage-identifiers
-description: Generic identifier management for X-Mech repositories - finding highest IDs, minting new IDs, and adding records with proper ID placement
+description: Use this skill to manage MediaIngredientMech record identifiers — find the highest existing MIM id, mint the next id, and insert new ingredient records with correct id placement and prefix conventions (MIM / CHEBI / cas / kgmicrobe.*). Use when adding or importing ingredient records, or reconciling id collisions.
 category: workflow
 requires_database: false
 requires_internet: false

--- a/.claude/skills/merge-ingredients/skill.md
+++ b/.claude/skills/merge-ingredients/skill.md
@@ -1,3 +1,8 @@
+---
+name: merge-ingredients
+description: Use this skill to deduplicate and merge MediaIngredientMech ingredient records — when two or more records describe the same ingredient (duplicate CHEBI mappings, name variants, or a placeholder plus its resolved record) and must be consolidated into one, preserving synonyms, occurrence statistics, curation_history, and SSSOM rows. Covers detection strategies, the merge procedure, and post-merge validation.
+---
+
 # Merge Ingredients Skill
 
 **Purpose**: Comprehensive guide for deduplicating and merging ingredient records in MediaIngredientMech


### PR DESCRIPTION
Per [author-skills guidance](https://ai4curation.io/aidocs/how-tos/author-skills/): `merge-ingredients/skill.md` had **no frontmatter** (missing required name+description → not reliably discoverable) — added an action-oriented one. `manage-identifiers` had the vague placeholder "Generic identifier management for X-Mech repositories" — replaced with a MIM-specific "Use when…" description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)