### PR TITLE
skills: fix merge-ingredients SSSOM overclaim + rewrite manage-identifiers to MIM's real id model

### DIFF
--- a/.claude/skills/manage-identifiers/skill.md
+++ b/.claude/skills/manage-identifiers/skill.md
@@ -1,159 +1,143 @@
 ---
 name: manage-identifiers
-description: Use this skill to manage MediaIngredientMech record identifiers — find the highest existing MIM id, mint the next id, and insert new ingredient records with correct id placement and prefix conventions (MIM / CHEBI / cas / kgmicrobe.*). Use when adding or importing ingredient records, or reconciling id collisions.
+description: Use this skill to manage MediaIngredientMech record identifiers. In MIM the record `identifier` IS the ontology mapping CURIE (CHEBI / FOODON / cas / kgmicrobe.compound / kgmicrobe.ingredient / mesh / NCIT / MICRO / ENVO) for a mapped ingredient, or an `UNMAPPED_NNNN` placeholder for an unmapped one — there is no separate sequential id. Use when adding or importing ingredient records, minting the next `UNMAPPED_NNNN` placeholder, promoting an unmapped record to its resolved CURIE, or reconciling identifier collisions. (Sequential `RepoName:NNNNNN` ids are a sister-repo scheme — see the cross-repo reference.)
 category: workflow
 requires_database: false
 requires_internet: false
-version: 1.1.0
+version: 2.0.0
 ---
 
 # Identifier Management (MediaIngredientMech)
 
-## Overview
+## Overview — MIM uses CURIE identifiers, not sequential ids
 
-Maintain stable, sequential record identifiers for MediaIngredientMech so records have
-persistent references, link cleanly across repositories, and integrate into the knowledge
-graph. IDs never change once assigned and are never reused.
+MediaIngredientMech is a **multi-file collection**: every ingredient is its own YAML file
+under `data/ingredients/mapped/` (mapped) or `data/ingredients/unmapped/` (unmapped). The
+identifying field is **`identifier`** (the schema's `identifier: true` slot on
+`IngredientRecord`), and its value is:
 
-MediaIngredientMech is a **single-file collection**: every ingredient lives in one YAML
-file under a collection key (`ingredients`), each with an `id` of the form
-`MediaIngredientMech:NNNNNN` (zero-padded 6-digit, `000001`–`999999`).
+- **Mapped record** → the ontology mapping **CURIE**, equal to `ontology_mapping.ontology_id`
+  (e.g. `identifier: CHEBI:9532`). Prefixes actually in use, by frequency: `CHEBI:` (~1360),
+  `cas:` (~248), `kgmicrobe.compound:` (~64), `mesh:` (~61), `MICRO:` (~44), `NCIT:` (~31),
+  `FOODON:` (~26), `kgmicrobe.ingredient:` (~25), `ENVO:` (~10).
+- **Unmapped record** → an **`UNMAPPED_NNNN`** placeholder (zero-padded 4-digit, e.g.
+  `UNMAPPED_0001`); ~380 records.
 
-> The same identifier infrastructure is shared with CultureMech (multi-file + registry)
-> and CommunityMech (multi-file). Those collection types, their find/mint/add variants,
-> and a copy-paste utility module are documented in the reference files below — use them
-> when working cross-repo or setting up a new X-Mech repository.
+> **There is no `MediaIngredientMech:NNNNNN` sequential id in MIM.** The legacy separate id
+> was removed (`scripts/migrate_drop_legacy_ontology_id.py`); records carry only `identifier`.
+> Sister repos **CultureMech** and **CommunityMech** *do* mint sequential `RepoName:NNNNNN`
+> ids — that scheme lives in the [cross-repo reference](reference/cross-repo.md), not here.
 
 ## When to Use This Skill
 
-- Adding a new ingredient record (or importing a batch)
-- Finding the next available ID before minting
-- Running batch ID assignment
-- Validating ID sequences (duplicates, gaps, format)
-- Reconciling ID collisions
+- Adding or importing an ingredient record (set its `identifier` correctly)
+- Minting the next `UNMAPPED_NNNN` placeholder for a new unmapped ingredient
+- Promoting an unmapped record to its resolved CURIE once it's mapped
+- Reconciling identifier collisions / duplicates, or auditing identifier↔mapping consistency
 
 ---
 
 ## Identifier Format
 
