### PR TITLE
MIM embedding pages: facet panel below the plot (live-filter points)

### DIFF
--- a/docs/ingredient_graph.html
+++ b/docs/ingredient_graph.html
@@ -196,6 +196,53 @@
             color: var(--text-light);
             font-size: 0.9rem;
         }
+
+        .facets {
+            margin: 0 0 1.5rem;
+            padding: 1rem 1.25rem;
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+        }
+        .facets h3 {
+            font-size: 0.8rem;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+            color: var(--text-light);
+            margin: 0 0 0.75rem;
+        }
+        .facet-groups {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1.75rem;
+        }
+        .facet-group {
+            min-width: 180px;
+        }
+        .facet-title {
+            font-weight: 600;
+            font-size: 0.9rem;
+            margin-bottom: 0.4rem;
+        }
+        label.facet-opt {
+            display: flex;
+            align-items: center;
+            gap: 0.45rem;
+            font-size: 0.85rem;
+            padding: 0.12rem 0;
+            cursor: pointer;
+        }
+        label.facet-opt .cnt {
+            margin-left: auto;
+            color: var(--text-light);
+            font-variant-numeric: tabular-nums;
+            padding-left: 1rem;
+        }
+        .facet-showing {
+            margin-top: 0.75rem;
+            font-size: 0.8rem;
+            color: var(--text-light);
+        }
     </style>
 </head>
 <body>
@@ -232,6 +279,8 @@
 
         <div class="legend" id="legend"></div>
 
+        <div class="facets" id="facet-panel"></div>
+
         <div class="info-panel">
             <h2>How to Interpret This Visualization</h2>
             <ul>
@@ -253,6 +302,64 @@
     <script>
         // Load data
         let ingredientData = [];
+        let circles = null;
+
+        // --- Facets: live-filter the plotted points (panel sits below the plot) ---
+        const FACET_FIELDS = [
+            { key: 'mapping_status', title: 'Mapping status' },
+            { key: 'ontology_source', title: 'Ontology source' },
+            { key: 'mapping_quality', title: 'Mapping quality' },
+        ];
+        const activeFacets = {};  // key -> Set of allowed (checked) values
+
+        function facetVal(d, key) { return (d[key] ?? '') === '' ? '—' : d[key]; }
+        function facetPass(d) {
+            return FACET_FIELDS.every(f => !activeFacets[f.key] || activeFacets[f.key].has(facetVal(d, f.key)));
+        }
+
+        function buildFacets() {
+            const panel = document.getElementById('facet-panel');
+            if (!panel) return;
+            panel.innerHTML = '<h3>Filter points</h3>';
+            const groups = document.createElement('div');
+            groups.className = 'facet-groups';
+            FACET_FIELDS.forEach(f => {
+                const counts = {};
+                ingredientData.forEach(d => { const v = facetVal(d, f.key); counts[v] = (counts[v] || 0) + 1; });
+                activeFacets[f.key] = new Set(Object.keys(counts));  // all checked initially
+                const grp = document.createElement('div');
+                grp.className = 'facet-group';
+                grp.innerHTML = `<div class="facet-title">${f.title}</div>`;
+                Object.keys(counts).sort().forEach(v => {
+                    const lab = document.createElement('label');
+                    lab.className = 'facet-opt';
+                    lab.innerHTML = `<input type="checkbox" checked><span>${v}</span><span class="cnt">${counts[v].toLocaleString()}</span>`;
+                    lab.querySelector('input').addEventListener('change', (e) => {
+                        if (e.target.checked) activeFacets[f.key].add(v); else activeFacets[f.key].delete(v);
+                        applyFilters();
+                    });
+                    grp.appendChild(lab);
+                });
+                groups.appendChild(grp);
+            });
+            panel.appendChild(groups);
+            const showing = document.createElement('div');
+            showing.className = 'facet-showing';
+            showing.innerHTML = `Showing <b id="facet-count">${ingredientData.length.toLocaleString()}</b> of ${ingredientData.length.toLocaleString()} points`;
+            panel.appendChild(showing);
+        }
+
+        function applyFilters() {
+            if (!circles) return;
+            const q = (document.getElementById('search').value || '').toLowerCase();
+            const match = d => !q || d.name.toLowerCase().includes(q) || d.id.toLowerCase().includes(q);
+            circles
+                .style('display', d => facetPass(d) ? null : 'none')
+                .attr('fill-opacity', d => !q ? 0.7 : (match(d) ? 0.9 : 0.2))
+                .attr('stroke-width', d => !q ? 1 : (match(d) ? 2 : 1));
+            const cnt = document.getElementById('facet-count');
+            if (cnt) cnt.textContent = ingredientData.filter(facetPass).length.toLocaleString();
+        }
 
         fetch('data/ingredient_graph.json')
             .then(response => response.json())
