### PR TITLE
Landing: relabel embedding button UMAP → PaCMAP

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -68,7 +68,7 @@
       </div>
       <div class="card">
         <div class="ic">&#128506;&#65039;</div>
-        <div class="actions"><a class="btn" href="ingredient_umap.html">Explore UMAP &rarr;</a><a class="btn" href="ingredient_graph.html">Graph layout &rarr;</a></div>
+        <div class="actions"><a class="btn" href="ingredient_umap.html">Explore embedding (PaCMAP) &rarr;</a><a class="btn" href="ingredient_graph.html">Graph layout &rarr;</a></div>
         <h2>Embedding browser</h2>
         <p>Interactive UMAP of ingredient embeddings in KG-Microbe space.</p>
       </div>


### PR DESCRIPTION
The default projection is PaCMAP; the landing button still read "Explore UMAP". Now "Explore embedding (PaCMAP)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)