-```
-MediaIngredientMech:NNNNNN
-```
+| Record state | `identifier` value | Example |
+|---|---|---|
+| **Mapped** | the ontology CURIE, `== ontology_mapping.ontology_id` | `CHEBI:26710`, `cas:7647-14-5`, `kgmicrobe.compound:foo` |
+| **Unmapped** | `UNMAPPED_NNNN` (4-digit, zero-padded) | `UNMAPPED_0042` |
 
-- `MediaIngredientMech` — repository prefix
-- `NNNNNN` — zero-padded 6-digit sequential number (`000001`–`999999`)
-
-Zero-padding makes alphabetical sort == numerical sort. The `id` is stable, unique within
-the repo, and works directly as an RDF subject/object. (Record `id` is distinct from the
-ontology mapping `identifier`, which carries the `CHEBI` / `cas` / `kgmicrobe.*` / `UNMAPPED_*`
-value — see [`merge-ingredients`](../merge-ingredients/skill.md) and
-[`map-media-ingredients`](../map-media-ingredients/skill.md).)
+Schema pattern for CURIE identifiers (`src/mediaingredientmech/schema/mediaingredientmech.yaml`):
+`^[A-Za-z][A-Za-z0-9.]*:[A-Za-z0-9][A-Za-z0-9._~-]*$`. The `identifier` of a mapped record
+**must equal** its `ontology_mapping.ontology_id` (the id↔label gate checks this).
 
 ---
 
 ## Core Workflow
 
-**Data file:** `data/curated/unmapped_ingredients.yaml` (collection key: `ingredients`).
-Full code for every step — including the multi-file and registry variants — is in
-[`reference/finding-highest-id.md`](reference/finding-highest-id.md) and
-[`reference/minting-and-adding.md`](reference/minting-and-adding.md).
+Records are one file per ingredient. Choosing/curating the ontology mapping is the
+[`map-media-ingredients`](../map-media-ingredients/skill.md) skill; consolidating duplicates is
+[`merge-ingredients`](../merge-ingredients/skill.md). This skill is about the **`identifier`
+value** itself.
 
-### 1. Find the highest existing ID
+### 1. Mapped record — the identifier IS the CURIE
+
+The identifier is **not** minted sequentially; it is the ontology term selected during mapping.
+Set `identifier` to the mapping's CURIE so the two agree:
+
+```yaml
+identifier: CHEBI:26710          # == ontology_mapping.ontology_id
+preferred_term: sodium chloride
+ontology_mapping:
+  ontology_id: CHEBI:26710
+  ontology_label: sodium chloride
+  ontology_source: CHEBI
+```
+
+### 2. Unmapped record — mint the next `UNMAPPED_NNNN`
+
+Find the highest existing placeholder across all record files, then add 1:
 
 ```bash
 # quick check
-grep -o 'MediaIngredientMech:[0-9]\+' data/curated/unmapped_ingredients.yaml \
-  | cut -d: -f2 | sort -n | tail -1
+grep -rhoE 'UNMAPPED_[0-9]{4}' data/ingredients/ | sort -u | tail -1
 ```
 
 ```python
-highest = find_highest_id_single_file(
-    Path('data/curated/unmapped_ingredients.yaml'), 'MediaIngredientMech', 'ingredients')
+import re, pathlib
+nums = [int(m.group(1))
+        for p in pathlib.Path('data/ingredients').rglob('*.yaml')
+        for m in re.finditer(r'^identifier:\s*UNMAPPED_(\d{4})', p.read_text(), re.M)]
+next_id = f"UNMAPPED_{(max(nums, default=0) + 1):04d}"
 ```
 
-### 2. Mint the next ID
+Write the new record as its own file `data/ingredients/unmapped/<slug>.yaml` with
+`identifier: <next_id>`, `mapping_status: UNMAPPED`, and a `curation_history` entry. Save with
+`sort_keys=False` to preserve field order.
 
-```python
-next_id = generate_xmech_id('MediaIngredientMech', highest + 1)   # -> 'MediaIngredientMech:000113'
-# generate_xmech_id(prefix, n) == f"{prefix}:{n:06d}"
-```
+### 3. Promote an unmapped record to its CURIE
 