@@ -260,6 +367,8 @@
                 ingredientData = data;
                 updateStats();
                 renderUMAP();
+                buildFacets();
+                applyFilters();
             })
             .catch(error => {
                 console.error('Error loading data:', error);
@@ -388,7 +497,7 @@
             svg.call(zoom);
 
             // Draw points
-            const circles = g.selectAll('circle')
+            circles = g.selectAll('circle')
                 .data(ingredientData)
                 .join('circle')
                 .attr('cx', d => xScale(d.umap_x))
@@ -454,18 +563,10 @@
                     .attr('r', d => sizeScale(d[currentSizeBy] || 1));
             });
 
-            document.getElementById('search').addEventListener('input', (e) => {
-                const query = e.target.value.toLowerCase();
-                circles
-                    .attr('fill-opacity', d => {
-                        if (!query) return 0.7;
-                        return (d.name.toLowerCase().includes(query) || d.id.toLowerCase().includes(query)) ? 0.9 : 0.2;
-                    })
-                    .attr('stroke-width', d => {
-                        if (!query) return 1;
-                        return (d.name.toLowerCase().includes(query) || d.id.toLowerCase().includes(query)) ? 2 : 1;
-                    });
-            });
+            document.getElementById('search').addEventListener('input', applyFilters);
+
+            // Re-apply facet/search state whenever the plot is (re)drawn.
+            applyFilters();
         }
 
         function updateLegend(colorScale, attribute) {

--- a/docs/ingredient_umap.html
+++ b/docs/ingredient_umap.html
@@ -196,6 +196,53 @@
             color: var(--text-light);
             font-size: 0.9rem;
         }
+
+        .facets {
+            margin: 0 0 1.5rem;
+            padding: 1rem 1.25rem;
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+        }
+        .facets h3 {
+            font-size: 0.8rem;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+            color: var(--text-light);
+            margin: 0 0 0.75rem;
+        }
+        .facet-groups {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1.75rem;
+        }
+        .facet-group {
+            min-width: 180px;
+        }
+        .facet-title {
+            font-weight: 600;
+            font-size: 0.9rem;
+            margin-bottom: 0.4rem;
+        }
+        label.facet-opt {
+            display: flex;
+            align-items: center;
+            gap: 0.45rem;
+            font-size: 0.85rem;
+            padding: 0.12rem 0;
+            cursor: pointer;
+        }
+        label.facet-opt .cnt {
+            margin-left: auto;
+            color: var(--text-light);
+            font-variant-numeric: tabular-nums;
+            padding-left: 1rem;
+        }
+        .facet-showing {
+            margin-top: 0.75rem;
+            font-size: 0.8rem;
+            color: var(--text-light);
+        }
     </style>
 </head>
 <body>
@@ -232,6 +279,8 @@
 
         <div class="legend" id="legend"></div>
 
+        <div class="facets" id="facet-panel"></div>
+
         <div class="info-panel">
             <h2>How to Interpret This Visualization</h2>
             <ul>
@@ -253,6 +302,64 @@
     <script>
         // Load data
         let ingredientData = [];
