### PR TITLE
Relabel embedding pages to reflect PaCMAP / sfdp (not UMAP)

### DIFF
--- a/docs/ingredient_graph.html
+++ b/docs/ingredient_graph.html
@@ -389,7 +389,7 @@
                 .attr('y', 35)
                 .attr('fill', '#1e293b')
                 .attr('font-weight', 500)
-                .text('UMAP Dimension 1');
+                .text('Dimension 1');
 
             g.append('g')
                 .attr('class', 'y-axis')
@@ -400,7 +400,7 @@
                 .attr('y', -45)
                 .attr('fill', '#1e293b')
                 .attr('font-weight', 500)
-                .text('UMAP Dimension 2');
+                .text('Dimension 2');
 
             // Tooltip
             const tooltip = d3.select('#tooltip');

--- a/docs/ingredient_umap.html
+++ b/docs/ingredient_umap.html
@@ -202,7 +202,7 @@
     <div class="container">
         <header>
             <h1>🧪 Ingredient Embedding Space</h1>
-            <p class="subtitle">UMAP projection of 1,098 ingredients from KG-Microbe knowledge graph (986 with real embeddings, 112 with synthetic embeddings)</p>
+            <p class="subtitle">PaCMAP projection of 1,098 ingredients from KG-Microbe knowledge graph (986 with real embeddings, 112 with synthetic embeddings)</p>
             <a href="index.html" class="nav-link">← Back to Home</a>
         </header>
 
@@ -389,7 +389,7 @@
                 .attr('y', 35)
                 .attr('fill', '#1e293b')
                 .attr('font-weight', 500)
-                .text('UMAP Dimension 1');
+                .text('Dimension 1');
 
             g.append('g')
                 .attr('class', 'y-axis')
@@ -400,7 +400,7 @@
                 .attr('y', -45)
                 .attr('fill', '#1e293b')
                 .attr('font-weight', 500)
-                .text('UMAP Dimension 2');
+                .text('Dimension 2');
 
             // Tooltip
             const tooltip = d3.select('#tooltip');


### PR DESCRIPTION
The default projection is PaCMAP and there's a separate sfdp graph-layout page — update page titles/subtitles/axis labels so the served pages read accurately. Templates made method-neutral for future regenerations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)