-### 3. Add the record (single-file append)
-
-```python
-new_record = {
-    'id': next_id,                                  # ALWAYS the first field
-    'identifier': f'UNMAPPED_{(highest + 1):04d}',  # or CHEBI/cas/kgmicrobe.* once mapped
-    'preferred_term': 'New Ingredient Name',
-    'synonyms': [],
-    'mapping_status': 'UNMAPPED',
-    'occurrence_statistics': {'total_occurrences': 1, 'media_count': 1},
-    'curation_history': [{
-        'timestamp': datetime.now(timezone.utc).isoformat(),
-        'curator': 'manual_addition', 'action': 'CREATED',
-        'changes': 'New ingredient added manually',
-        'new_status': 'UNMAPPED', 'llm_assisted': False,
-    }],
-    'notes': 'Added manually via identifier management workflow',
-}
-data['ingredients'].append(new_record)
-data['total_count'] = len(data['ingredients'])
-data['generation_date'] = datetime.now(timezone.utc).isoformat()
-with open(yaml_path, 'w') as f:
-    yaml.dump(data, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
-```
-
-Key points: `id` first; update `total_count` and `generation_date`; **`sort_keys=False`**
-to preserve field order; always include a `curation_history` entry.
-
-### 4. Batch assignment
-
-```bash
-python scripts/add_mediaingredientmech_ids.py --dry-run   # preview (always first)
-python scripts/add_mediaingredientmech_ids.py             # execute
-```
-
-Skips records that already have IDs, assigns sequentially, prints a Rich sample table and
-added/skipped stats. `--force-overwrite` exists — use with caution. CultureMech/CommunityMech
-batch scripts are covered in [`reference/minting-and-adding.md`](reference/minting-and-adding.md).
+When an `UNMAPPED_NNNN` ingredient gets an ontology mapping, change `identifier` from the
+placeholder to the CURIE (matching `ontology_mapping.ontology_id`), flip `mapping_status`,
+move the file from `unmapped/` to `mapped/`, and append a `curation_history` entry recording
+the old placeholder → new CURIE transition. Never silently drop the provenance.
 
 ---
 
 ## Validation
 
-Validate format, find duplicates, and find sequence gaps — full validators and fixes in
-[`reference/validation.md`](reference/validation.md):
-
-- **Format:** every `id` matches `^MediaIngredientMech:\d{6}$`.
-- **Duplicates:** no two records share an ID (breaks references).
-- **Gaps:** sequence is contiguous (gaps are tolerable but avoid creating them).
+- **Format:** every `identifier` is a valid CURIE (schema pattern above) **or** `UNMAPPED_NNNN`.
+- **Consistency:** for mapped records, `identifier == ontology_mapping.ontology_id`.
+- **Uniqueness:** no two records share an `identifier` (collisions break cross-references).
+- **Gate:** `just validate-strict` (closed-schema), `just validate-terms[-all]`, and
+  `just validate-products` (Engine B id↔label) enforce the above.
 
 ---
 
 ## Best Practices
 
 ### DO
-- **Run `--dry-run` first** before any batch operation, and validate after changes.
-- **Zero-pad** with `{number:06d}`; place `id` first in the YAML.
-- **Update metadata** (`total_count`, `generation_date`) on the single file.
-- **Preserve ID history** — never reuse a deleted ID.
-- **Use the existing scripts** for batches; document manual additions in `curation_history`.
+- **Mapped identifier = the ontology CURIE** (equal to `ontology_mapping.ontology_id`).
+- **Mint `UNMAPPED_NNNN` as highest+1**, zero-padded to 4 digits, scanning all record files.
+- **Append `curation_history`** on every identifier assignment or change; save `sort_keys=False`.
+- **Preserve provenance** when promoting `UNMAPPED_NNNN` → CURIE (record it in history).
 
 ### DON'T
-- **Don't assign IDs** without checking the highest first.
-- **Don't reuse** IDs from deleted records (breaks cross-references).
+- **Don't invent `MediaIngredientMech:NNNNNN` ids** — MIM does not use a sequential record id.
+- **Don't let `identifier` diverge** from `ontology_mapping.ontology_id` on a mapped record.
+- **Don't reuse a retired `UNMAPPED_NNNN`** number, and don't renumber existing placeholders.
 - **Don't use `sort_keys=True`** when saving (breaks field order).
-- **Don't force-overwrite** existing IDs unless absolutely necessary.
-- **Don't create gaps intentionally**, and don't use non-standard formats.
 
 ---
 