+        let circles = null;
+
+        // --- Facets: live-filter the plotted points (panel sits below the plot) ---
+        const FACET_FIELDS = [
+            { key: 'mapping_status', title: 'Mapping status' },
+            { key: 'ontology_source', title: 'Ontology source' },
+            { key: 'mapping_quality', title: 'Mapping quality' },
+        ];
+        const activeFacets = {};  // key -> Set of allowed (checked) values
+
+        function facetVal(d, key) { return (d[key] ?? '') === '' ? '—' : d[key]; }
+        function facetPass(d) {
+            return FACET_FIELDS.every(f => !activeFacets[f.key] || activeFacets[f.key].has(facetVal(d, f.key)));
+        }
+
+        function buildFacets() {
+            const panel = document.getElementById('facet-panel');
+            if (!panel) return;
+            panel.innerHTML = '<h3>Filter points</h3>';
+            const groups = document.createElement('div');
+            groups.className = 'facet-groups';
+            FACET_FIELDS.forEach(f => {
+                const counts = {};
+                ingredientData.forEach(d => { const v = facetVal(d, f.key); counts[v] = (counts[v] || 0) + 1; });
+                activeFacets[f.key] = new Set(Object.keys(counts));  // all checked initially
+                const grp = document.createElement('div');
+                grp.className = 'facet-group';
+                grp.innerHTML = `<div class="facet-title">${f.title}</div>`;
+                Object.keys(counts).sort().forEach(v => {
+                    const lab = document.createElement('label');
+                    lab.className = 'facet-opt';
+                    lab.innerHTML = `<input type="checkbox" checked><span>${v}</span><span class="cnt">${counts[v].toLocaleString()}</span>`;
+                    lab.querySelector('input').addEventListener('change', (e) => {
+                        if (e.target.checked) activeFacets[f.key].add(v); else activeFacets[f.key].delete(v);
+                        applyFilters();
+                    });
+                    grp.appendChild(lab);
+                });
+                groups.appendChild(grp);
+            });
+            panel.appendChild(groups);
+            const showing = document.createElement('div');
+            showing.className = 'facet-showing';
+            showing.innerHTML = `Showing <b id="facet-count">${ingredientData.length.toLocaleString()}</b> of ${ingredientData.length.toLocaleString()} points`;
+            panel.appendChild(showing);
+        }
+
+        function applyFilters() {
+            if (!circles) return;
+            const q = (document.getElementById('search').value || '').toLowerCase();
+            const match = d => !q || d.name.toLowerCase().includes(q) || d.id.toLowerCase().includes(q);
+            circles
+                .style('display', d => facetPass(d) ? null : 'none')
+                .attr('fill-opacity', d => !q ? 0.7 : (match(d) ? 0.9 : 0.2))
+                .attr('stroke-width', d => !q ? 1 : (match(d) ? 2 : 1));
+            const cnt = document.getElementById('facet-count');
+            if (cnt) cnt.textContent = ingredientData.filter(facetPass).length.toLocaleString();
+        }
 
         fetch('data/ingredient_umap.json')
             .then(response => response.json())
@@ -260,6 +367,8 @@
                 ingredientData = data;
                 updateStats();
                 renderUMAP();
+                buildFacets();
+                applyFilters();
             })
             .catch(error => {
                 console.error('Error loading data:', error);
@@ -394,7 +503,7 @@
             svg.call(zoom);
 
             // Draw points
-            const circles = g.selectAll('circle')
+            circles = g.selectAll('circle')
                 .data(ingredientData)
                 .join('circle')
                 .attr('cx', d => xScale(d.umap_x))
@@ -460,18 +569,10 @@
                     .attr('r', d => sizeScale(d[currentSizeBy] || 1));
             });
 
-            document.getElementById('search').addEventListener('input', (e) => {
-                const query = e.target.value.toLowerCase();
-                circles
-                    .attr('fill-opacity', d => {
-                        if (!query) return 0.7;
-                        return (d.name.toLowerCase().includes(query) || d.id.toLowerCase().includes(query)) ? 0.9 : 0.2;
-                    })
-                    .attr('stroke-width', d => {
-                        if (!query) return 1;
-                        return (d.name.toLowerCase().includes(query) || d.id.toLowerCase().includes(query)) ? 2 : 1;
-                    });
-            });
+            document.getElementById('search').addEventListener('input', applyFilters);
+
+            // Re-apply facet/search state whenever the plot is (re)drawn.
+            applyFilters();
         }
 
         function updateLegend(colorScale, attribute) {


### PR DESCRIPTION
Adds a 'Filter points' facet panel below the PaCMAP + sfdp plots (Mapping status / Ontology source / Mapping quality, with counts) that live-filters the plotted points. Reference implementation for the other Mechs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)