### PR TITLE
MIM landing: refresh stale ingredient stats (1,107 → 2,258)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -53,9 +53,9 @@
     <h1>MediaIngredientMech</h1>
     <p class="tagline">Curated media-ingredient ontology mappings — CHEBI &middot; FOODON &middot; NCIT &middot; CAS.</p>
     <div class="stats">
-      <div class="stat"><b>1,107</b><span>ingredients</span></div>
-      <div class="stat"><b>995</b><span>mapped</span></div>
-      <div class="stat"><b>89.9%</b><span>coverage</span></div>
+      <div class="stat"><b>2,258</b><span>ingredients</span></div>
+      <div class="stat"><b>1,873</b><span>mapped</span></div>
+      <div class="stat"><b>83%</b><span>coverage</span></div>
     </div>
   </header>
   <main class="wrap">


### PR DESCRIPTION
The landing hero showed 1,107 ingredients / 995 mapped / 89.9%; the curated collections have 2,258 ingredients (1,873 mapped), ~83% coverage. Updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)