-## Reference Files
+## Reference Files (sister-repo sequential-id scheme — not MIM's model)
+
+> These describe the **sequential `RepoName:NNNNNN`** identifier scheme used by **CultureMech**
+> and **CommunityMech** (and the generic X-Mech template). They do **not** apply to MIM, whose
+> model is the CURIE / `UNMAPPED_NNNN` `identifier` described above. Use them when working in
+> those sister repos or bootstrapping a new X-Mech repository.
 
 | File | Contents |
 |------|----------|
-| [`reference/finding-highest-id.md`](reference/finding-highest-id.md) | Finding the highest ID for all three collection types (single-file, multi-file scan, registry) |
-| [`reference/minting-and-adding.md`](reference/minting-and-adding.md) | Generic mint function, full add-record workflows (1 single-file, 2 multi-file, 3 multi-file+registry), and all three batch-assignment scripts |
-| [`reference/validation.md`](reference/validation.md) | ID-format validator, duplicate finder, gap finder, and common issues + fixes |
-| [`reference/cross-repo.md`](reference/cross-repo.md) | Collection-type comparison, CultureMech/CommunityMech quick references, integration with `IngredientCurator` and KGX export, and the future-enhancements/decision-tree material |
-| [`reference/utility-module.md`](reference/utility-module.md) | Copy-paste-ready `xmech_id_utils` module covering all collection types |
+| [`reference/finding-highest-id.md`](reference/finding-highest-id.md) | Finding the highest sequential id (single-file, multi-file scan, registry) |
+| [`reference/minting-and-adding.md`](reference/minting-and-adding.md) | Generic mint function and add-record workflows + batch-assignment scripts for the sequential scheme |
+| [`reference/validation.md`](reference/validation.md) | Sequential-id format validator, duplicate finder, gap finder |
+| [`reference/cross-repo.md`](reference/cross-repo.md) | Collection-type comparison, CultureMech/CommunityMech quick references, integration, decision tree |
+| [`reference/utility-module.md`](reference/utility-module.md) | Copy-paste `xmech_id_utils` module for the sequential scheme |

--- a/.claude/skills/merge-ingredients/skill.md
+++ b/.claude/skills/merge-ingredients/skill.md
@@ -1,6 +1,6 @@
 ---
 name: merge-ingredients
-description: Use this skill to deduplicate and merge MediaIngredientMech ingredient records — when two or more records describe the same ingredient (duplicate CHEBI mappings, name variants, or a placeholder plus its resolved record) and must be consolidated into one, preserving synonyms, occurrence statistics, curation_history, and SSSOM rows. Covers detection strategies, the merge procedure, and post-merge validation.
+description: Use this skill to deduplicate and merge MediaIngredientMech ingredient records — when two or more records describe the same ingredient (duplicate CHEBI mappings, name variants, or a placeholder plus its resolved record) and must be consolidated into one, preserving synonyms, occurrence statistics, and curation_history. Covers detection strategies, the merge procedure, and post-merge validation.
 ---
 
 # Merge Ingredients Skill


### PR DESCRIPTION
Two skill-accuracy fixes surfaced by `/dynamic-review` (PR #86 review) and **verified against the live data on `origin/main`**.

**1. `merge-ingredients` — drop overclaim.** The description promised the merge preserves "…and SSSOM rows," but `SSSOM` appears nowhere else in the 1249-line body; the merge procedure never touches SSSOM rows. Aligned the description to the body.

**2. `manage-identifiers` — rewrite to MIM's actual model.** The skill claimed MIM is a single-file collection that mints sequential `MediaIngredientMech:NNNNNN` ids via `add_mediaingredientmech_ids.py`. Verified false:
- **0 of 2258** records have a sequential id; **all** carry a CURIE `identifier` (CHEBI ~1360, cas ~248, kgmicrobe.* ~89, mesh/MICRO/NCIT/FOODON/ENVO) or an `UNMAPPED_NNNN` placeholder (~380);
- records are **one file per ingredient** under `data/ingredients/{mapped,unmapped}/`;
- the legacy id was dropped (`scripts/migrate_drop_legacy_ontology_id.py`); the referenced minting script **doesn't exist**.

Rewrote the skill to MIM's real model (identifier = ontology CURIE for mapped, `UNMAPPED_NNNN` for unmapped; mint the next `UNMAPPED_NNNN`; promote `UNMAPPED`→CURIE on mapping) and reframed the `reference/` files as the **sister-repo** (CultureMech/CommunityMech) sequential scheme they actually document. Version 1.1.0 → 2.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)