### PR TITLE
Add toggleable dark theme + reduced-motion guard to MIM website

### DIFF
--- a/docs/browser.html
+++ b/docs/browser.html
@@ -282,6 +282,70 @@
             color: #666;
             margin-top: 3rem;
         }
+
+        /* ---- Reduced-motion guard ---- */
+        @media (prefers-reduced-motion: reduce){
+          *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;
+            transition-duration:.01ms!important;scroll-behavior:auto!important;}
+        }
+
+        /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+        @media (prefers-color-scheme: dark){
+          :root:not([data-theme="light"]) body{color:#ece9f4;background:#14121c;}
+          :root:not([data-theme="light"]) .header{background:linear-gradient(135deg,#241d33,#14121c);color:#ece9f4;}
+          :root:not([data-theme="light"]) .nav-link{background:rgba(255,255,255,.08);color:#b499f0;}
+          :root:not([data-theme="light"]) .nav-link:hover{background:rgba(255,255,255,.14);}
+          :root:not([data-theme="light"]) .stats,
+          :root:not([data-theme="light"]) .controls,
+          :root:not([data-theme="light"]) .ingredient-card{background:#1e1b29;}
+          :root:not([data-theme="light"]) .stat{border-right-color:#302b40;}
+          :root:not([data-theme="light"]) .stat-value{color:#b499f0;}
+          :root:not([data-theme="light"]) .stat-label,
+          :root:not([data-theme="light"]) .meta-item,
+          :root:not([data-theme="light"]) .filter-group label,
+          :root:not([data-theme="light"]) .synonyms-label,
+          :root:not([data-theme="light"]) .no-results,
+          :root:not([data-theme="light"]) footer{color:#a39db8;}
+          :root:not([data-theme="light"]) .search-box,
+          :root:not([data-theme="light"]) .filter-group select{background:#14121c;color:#ece9f4;border-color:#302b40;}
+          :root:not([data-theme="light"]) .search-box:focus{border-color:#b499f0;}
+          :root:not([data-theme="light"]) .ingredient-title,
+          :root:not([data-theme="light"]) .meta-label{color:#ece9f4;}
+          :root:not([data-theme="light"]) .ingredient-ontology,
+          :root:not([data-theme="light"]) .loading{color:#b499f0;}
+          :root:not([data-theme="light"]) .ingredient-meta{border-top-color:#302b40;}
+          :root:not([data-theme="light"]) .synonyms{background:#14121c;}
+          :root:not([data-theme="light"]) .synonym-tag{background:#1e1b29;border-color:#302b40;}
+          :root:not([data-theme="light"]) .badge-mapped{background:rgba(52,211,153,.15);color:#34d399;}
+          :root:not([data-theme="light"]) .badge-unmapped{background:rgba(251,191,36,.15);color:#fbbf24;}
+        }
+        :root[data-theme="dark"] body{color:#ece9f4;background:#14121c;}
+        :root[data-theme="dark"] .header{background:linear-gradient(135deg,#241d33,#14121c);color:#ece9f4;}
+        :root[data-theme="dark"] .nav-link{background:rgba(255,255,255,.08);color:#b499f0;}
+        :root[data-theme="dark"] .nav-link:hover{background:rgba(255,255,255,.14);}
+        :root[data-theme="dark"] .stats,
+        :root[data-theme="dark"] .controls,
+        :root[data-theme="dark"] .ingredient-card{background:#1e1b29;}
+        :root[data-theme="dark"] .stat{border-right-color:#302b40;}
+        :root[data-theme="dark"] .stat-value{color:#b499f0;}
+        :root[data-theme="dark"] .stat-label,
+        :root[data-theme="dark"] .meta-item,
+        :root[data-theme="dark"] .filter-group label,
+        :root[data-theme="dark"] .synonyms-label,
+        :root[data-theme="dark"] .no-results,
+        :root[data-theme="dark"] footer{color:#a39db8;}
+        :root[data-theme="dark"] .search-box,
+        :root[data-theme="dark"] .filter-group select{background:#14121c;color:#ece9f4;border-color:#302b40;}
+        :root[data-theme="dark"] .search-box:focus{border-color:#b499f0;}
+        :root[data-theme="dark"] .ingredient-title,
+        :root[data-theme="dark"] .meta-label{color:#ece9f4;}
+        :root[data-theme="dark"] .ingredient-ontology,
+        :root[data-theme="dark"] .loading{color:#b499f0;}
+        :root[data-theme="dark"] .ingredient-meta{border-top-color:#302b40;}
+        :root[data-theme="dark"] .synonyms{background:#14121c;}
+        :root[data-theme="dark"] .synonym-tag{background:#1e1b29;border-color:#302b40;}
+        :root[data-theme="dark"] .badge-mapped{background:rgba(52,211,153,.15);color:#34d399;}
+        :root[data-theme="dark"] .badge-unmapped{background:rgba(251,191,36,.15);color:#fbbf24;}
     </style>
 </head>
 <body>
@@ -480,5 +544,6 @@
         document.getElementById('filter-source').addEventListener('change', applyFilters);
         document.getElementById('filter-quality').addEventListener('change', applyFilters);
     </script>
+    <script src="theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -46,6 +46,28 @@
   footer .fam{margin:.2em 0}
   footer .fam a{margin:0 .45em;white-space:nowrap}
   footer strong{color:var(--ink)}
+  /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+  @media (prefers-color-scheme: dark){
+    :root:not([data-theme="light"]){
+      --pastel-a:#241d33; --pastel-b:#14121c; --accent:#b499f0;
+      --ink:#ece9f4; --muted:#a39db8; --card:#1e1b29; --line:#302b40;
+    }
+    :root:not([data-theme="light"]) .stat{background:rgba(255,255,255,.05)}
+    :root:not([data-theme="light"]) footer{background:rgba(255,255,255,.05)}
+    :root:not([data-theme="light"]) .btn{color:#14121c}
+  }
+  :root[data-theme="dark"]{
+    --pastel-a:#241d33; --pastel-b:#14121c; --accent:#b499f0;
+    --ink:#ece9f4; --muted:#a39db8; --card:#1e1b29; --line:#302b40;
+  }
+  :root[data-theme="dark"] .stat{background:rgba(255,255,255,.05)}
+  :root[data-theme="dark"] footer{background:rgba(255,255,255,.05)}
+  :root[data-theme="dark"] .btn{color:#14121c}
+  /* ---- Reduced-motion guard ---- */
+  @media (prefers-reduced-motion: reduce){
+    *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;
+      transition-duration:.01ms!important;scroll-behavior:auto!important;}
+  }
 </style>
 </head>
 <body>
@@ -88,5 +110,6 @@
       <a href="https://github.com/Knowledge-Graph-Hub/kg-microbe">kg-microbe</a>&middot;<a href="https://bioportal.bioontology.org/ontologies/METPO">METPO</a>
     </div>
   </footer>
+  <script src="theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/ingredient_graph.html
+++ b/docs/ingredient_graph.html
@@ -243,6 +243,36 @@
             font-size: 0.8rem;
             color: var(--text-light);
         }
+
+        /* ---- Reduced-motion guard ---- */
+        @media (prefers-reduced-motion: reduce){
+          *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;
+            transition-duration:.01ms!important;scroll-behavior:auto!important;}
+        }
+
+        /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+        @media (prefers-color-scheme: dark){
+          :root:not([data-theme="light"]){
+            --primary:#b499f0; --primary-dark:#b499f0; --secondary:#a39db8;
+            --background:#14121c; --surface:#1e1b29; --border:#302b40;
+            --text:#ece9f4; --text-light:#a39db8; --success:#34d399; --warning:#fbbf24;
+          }
+          :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#241d33,#14121c);}
+          :root:not([data-theme="light"]) h1,
+          :root:not([data-theme="light"]) .subtitle{color:#ece9f4;}
+          :root:not([data-theme="light"]) #umap-plot{background:var(--surface);color:#a39db8;}
+          :root:not([data-theme="light"]) #umap-plot text{fill:#ece9f4;}
+        }
+        :root[data-theme="dark"]{
+          --primary:#b499f0; --primary-dark:#b499f0; --secondary:#a39db8;
+          --background:#14121c; --surface:#1e1b29; --border:#302b40;
+          --text:#ece9f4; --text-light:#a39db8; --success:#34d399; --warning:#fbbf24;
+        }
+        :root[data-theme="dark"] header{background:linear-gradient(135deg,#241d33,#14121c);}
+        :root[data-theme="dark"] h1,
+        :root[data-theme="dark"] .subtitle{color:#ece9f4;}
+        :root[data-theme="dark"] #umap-plot{background:var(--surface);color:#a39db8;}
+        :root[data-theme="dark"] #umap-plot text{fill:#ece9f4;}
     </style>
 </head>
 <body>
@@ -389,6 +419,13 @@
             // Clear existing
             container.innerHTML = '';
 
+            // Theme-aware colors read from the page tokens (light values are
+            // identical to the former hard-coded ones, so the light look is unchanged).
+            const _cs = getComputedStyle(document.documentElement);
+            const axisTextColor = _cs.getPropertyValue('--text').trim() || '#1e293b';
+            const HALO = getComputedStyle(container).backgroundColor || '#fff';   // point-stroke halo = plot bg
+            const HILITE = axisTextColor;                                          // hover emphasis stroke
+
             // Create SVG
             const svg = d3.select('#umap-plot')
                 .append('svg')
@@ -469,7 +506,7 @@
                 .append('text')
                 .attr('x', plotWidth / 2)
                 .attr('y', 35)
-                .attr('fill', '#1e293b')
+                .attr('fill', axisTextColor)
                 .attr('font-weight', 500)
                 .text('Dimension 1');
 
@@ -480,7 +517,7 @@
                 .attr('transform', 'rotate(-90)')
                 .attr('x', -plotHeight / 2)
                 .attr('y', -45)
-                .attr('fill', '#1e293b')
+                .attr('fill', axisTextColor)
                 .attr('font-weight', 500)
                 .text('Dimension 2');
 
@@ -505,12 +542,12 @@
                 .attr('r', d => sizeScale(d[currentSizeBy] || 1))
                 .attr('fill', d => colorScale(d[currentColorBy] || 'Unknown'))
                 .attr('fill-opacity', 0.7)
-                .attr('stroke', '#fff')
+                .attr('stroke', HALO)
                 .attr('stroke-width', 1)
                 .style('cursor', 'pointer')
                 .on('mouseover', function(event, d) {
                     d3.select(this)
-                        .attr('stroke', '#000')
+                        .attr('stroke', HILITE)
                         .attr('stroke-width', 2);
 
                     tooltip
@@ -535,7 +572,7 @@
                 })
                 .on('mouseout', function() {
                     d3.select(this)
-                        .attr('stroke', '#fff')
+                        .attr('stroke', HALO)
                         .attr('stroke-width', 1);
                     tooltip.style('opacity', 0);
                 })
@@ -591,5 +628,6 @@
             }
         });
     </script>
+    <script src="theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/ingredient_umap.html
+++ b/docs/ingredient_umap.html
@@ -243,6 +243,36 @@
             font-size: 0.8rem;
             color: var(--text-light);
         }
+
+        /* ---- Reduced-motion guard ---- */
+        @media (prefers-reduced-motion: reduce){
+          *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;
+            transition-duration:.01ms!important;scroll-behavior:auto!important;}
+        }
+
+        /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+        @media (prefers-color-scheme: dark){
+          :root:not([data-theme="light"]){
+            --primary:#b499f0; --primary-dark:#b499f0; --secondary:#a39db8;
+            --background:#14121c; --surface:#1e1b29; --border:#302b40;
+            --text:#ece9f4; --text-light:#a39db8; --success:#34d399; --warning:#fbbf24;
+          }
+          :root:not([data-theme="light"]) header{background:linear-gradient(135deg,#241d33,#14121c);}
+          :root:not([data-theme="light"]) h1,
+          :root:not([data-theme="light"]) .subtitle{color:#ece9f4;}
+          :root:not([data-theme="light"]) #umap-plot{background:var(--surface);color:#a39db8;}
+          :root:not([data-theme="light"]) #umap-plot text{fill:#ece9f4;}
+        }
+        :root[data-theme="dark"]{
+          --primary:#b499f0; --primary-dark:#b499f0; --secondary:#a39db8;
+          --background:#14121c; --surface:#1e1b29; --border:#302b40;
+          --text:#ece9f4; --text-light:#a39db8; --success:#34d399; --warning:#fbbf24;
+        }
+        :root[data-theme="dark"] header{background:linear-gradient(135deg,#241d33,#14121c);}
+        :root[data-theme="dark"] h1,
+        :root[data-theme="dark"] .subtitle{color:#ece9f4;}
+        :root[data-theme="dark"] #umap-plot{background:var(--surface);color:#a39db8;}
+        :root[data-theme="dark"] #umap-plot text{fill:#ece9f4;}
     </style>
 </head>
 <body>
@@ -395,6 +425,13 @@
             // Clear existing
             container.innerHTML = '';
 
+            // Theme-aware colors read from the page tokens (light values are
+            // identical to the former hard-coded ones, so the light look is unchanged).
+            const _cs = getComputedStyle(document.documentElement);
+            const axisTextColor = _cs.getPropertyValue('--text').trim() || '#1e293b';
+            const HALO = getComputedStyle(container).backgroundColor || '#fff';   // point-stroke halo = plot bg
+            const HILITE = axisTextColor;                                          // hover emphasis stroke
+
             // Create SVG
             const svg = d3.select('#umap-plot')
                 .append('svg')
@@ -475,7 +512,7 @@
                 .append('text')
                 .attr('x', plotWidth / 2)
                 .attr('y', 35)
-                .attr('fill', '#1e293b')
+                .attr('fill', axisTextColor)
                 .attr('font-weight', 500)
                 .text('Dimension 1');
 
@@ -486,7 +523,7 @@
                 .attr('transform', 'rotate(-90)')
                 .attr('x', -plotHeight / 2)
                 .attr('y', -45)
-                .attr('fill', '#1e293b')
+                .attr('fill', axisTextColor)
                 .attr('font-weight', 500)
                 .text('Dimension 2');
 
@@ -511,12 +548,12 @@
                 .attr('r', d => sizeScale(d[currentSizeBy] || 1))
                 .attr('fill', d => colorScale(d[currentColorBy] || 'Unknown'))
                 .attr('fill-opacity', 0.7)
-                .attr('stroke', '#fff')
+                .attr('stroke', HALO)
                 .attr('stroke-width', 1)
                 .style('cursor', 'pointer')
                 .on('mouseover', function(event, d) {
                     d3.select(this)
-                        .attr('stroke', '#000')
+                        .attr('stroke', HILITE)
                         .attr('stroke-width', 2);
 
                     tooltip
@@ -541,7 +578,7 @@
                 })
                 .on('mouseout', function() {
                     d3.select(this)
-                        .attr('stroke', '#fff')
+                        .attr('stroke', HALO)
                         .attr('stroke-width', 1);
                     tooltip.style('opacity', 0);
                 })
@@ -597,5 +634,6 @@
             }
         });
     </script>
+    <script src="theme-toggle.js"></script>
 </body>
 </html>

--- a/docs/theme-toggle.js
+++ b/docs/theme-toggle.js
@@ -1,0 +1,74 @@
+/* Mech theme toggle — vendored byte-identical across all Mech sites.
+ * Applies the saved theme to <html data-theme> (falling back to the OS
+ * preference) before paint, and injects a self-contained fixed toggle button.
+ * No dependencies; no per-page markup or CSS required beyond loading this file.
+ * The page's own dark palette is supplied via :root[data-theme="dark"] and the
+ * prefers-color-scheme media query in that page's stylesheet. */
+(function () {
+  var KEY = 'mech-theme';
+  var root = document.documentElement;
+
+  function osDark() {
+    return !!(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches);
+  }
+  function current() {
+    return root.getAttribute('data-theme') || (osDark() ? 'dark' : 'light');
+  }
+
+  // Apply the saved preference as early as possible to avoid a flash.
+  try {
+    var saved = localStorage.getItem(KEY);
+    if (saved === 'dark' || saved === 'light') root.setAttribute('data-theme', saved);
+  } catch (e) {}
+
+  function setIcon(btn) {
+    var dark = current() === 'dark';
+    btn.querySelector('.theme-toggle-icon').textContent = dark ? '☀' : '☾'; // sun / moon
+    btn.setAttribute('aria-pressed', dark ? 'true' : 'false');
+  }
+  function toggle(btn) {
+    var next = current() === 'dark' ? 'light' : 'dark';
+    root.setAttribute('data-theme', next);
+    try { localStorage.setItem(KEY, next); } catch (e) {}
+    setIcon(btn);
+  }
+  function mount() {
+    if (document.querySelector('.theme-toggle')) return;
+
+    var css =
+      '.theme-toggle{position:fixed;bottom:18px;right:18px;z-index:2000;width:40px;height:40px;' +
+      'border-radius:50%;border:1px solid var(--line,var(--border,rgba(128,128,128,.4)));' +
+      'background:var(--card,var(--surface,var(--card-bg,#fff)));' +
+      'color:var(--ink,var(--text,var(--fg,#1a1a1a)));font-size:18px;line-height:1;cursor:pointer;' +
+      'display:flex;align-items:center;justify-content:center;box-shadow:0 2px 8px rgba(0,0,0,.25);' +
+      'transition:border-color .15s,transform .15s;}' +
+      '.theme-toggle:hover{border-color:var(--accent,var(--primary,var(--brand-1,#888)));transform:translateY(-1px);}' +
+      '.theme-toggle:focus-visible{outline:2px solid var(--accent,var(--primary,#888));outline-offset:2px;}' +
+      '@media (prefers-reduced-motion: reduce){.theme-toggle{transition:none;}}';
+    var st = document.createElement('style');
+    st.textContent = css;
+    document.head.appendChild(st);
+
+    var btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'theme-toggle';
+    btn.setAttribute('aria-label', 'Toggle dark mode');
+    btn.title = 'Toggle light / dark';
+    btn.innerHTML = '<span class="theme-toggle-icon" aria-hidden="true"></span>';
+    btn.addEventListener('click', function () { toggle(btn); });
+    document.body.appendChild(btn);
+    setIcon(btn);
+
+    // If the visitor has no explicit choice, follow live OS-theme changes.
+    if (window.matchMedia) {
+      try {
+        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function () {
+          if (!root.getAttribute('data-theme')) setIcon(btn);
+        });
+      } catch (e) {}
+    }
+  }
+
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', mount);
+  else mount();
+})();

--- a/src/mediaingredientmech/templates/style.css
+++ b/src/mediaingredientmech/templates/style.css
@@ -86,3 +86,39 @@ a { color: var(--accent); }
                       border: 1px solid #2c8a3a33; }
 .badge.type-complex { background: #fff8c5; color: #9a6700;
                       border: 1px solid #d68f0033; }
+
+/* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark){
+  :root:not([data-theme="light"]){
+    --bg: #14121c; --fg: #ece9f4; --muted: #a39db8; --line: #302b40;
+    --bg-soft: #1e1b29; --accent: #b499f0;
+    --pass: #34d399; --warn: #fbbf24; --fail: #f87171;
+  }
+  :root:not([data-theme="light"]) body{ background: var(--bg); }
+  :root:not([data-theme="light"]) .badge{ color: var(--fg); }
+  :root:not([data-theme="light"]) .evidence blockquote.snippet,
+  :root:not([data-theme="light"]) .evidence p.explanation{ color: var(--muted); }
+  :root:not([data-theme="light"]) .badge.type-defined{
+    background: rgba(52,211,153,.15); color: #34d399; border-color: rgba(52,211,153,.35); }
+  :root:not([data-theme="light"]) .badge.type-complex{
+    background: rgba(251,191,36,.15); color: #fbbf24; border-color: rgba(251,191,36,.35); }
+}
+:root[data-theme="dark"]{
+  --bg: #14121c; --fg: #ece9f4; --muted: #a39db8; --line: #302b40;
+  --bg-soft: #1e1b29; --accent: #b499f0;
+  --pass: #34d399; --warn: #fbbf24; --fail: #f87171;
+}
+:root[data-theme="dark"] body{ background: var(--bg); }
+:root[data-theme="dark"] .badge{ color: var(--fg); }
+:root[data-theme="dark"] .evidence blockquote.snippet,
+:root[data-theme="dark"] .evidence p.explanation{ color: var(--muted); }
+:root[data-theme="dark"] .badge.type-defined{
+  background: rgba(52,211,153,.15); color: #34d399; border-color: rgba(52,211,153,.35); }
+:root[data-theme="dark"] .badge.type-complex{
+  background: rgba(251,191,36,.15); color: #fbbf24; border-color: rgba(251,191,36,.35); }
+
+/* ---- Reduced-motion guard ---- */
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;
+    transition-duration:.01ms!important;scroll-behavior:auto!important;}
+}


### PR DESCRIPTION
Adds an **OS-default dark theme** with a persisted light/dark **toggle** and a **reduced-motion guard** to the reviewed MIM website pages. All dark rules are **additive** — the light appearance is unchanged.

## What changed
- **`docs/theme-toggle.js`** — vendored (byte-identical across Mechs) toggle button. Reads `localStorage` (`mech-theme`), sets `data-theme` on `<html>` before paint, injects a fixed ☾/☀ button themed from the page tokens.
- **`docs/index.html`** — dark overrides for the `--pastel-a/-b/--accent/--ink/--card/--line/--muted` token system (`--pastel-b → --bg`, `--pastel-a → heroA`), translucent-white `.stat`/`footer` darkened, `.btn` text flipped to the dark bg color; reduced-motion guard; toggle include.
- **`docs/browser.html`** — token-less page; targeted dark overrides for its specific selectors (header gradient, cards, inputs/selects, badges, borders, text) + reduced-motion + toggle. Status badges brightened (`#34d399` / `#fbbf24`).
- **`docs/ingredient_umap.html`, `docs/ingredient_graph.html`** — "slate" token system mapped by role to the dark palette; hard-coded header gradient and `#umap-plot` white background overridden; d3 scatter now reads theme tokens for the axis-label fill, the point-stroke halo (= plot bg) and the hover emphasis stroke; axis text/lines get a dark CSS override. The categorical point/legend palette is intentionally left unchanged. Reduced-motion + toggle added.
- **`src/mediaingredientmech/templates/style.css`** — record-page CSS: dark block for its `--fg/--muted/--line/--bg-soft/--accent/--pass/--warn/--fail` system (`body` bg set to `--bg`), status/type badges brightened; reduced-motion guard. The deployed (gitignored) `pages/style.css` received the identical block to stay in sync.

## Dark palette (MIM)
bg `#14121c` · surface/card `#1e1b29` · ink `#ece9f4` · muted `#a39db8` · line `#302b40` · accent `#b499f0` · heroA `#241d33` · success `#34d399` · warning `#fbbf24` · error/fail `#f87171`.

## Not touched
`app/` and `discussions/` per scope.

**Please do not merge** — review only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)