### PR TITLE
MIM embedding subtitle: anchor plotted count to the 2,258 corpus

### DIFF
--- a/docs/ingredient_umap.html
+++ b/docs/ingredient_umap.html
@@ -301,9 +301,8 @@
             const subtitle = document.getElementById('subtitle');
             if (subtitle) {
                 subtitle.textContent =
-                    `PaCMAP projection of ${ingredientData.length.toLocaleString()} ingredients from the `
-                    + `KG-Microbe knowledge graph (${mapped.toLocaleString()} mapped, `
-                    + `${unmapped.toLocaleString()} unmapped)`;
+                    `PaCMAP projection of ${ingredientData.length.toLocaleString()} of 2,258 curated `
+                    + `ingredients — those with a KG-Microbe embedding`;
             }
         }
 


### PR DESCRIPTION
Resolves the 1,935-vs-1,873 confusion: the embedding subtitle now reads 'N of 2,258 curated ingredients — those with a KG-Microbe embedding', so the plotted subset is clearly a subset of the same corpus the landing reports (2,258 total, 1,873 mapped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)