### PR TITLE
Review-cleanup sweep for the MIM website (stacks on dark-mode)

### DIFF
--- a/app/discussions/index.html
+++ b/app/discussions/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Knowledge gaps & discussions</title>
 <style>
-  :root { --fg:#1a1a1a; --muted:#666; --line:#e2e2e2; --accent:#2a6; --bg:#fff; }
+  :root { --fg:#1a1a1a; --muted:#666; --line:#e2e2e2; --accent:#2a6; --bg:#fff; --card:#fff; }
   * { box-sizing: border-box; }
   body { font-family: -apple-system, system-ui, sans-serif; color: var(--fg); margin: 0; background: var(--bg); }
   header { padding: 1rem 1.25rem; border-bottom: 1px solid var(--line); }
@@ -27,6 +27,34 @@
   a { color: var(--accent); text-decoration: none; }
   a:hover { text-decoration: underline; }
   .empty { color: var(--muted); padding: 2rem; text-align: center; }
+
+  /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+  @media (prefers-color-scheme: dark){
+    :root:not([data-theme="light"]){
+      --fg:#ece9f4; --muted:#a39db8; --line:#302b40; --accent:#4ade80;
+      --bg:#14121c; --card:#1e1b29;
+    }
+    :root:not([data-theme="light"]) body { background: var(--bg); }
+    :root:not([data-theme="light"]) .card { background: var(--card); }
+    :root:not([data-theme="light"]) .badge { background:#233047; color:#bcd3f5; }
+    :root:not([data-theme="light"]) .badge.gap { background:#3a2323; color:#f2b8b8; }
+    :root:not([data-theme="light"]) .rationale { color: var(--fg); }
+  }
+  :root[data-theme="dark"]{
+    --fg:#ece9f4; --muted:#a39db8; --line:#302b40; --accent:#4ade80;
+    --bg:#14121c; --card:#1e1b29;
+  }
+  :root[data-theme="dark"] body { background: var(--bg); }
+  :root[data-theme="dark"] .card { background: var(--card); }
+  :root[data-theme="dark"] .badge { background:#233047; color:#bcd3f5; }
+  :root[data-theme="dark"] .badge.gap { background:#3a2323; color:#f2b8b8; }
+  :root[data-theme="dark"] .rationale { color: var(--fg); }
+
+  /* ---- Reduced-motion guard ---- */
+  @media (prefers-reduced-motion: reduce){
+    *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;
+      transition-duration:.01ms!important;scroll-behavior:auto!important;}
+  }
 </style>
 </head>
 <body>
@@ -123,5 +151,6 @@
   renderFacets(); render();
 })();
 </script>
+<script src="theme-toggle.js"></script>
 </body>
 </html>

--- a/app/discussions/theme-toggle.js
+++ b/app/discussions/theme-toggle.js
@@ -1,0 +1,74 @@
+/* Mech theme toggle — vendored byte-identical across all Mech sites.
+ * Applies the saved theme to <html data-theme> (falling back to the OS
+ * preference) before paint, and injects a self-contained fixed toggle button.
+ * No dependencies; no per-page markup or CSS required beyond loading this file.
+ * The page's own dark palette is supplied via :root[data-theme="dark"] and the
+ * prefers-color-scheme media query in that page's stylesheet. */
+(function () {
+  var KEY = 'mech-theme';
+  var root = document.documentElement;
+
+  function osDark() {
+    return !!(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches);
+  }
+  function current() {
+    return root.getAttribute('data-theme') || (osDark() ? 'dark' : 'light');
+  }
+
+  // Apply the saved preference as early as possible to avoid a flash.
+  try {
+    var saved = localStorage.getItem(KEY);
+    if (saved === 'dark' || saved === 'light') root.setAttribute('data-theme', saved);
+  } catch (e) {}
+
+  function setIcon(btn) {
+    var dark = current() === 'dark';
+    btn.querySelector('.theme-toggle-icon').textContent = dark ? '☀' : '☾'; // sun / moon
+    btn.setAttribute('aria-pressed', dark ? 'true' : 'false');
+  }
+  function toggle(btn) {
+    var next = current() === 'dark' ? 'light' : 'dark';
+    root.setAttribute('data-theme', next);
+    try { localStorage.setItem(KEY, next); } catch (e) {}
+    setIcon(btn);
+  }
+  function mount() {
+    if (document.querySelector('.theme-toggle')) return;
+
+    var css =
+      '.theme-toggle{position:fixed;bottom:18px;right:18px;z-index:2000;width:40px;height:40px;' +
+      'border-radius:50%;border:1px solid var(--line,var(--border,rgba(128,128,128,.4)));' +
+      'background:var(--card,var(--surface,var(--card-bg,#fff)));' +
+      'color:var(--ink,var(--text,var(--fg,#1a1a1a)));font-size:18px;line-height:1;cursor:pointer;' +
+      'display:flex;align-items:center;justify-content:center;box-shadow:0 2px 8px rgba(0,0,0,.25);' +
+      'transition:border-color .15s,transform .15s;}' +
+      '.theme-toggle:hover{border-color:var(--accent,var(--primary,var(--brand-1,#888)));transform:translateY(-1px);}' +
+      '.theme-toggle:focus-visible{outline:2px solid var(--accent,var(--primary,#888));outline-offset:2px;}' +
+      '@media (prefers-reduced-motion: reduce){.theme-toggle{transition:none;}}';
+    var st = document.createElement('style');
+    st.textContent = css;
+    document.head.appendChild(st);
+
+    var btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'theme-toggle';
+    btn.setAttribute('aria-label', 'Toggle dark mode');
+    btn.title = 'Toggle light / dark';
+    btn.innerHTML = '<span class="theme-toggle-icon" aria-hidden="true"></span>';
+    btn.addEventListener('click', function () { toggle(btn); });
+    document.body.appendChild(btn);
+    setIcon(btn);
+
+    // If the visitor has no explicit choice, follow live OS-theme changes.
+    if (window.matchMedia) {
+      try {
+        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function () {
+          if (!root.getAttribute('data-theme')) setIcon(btn);
+        });
+      } catch (e) {}
+    }
+  }
+
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', mount);
+  else mount();
+})();

--- a/docs/browser.html
+++ b/docs/browser.html
@@ -350,7 +350,7 @@
 </head>
 <body>
     <header class="header">
-        <h1>🧪 MediaIngredientMech Browser</h1>
+        <h1>MediaIngredientMech Browser</h1>
         <p id="subtitle">Explore curated media ingredients with ontology mappings</p>
         <a href="index.html" class="nav-link">← Back to Home</a>
     </header>
@@ -361,7 +361,7 @@
                 <input type="text"
                        id="search"
                        class="search-box"
-                       placeholder="🔍 Search ingredients by name, synonym, or ontology ID...">
+                       placeholder="Search ingredients by name, synonym, or ontology ID...">
 
                 <div class="filters">
                     <div class="filter-group">
@@ -494,7 +494,7 @@
 
                     ${ing.ontology_id ? `
                         <div class="ingredient-ontology">
-                            🔗 ${ing.ontology_source}:${ing.ontology_id.split(':')[1]} — ${escapeHtml(ing.ontology_label)}
+                            ${ing.ontology_source}:${ing.ontology_id.split(':')[1]} — ${escapeHtml(ing.ontology_label)}
                             ${ing.mapping_quality ? `<span style="color: #666; font-size: 0.85rem;">(${ing.mapping_quality})</span>` : ''}
                         </div>
                     ` : ''}

--- a/docs/index.html
+++ b/docs/index.html
@@ -34,7 +34,6 @@
   .card{background:var(--card);border:1px solid var(--line);border-radius:16px;padding:28px;
         box-shadow:0 1px 3px rgba(0,0,0,.05);transition:transform .15s ease,box-shadow .15s ease}
   .card:hover{transform:translateY(-3px);box-shadow:0 10px 26px rgba(0,0,0,.10)}
-  .card .ic{font-size:2.1rem}
   .card .actions{margin:.55em 0 .9em;display:flex;flex-wrap:wrap;gap:.5em}
   .card h2{margin:.1em 0 .35em;font-size:1.25rem}
   .card p{margin:0;color:var(--muted);font-size:.95rem}
@@ -83,19 +82,16 @@
   <main class="wrap">
     <div class="cards">
       <div class="card">
-        <div class="ic">&#128270;</div>
         <div class="actions"><a class="btn" href="browser.html">Browse records &rarr;</a></div>
         <h2>Record browser</h2>
         <p>Search ingredients by name, synonym, or ontology ID; filter by source, mapping status, and mapping quality.</p>
       </div>
       <div class="card">
-        <div class="ic">&#128506;&#65039;</div>
         <div class="actions"><a class="btn" href="ingredient_umap.html">Explore embedding (PaCMAP) &rarr;</a><a class="btn" href="ingredient_graph.html">Graph layout &rarr;</a></div>
         <h2>Embedding browser</h2>
-        <p>Interactive UMAP of ingredient embeddings in KG-Microbe space.</p>
+        <p>Interactive PaCMAP projection of ingredient embeddings in KG-Microbe space.</p>
       </div>
       <div class="card">
-        <div class="ic">&#128187;</div>
         <div class="actions"><a class="btn" href="https://github.com/CultureBotAI/MediaIngredientMech">View on GitHub &rarr;</a></div>
         <h2>GitHub</h2>
         <p>Source code, data, schema, and the curation workflow.</p>
@@ -104,7 +100,7 @@
   </main>
   <footer>
     <div class="fam"><strong>KG-Microbe Mechs:</strong>
-      <a href="https://culturebotai.github.io/CultureMech/">CultureMech</a>&middot;<a href="https://culturebotai.github.io/MediaIngredientMech/">MediaIngredientMech</a>&middot;<a href="https://culturebotai.github.io/CommunityMech/">CommunityMech</a>&middot;<a href="https://culturebotai.github.io/TraitMech/">TraitMech</a>&middot;<a href="https://culturebotai.github.io/proteintraitsmech/">ProteinTraitsMech</a>
+      <a href="https://culturebotai.github.io/CultureMech/">CultureMech</a>&middot;<strong>MediaIngredientMech</strong>&middot;<a href="https://culturebotai.github.io/CommunityMech/">CommunityMech</a>&middot;<a href="https://culturebotai.github.io/TraitMech/">TraitMech</a>&middot;<a href="https://culturebotai.github.io/proteintraitsmech/">ProteinTraitsMech</a>
     </div>
     <div class="fam">
       <a href="https://github.com/Knowledge-Graph-Hub/kg-microbe">kg-microbe</a>&middot;<a href="https://bioportal.bioontology.org/ontologies/METPO">METPO</a>

--- a/docs/ingredient_graph.html
+++ b/docs/ingredient_graph.html
@@ -244,6 +244,48 @@
             color: var(--text-light);
         }
 
+        /* ---- Data-table fallback (keyboard-reachable, theme-tokenized) ---- */
+        .data-table-details {
+            margin: 0 0 1.5rem;
+            padding: 0.5rem 1rem;
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+        }
+        .data-table-details summary {
+            cursor: pointer;
+            font-weight: 600;
+            color: var(--primary);
+            padding: 0.25rem 0;
+        }
+        .data-table-wrap {
+            overflow-x: auto;
+            max-height: 420px;
+            overflow-y: auto;
+            margin-top: 0.75rem;
+        }
+        .data-table-wrap table {
+            border-collapse: collapse;
+            width: 100%;
+            font-size: 0.82rem;
+        }
+        .data-table-wrap th,
+        .data-table-wrap td {
+            text-align: left;
+            padding: 0.35rem 0.6rem;
+            border-bottom: 1px solid var(--border);
+            white-space: nowrap;
+        }
+        .data-table-wrap th {
+            position: sticky;
+            top: 0;
+            background: var(--surface);
+            color: var(--text-light);
+            text-transform: uppercase;
+            font-size: 0.72rem;
+            letter-spacing: 0.03em;
+        }
+
         /* ---- Reduced-motion guard ---- */
         @media (prefers-reduced-motion: reduce){
           *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;
@@ -278,7 +320,7 @@
 <body>
     <div class="container">
         <header>
-            <h1>🧪 Ingredient Graph layout (sfdp)</h1>
+            <h1>Ingredient Graph layout (sfdp)</h1>
             <p class="subtitle">Graphviz sfdp force-directed layout of the mutual-kNN ingredient graph from KG-Microbe embeddings</p>
             <a href="index.html" class="nav-link">← Back to Home</a>
         </header>
@@ -302,10 +344,15 @@
                 </select>
             </label>
 
-            <input type="search" id="search" placeholder="🔍 Search ingredients by name or ID...">
+            <input type="search" id="search" placeholder="Search ingredients by name or ID...">
         </div>
 
         <div id="umap-plot"></div>
+
+        <details class="data-table-details" id="data-table">
+            <summary>View data as table</summary>
+            <div class="data-table-wrap"><table id="data-table-el"></table></div>
+        </details>
 
         <div class="legend" id="legend"></div>
 
@@ -315,7 +362,7 @@
             <h2>How to Interpret This Visualization</h2>
             <ul>
                 <li><strong>Proximity:</strong> Ingredients close together have similar semantic relationships in the knowledge graph embedding space</li>
-                <li><strong>Color:</strong> Categorical grouping (default: mapping status - <span style="color: #10b981;">green = mapped</span>, <span style="color: #ef4444;">red = unmapped</span>)</li>
+                <li><strong>Color &amp; shape:</strong> Categorical grouping (default: mapping status - <span style="color: #2a78d6;">blue filled circle = mapped</span>, <span style="color: #eb6834;">orange hollow ring = unmapped</span>)</li>
                 <li><strong>Unmapped Ingredients:</strong> Complex mixtures (e.g., "Allen Medium", "Biotin Vitamin Solution") without single chemical entity embeddings - shown with synthetic embeddings near cluster center</li>
                 <li><strong>Size:</strong> Metric of interest (default: total occurrences across media recipes)</li>
                 <li><strong>Hover:</strong> View detailed metadata tooltip</li>
@@ -328,11 +375,21 @@
 
     <div class="tooltip" id="tooltip"></div>
 
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="d3.v7.min.js"></script>
     <script>
         // Load data
         let ingredientData = [];
         let circles = null;
+        let currentColorBy = 'mapping_status';  // Start with mapping_status to show unmapped
+
+        // Validated CVD-safe categorical palette (assign in order; 9th+ -> Other grey).
+        const CAT8 = ['#2a78d6', '#1baf7a', '#eda100', '#008300',
+                      '#4a3aa7', '#e34948', '#e87ba4', '#eb6834'];
+        const CAT_OTHER = '#898781';
+        // Mapping status uses colour + SHAPE: MAPPED = blue filled circle,
+        // UNMAPPED = orange hollow ring (fill:none, coloured stroke).
+        const STATUS_COLORS = { 'MAPPED': '#2a78d6', 'UNMAPPED': '#eb6834', 'PENDING_REVIEW': '#eda100' };
+        function isHollow(d, attr) { return attr === 'mapping_status' && d.mapping_status === 'UNMAPPED'; }
 
         // --- Facets: live-filter the plotted points (panel sits below the plot) ---
         const FACET_FIELDS = [
@@ -386,7 +443,10 @@
             circles
                 .style('display', d => facetPass(d) ? null : 'none')
                 .attr('fill-opacity', d => !q ? 0.7 : (match(d) ? 0.9 : 0.2))
-                .attr('stroke-width', d => !q ? 1 : (match(d) ? 2 : 1));
+                .attr('stroke-width', d => {
+                    const base = isHollow(d, currentColorBy) ? 1.6 : 1;
+                    return !q ? base : (match(d) ? base + 1 : base);
+                });
             const cnt = document.getElementById('facet-count');
             if (cnt) cnt.textContent = ingredientData.filter(facetPass).length.toLocaleString();
         }
@@ -398,6 +458,7 @@
                 updateStats();
                 renderUMAP();
                 buildFacets();
+                buildTable();
                 applyFilters();
             })
             .catch(error => {
@@ -454,42 +515,34 @@
             let currentSizeBy = 'total_occurrences';
             const sizeScale = d3.scaleSqrt()
                 .domain([0, d3.max(ingredientData, d => d[currentSizeBy])])
-                .range([3, 15]);
+                .range([5, 15]);
 
             // Color scale - special handling for mapping_status to highlight unmapped
-            let currentColorBy = 'mapping_status';  // Start with mapping_status to show unmapped
+            currentColorBy = 'mapping_status';  // Start with mapping_status to show unmapped
 
             function getColorScale(attribute) {
                 const categories = [...new Set(ingredientData.map(d => d[attribute]))].filter(c => c).sort();
 
-                // Special color scheme for mapping_status to highlight unmapped
+                // Mapping status: colour + shape (blue MAPPED, orange UNMAPPED ring).
                 if (attribute === 'mapping_status') {
-                    const colors = {
-                        'MAPPED': '#10b981',      // Green for mapped
-                        'UNMAPPED': '#ef4444',    // Red for unmapped
-                        'PENDING_REVIEW': '#f59e0b'  // Orange if any
-                    };
                     return d3.scaleOrdinal()
                         .domain(categories)
-                        .range(categories.map(c => colors[c] || '#64748b'));
+                        .range(categories.map(c => STATUS_COLORS[c] || CAT_OTHER));
                 } else if (attribute === 'ontology_source') {
-                    // For ontology source, use distinct colors
-                    const sourceColors = {
-                        'CHEBI': '#2563eb',
-                        'FOODON': '#059669',
-                        'NCIT': '#dc2626',
-                        'MESH': '#7c3aed',
-                        'UBERON': '#ea580c',
-                        'ENVO': '#0891b2',
-                        '': '#94a3b8'  // Grey for unmapped (no source)
-                    };
+                    // Assign the validated Categorical 8 in descending-frequency order;
+                    // 9th+ source -> Other grey. Order is the colourblind-safety mechanism.
+                    const freq = {};
+                    ingredientData.forEach(d => { const v = d[attribute]; if (v) freq[v] = (freq[v] || 0) + 1; });
+                    const ordered = Object.keys(freq).sort((a, b) => freq[b] - freq[a]);
+                    const map = {};
+                    ordered.forEach((c, i) => { map[c] = i < CAT8.length ? CAT8[i] : CAT_OTHER; });
                     return d3.scaleOrdinal()
                         .domain(categories)
-                        .range(categories.map(c => sourceColors[c] || '#64748b'));
+                        .range(categories.map(c => map[c] || CAT_OTHER));
                 } else {
                     return d3.scaleOrdinal()
                         .domain(categories)
-                        .range(d3.schemeTableau10);
+                        .range(categories.map((c, i) => i < CAT8.length ? CAT8[i] : CAT_OTHER));
                 }
             }
 
@@ -540,10 +593,10 @@
                 .attr('cx', d => xScale(d.umap_x))
                 .attr('cy', d => yScale(d.umap_y))
                 .attr('r', d => sizeScale(d[currentSizeBy] || 1))
-                .attr('fill', d => colorScale(d[currentColorBy] || 'Unknown'))
+                .attr('fill', d => isHollow(d, currentColorBy) ? 'none' : colorScale(d[currentColorBy] || 'Unknown'))
                 .attr('fill-opacity', 0.7)
-                .attr('stroke', HALO)
-                .attr('stroke-width', 1)
+                .attr('stroke', d => isHollow(d, currentColorBy) ? STATUS_COLORS.UNMAPPED : HALO)
+                .attr('stroke-width', d => isHollow(d, currentColorBy) ? 1.6 : 1)
                 .style('cursor', 'pointer')
                 .on('mouseover', function(event, d) {
                     d3.select(this)
@@ -570,10 +623,10 @@
                             <div class="tooltip-row">Synonyms: ${d.num_synonyms}</div>
                         `);
                 })
-                .on('mouseout', function() {
+                .on('mouseout', function(event, d) {
                     d3.select(this)
-                        .attr('stroke', HALO)
-                        .attr('stroke-width', 1);
+                        .attr('stroke', isHollow(d, currentColorBy) ? STATUS_COLORS.UNMAPPED : HALO)
+                        .attr('stroke-width', isHollow(d, currentColorBy) ? 1.6 : 1);
                     tooltip.style('opacity', 0);
                 })
                 .on('click', (event, d) => {
@@ -588,8 +641,12 @@
                 currentColorBy = e.target.value;
                 const newColorScale = getColorScale(currentColorBy);
 
-                circles.attr('fill', d => newColorScale(d[currentColorBy] || 'Unknown'));
+                circles
+                    .attr('fill', d => isHollow(d, currentColorBy) ? 'none' : newColorScale(d[currentColorBy] || 'Unknown'))
+                    .attr('stroke', d => isHollow(d, currentColorBy) ? STATUS_COLORS.UNMAPPED : HALO)
+                    .attr('stroke-width', d => isHollow(d, currentColorBy) ? 1.6 : 1);
                 updateLegend(newColorScale, currentColorBy);
+                applyFilters();
             });
 
             document.getElementById('size-by').addEventListener('change', (e) => {
@@ -613,12 +670,34 @@
             colorScale.domain().forEach(value => {
                 const item = document.createElement('div');
                 item.className = 'legend-item';
+                // Mapping-status UNMAPPED is drawn as a hollow ring — mirror that in the swatch.
+                const hollow = attribute === 'mapping_status' && value === 'UNMAPPED';
+                const swatch = hollow
+                    ? `<div class="legend-color" style="background:transparent;border:2px solid ${colorScale(value)};border-radius:50%"></div>`
+                    : `<div class="legend-color" style="background-color: ${colorScale(value)}"></div>`;
                 item.innerHTML = `
-                    <div class="legend-color" style="background-color: ${colorScale(value)}"></div>
+                    ${swatch}
                     <span>${value || 'Unknown'}</span>
                 `;
                 legend.appendChild(item);
             });
+        }
+
+        function buildTable() {
+            const el = document.getElementById('data-table-el');
+            if (!el) return;
+            const cols = [
+                ['name', 'Ingredient'], ['id', 'ID'], ['ontology_source', 'Source'],
+                ['ontology_id', 'Ontology ID'], ['ontology_label', 'Ontology label'],
+                ['mapping_status', 'Status'], ['total_occurrences', 'Occurrences'],
+                ['media_count', 'Media count']
+            ];
+            const esc = s => String(s ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+            const head = '<thead><tr>' + cols.map(c => `<th>${c[1]}</th>`).join('') + '</tr></thead>';
+            const rows = ingredientData.map(d =>
+                '<tr>' + cols.map(c => `<td>${esc(d[c[0]])}</td>`).join('') + '</tr>'
+            ).join('');
+            el.innerHTML = head + '<tbody>' + rows + '</tbody>';
         }
 
         // Handle window resize

--- a/docs/ingredient_umap.html
+++ b/docs/ingredient_umap.html
@@ -244,6 +244,48 @@
             color: var(--text-light);
         }
 
+        /* ---- Data-table fallback (keyboard-reachable, theme-tokenized) ---- */
+        .data-table-details {
+            margin: 0 0 1.5rem;
+            padding: 0.5rem 1rem;
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+        }
+        .data-table-details summary {
+            cursor: pointer;
+            font-weight: 600;
+            color: var(--primary);
+            padding: 0.25rem 0;
+        }
+        .data-table-wrap {
+            overflow-x: auto;
+            max-height: 420px;
+            overflow-y: auto;
+            margin-top: 0.75rem;
+        }
+        .data-table-wrap table {
+            border-collapse: collapse;
+            width: 100%;
+            font-size: 0.82rem;
+        }
+        .data-table-wrap th,
+        .data-table-wrap td {
+            text-align: left;
+            padding: 0.35rem 0.6rem;
+            border-bottom: 1px solid var(--border);
+            white-space: nowrap;
+        }
+        .data-table-wrap th {
+            position: sticky;
+            top: 0;
+            background: var(--surface);
+            color: var(--text-light);
+            text-transform: uppercase;
+            font-size: 0.72rem;
+            letter-spacing: 0.03em;
+        }
+
         /* ---- Reduced-motion guard ---- */
         @media (prefers-reduced-motion: reduce){
           *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;
@@ -278,7 +320,7 @@
 <body>
     <div class="container">
         <header>
-            <h1>🧪 Ingredient Embedding Space</h1>
+            <h1>Ingredient Embedding Space</h1>
             <p class="subtitle" id="subtitle">PaCMAP projection of ingredients from the KG-Microbe knowledge graph</p>
             <a href="index.html" class="nav-link">← Back to Home</a>
         </header>
@@ -302,10 +344,15 @@
                 </select>
             </label>
 
-            <input type="search" id="search" placeholder="🔍 Search ingredients by name or ID...">
+            <input type="search" id="search" placeholder="Search ingredients by name or ID...">
         </div>
 
         <div id="umap-plot"></div>
+
+        <details class="data-table-details" id="data-table">
+            <summary>View data as table</summary>
+            <div class="data-table-wrap"><table id="data-table-el"></table></div>
+        </details>
 
         <div class="legend" id="legend"></div>
 
@@ -315,7 +362,7 @@
             <h2>How to Interpret This Visualization</h2>
             <ul>
                 <li><strong>Proximity:</strong> Ingredients close together have similar semantic relationships in the knowledge graph embedding space</li>
-                <li><strong>Color:</strong> Categorical grouping (default: mapping status - <span style="color: #10b981;">green = mapped</span>, <span style="color: #ef4444;">red = unmapped</span>)</li>
+                <li><strong>Color &amp; shape:</strong> Categorical grouping (default: mapping status - <span style="color: #2a78d6;">blue filled circle = mapped</span>, <span style="color: #eb6834;">orange hollow ring = unmapped</span>)</li>
                 <li><strong>Unmapped Ingredients:</strong> Complex mixtures (e.g., "Allen Medium", "Biotin Vitamin Solution") without single chemical entity embeddings - shown with synthetic embeddings near cluster center</li>
                 <li><strong>Size:</strong> Metric of interest (default: total occurrences across media recipes)</li>
                 <li><strong>Hover:</strong> View detailed metadata tooltip</li>
@@ -328,11 +375,21 @@
 
     <div class="tooltip" id="tooltip"></div>
 
-    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="d3.v7.min.js"></script>
     <script>
         // Load data
         let ingredientData = [];
         let circles = null;
+        let currentColorBy = 'mapping_status';  // Start with mapping_status to show unmapped
+
+        // Validated CVD-safe categorical palette (assign in order; 9th+ -> Other grey).
+        const CAT8 = ['#2a78d6', '#1baf7a', '#eda100', '#008300',
+                      '#4a3aa7', '#e34948', '#e87ba4', '#eb6834'];
+        const CAT_OTHER = '#898781';
+        // Mapping status uses colour + SHAPE: MAPPED = blue filled circle,
+        // UNMAPPED = orange hollow ring (fill:none, coloured stroke).
+        const STATUS_COLORS = { 'MAPPED': '#2a78d6', 'UNMAPPED': '#eb6834', 'PENDING_REVIEW': '#eda100' };
+        function isHollow(d, attr) { return attr === 'mapping_status' && d.mapping_status === 'UNMAPPED'; }
 
         // --- Facets: live-filter the plotted points (panel sits below the plot) ---
         const FACET_FIELDS = [
@@ -386,7 +443,10 @@
             circles
                 .style('display', d => facetPass(d) ? null : 'none')
                 .attr('fill-opacity', d => !q ? 0.7 : (match(d) ? 0.9 : 0.2))
-                .attr('stroke-width', d => !q ? 1 : (match(d) ? 2 : 1));
+                .attr('stroke-width', d => {
+                    const base = isHollow(d, currentColorBy) ? 1.6 : 1;
+                    return !q ? base : (match(d) ? base + 1 : base);
+                });
             const cnt = document.getElementById('facet-count');
             if (cnt) cnt.textContent = ingredientData.filter(facetPass).length.toLocaleString();
         }
@@ -398,6 +458,7 @@
                 updateStats();
                 renderUMAP();
                 buildFacets();
+                buildTable();
                 applyFilters();
             })
             .catch(error => {
@@ -460,42 +521,34 @@
             let currentSizeBy = 'total_occurrences';
             const sizeScale = d3.scaleSqrt()
                 .domain([0, d3.max(ingredientData, d => d[currentSizeBy])])
-                .range([3, 15]);
+                .range([5, 15]);
 
             // Color scale - special handling for mapping_status to highlight unmapped
-            let currentColorBy = 'mapping_status';  // Start with mapping_status to show unmapped
+            currentColorBy = 'mapping_status';  // Start with mapping_status to show unmapped
 
             function getColorScale(attribute) {
                 const categories = [...new Set(ingredientData.map(d => d[attribute]))].filter(c => c).sort();
 
-                // Special color scheme for mapping_status to highlight unmapped
+                // Mapping status: colour + shape (blue MAPPED, orange UNMAPPED ring).
                 if (attribute === 'mapping_status') {
-                    const colors = {
-                        'MAPPED': '#10b981',      // Green for mapped
-                        'UNMAPPED': '#ef4444',    // Red for unmapped
-                        'PENDING_REVIEW': '#f59e0b'  // Orange if any
-                    };
                     return d3.scaleOrdinal()
                         .domain(categories)
-                        .range(categories.map(c => colors[c] || '#64748b'));
+                        .range(categories.map(c => STATUS_COLORS[c] || CAT_OTHER));
                 } else if (attribute === 'ontology_source') {
-                    // For ontology source, use distinct colors
-                    const sourceColors = {
-                        'CHEBI': '#2563eb',
-                        'FOODON': '#059669',
-                        'NCIT': '#dc2626',
-                        'MESH': '#7c3aed',
-                        'UBERON': '#ea580c',
-                        'ENVO': '#0891b2',
-                        '': '#94a3b8'  // Grey for unmapped (no source)
-                    };
+                    // Assign the validated Categorical 8 in descending-frequency order;
+                    // 9th+ source -> Other grey. Order is the colourblind-safety mechanism.
+                    const freq = {};
+                    ingredientData.forEach(d => { const v = d[attribute]; if (v) freq[v] = (freq[v] || 0) + 1; });
+                    const ordered = Object.keys(freq).sort((a, b) => freq[b] - freq[a]);
+                    const map = {};
+                    ordered.forEach((c, i) => { map[c] = i < CAT8.length ? CAT8[i] : CAT_OTHER; });
                     return d3.scaleOrdinal()
                         .domain(categories)
-                        .range(categories.map(c => sourceColors[c] || '#64748b'));
+                        .range(categories.map(c => map[c] || CAT_OTHER));
                 } else {
                     return d3.scaleOrdinal()
                         .domain(categories)
-                        .range(d3.schemeTableau10);
+                        .range(categories.map((c, i) => i < CAT8.length ? CAT8[i] : CAT_OTHER));
                 }
             }
 
@@ -546,10 +599,10 @@
                 .attr('cx', d => xScale(d.umap_x))
                 .attr('cy', d => yScale(d.umap_y))
                 .attr('r', d => sizeScale(d[currentSizeBy] || 1))
-                .attr('fill', d => colorScale(d[currentColorBy] || 'Unknown'))
+                .attr('fill', d => isHollow(d, currentColorBy) ? 'none' : colorScale(d[currentColorBy] || 'Unknown'))
                 .attr('fill-opacity', 0.7)
-                .attr('stroke', HALO)
-                .attr('stroke-width', 1)
+                .attr('stroke', d => isHollow(d, currentColorBy) ? STATUS_COLORS.UNMAPPED : HALO)
+                .attr('stroke-width', d => isHollow(d, currentColorBy) ? 1.6 : 1)
                 .style('cursor', 'pointer')
                 .on('mouseover', function(event, d) {
                     d3.select(this)
@@ -576,10 +629,10 @@
                             <div class="tooltip-row">Synonyms: ${d.num_synonyms}</div>
                         `);
                 })
-                .on('mouseout', function() {
+                .on('mouseout', function(event, d) {
                     d3.select(this)
-                        .attr('stroke', HALO)
-                        .attr('stroke-width', 1);
+                        .attr('stroke', isHollow(d, currentColorBy) ? STATUS_COLORS.UNMAPPED : HALO)
+                        .attr('stroke-width', isHollow(d, currentColorBy) ? 1.6 : 1);
                     tooltip.style('opacity', 0);
                 })
                 .on('click', (event, d) => {
@@ -594,8 +647,12 @@
                 currentColorBy = e.target.value;
                 const newColorScale = getColorScale(currentColorBy);
 
-                circles.attr('fill', d => newColorScale(d[currentColorBy] || 'Unknown'));
+                circles
+                    .attr('fill', d => isHollow(d, currentColorBy) ? 'none' : newColorScale(d[currentColorBy] || 'Unknown'))
+                    .attr('stroke', d => isHollow(d, currentColorBy) ? STATUS_COLORS.UNMAPPED : HALO)
+                    .attr('stroke-width', d => isHollow(d, currentColorBy) ? 1.6 : 1);
                 updateLegend(newColorScale, currentColorBy);
+                applyFilters();
             });
 
             document.getElementById('size-by').addEventListener('change', (e) => {
@@ -619,12 +676,34 @@
             colorScale.domain().forEach(value => {
                 const item = document.createElement('div');
                 item.className = 'legend-item';
+                // Mapping-status UNMAPPED is drawn as a hollow ring — mirror that in the swatch.
+                const hollow = attribute === 'mapping_status' && value === 'UNMAPPED';
+                const swatch = hollow
+                    ? `<div class="legend-color" style="background:transparent;border:2px solid ${colorScale(value)};border-radius:50%"></div>`
+                    : `<div class="legend-color" style="background-color: ${colorScale(value)}"></div>`;
                 item.innerHTML = `
-                    <div class="legend-color" style="background-color: ${colorScale(value)}"></div>
+                    ${swatch}
                     <span>${value || 'Unknown'}</span>
                 `;
                 legend.appendChild(item);
             });
+        }
+
+        function buildTable() {
+            const el = document.getElementById('data-table-el');
+            if (!el) return;
+            const cols = [
+                ['name', 'Ingredient'], ['id', 'ID'], ['ontology_source', 'Source'],
+                ['ontology_id', 'Ontology ID'], ['ontology_label', 'Ontology label'],
+                ['mapping_status', 'Status'], ['total_occurrences', 'Occurrences'],
+                ['media_count', 'Media count']
+            ];
+            const esc = s => String(s ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+            const head = '<thead><tr>' + cols.map(c => `<th>${c[1]}</th>`).join('') + '</tr></thead>';
+            const rows = ingredientData.map(d =>
+                '<tr>' + cols.map(c => `<td>${esc(d[c[0]])}</td>`).join('') + '</tr>'
+            ).join('');
+            el.innerHTML = head + '<tbody>' + rows + '</tbody>';
         }
 
         // Handle window resize


### PR DESCRIPTION
Stacks on \`feat/dark-mode-toggle\`. **Do not merge** until the dark-mode base lands. Additive; light and dark themes both remain intact.

## Changes
- **R1 (vendor d3):** drop the `d3js.org` CDN `<script>` on `docs/ingredient_umap.html` + `docs/ingredient_graph.html`; use the already-vendored `docs/d3.v7.min.js`.
- **R6 (markers):** size-scale floor `range([3,15])` → `range([5,15])` on both scatter pages.
- **MIM mapping-status (colour + SHAPE):** MAPPED = `#2a78d6` blue filled circle; UNMAPPED = `#eb6834` orange hollow ring (`fill:none` + coloured stroke), reflected in the marks and the legend swatch. `ontology_source` → validated Categorical 8 (descending-frequency order, 9th+ → Other grey); the third colour-by view also uses the Categorical 8 instead of `schemeTableau10`. Info-panel legend copy updated.
- **R2 (PaCMAP):** `docs/index.html` embedding card body "Interactive UMAP" → "Interactive PaCMAP projection". (Scatter page titles/subtitles already say PaCMAP / sfdp.)
- **R3 (emoji):** removed decorative glyphs — `index.html` card icons, `browser.html` header/search/ontology-row, and h1/search on both scatter pages.
- **R5 (data table):** keyboard-reachable, theme-tokenized `<details>` "View data as table" below the plot on both scatter pages, built from the same data.
- **R4 (footer self-link):** MediaIngredientMech rendered as plain text in the `docs/index.html` family footer.
- **Discussions dark + toggle:** `app/discussions/index.html` gets the dark palette block, reduced-motion guard, and a vendored `theme-toggle.js` alongside it (include path `theme-toggle.js` resolves in that dir).

## Judgment calls
- The scatter HTML pages are hand-maintained (the Python generator only emits the JSON), so edits are applied directly to the `docs/*.html` files — no template regeneration or embedding pipeline run.
- `docs/d3.v7.min.js` was already present and byte-identical to the CommunityMech source, so only the CDN `<script>` refs needed changing.
- All 5 present `ontology_source` values (CHEBI, NCIT, FOODON, ENVO, UBERON) fit within the Categorical 8 — nothing overflows to grey.
- Tooltip `⚠️` on unmapped records kept (per R3 it carries real data meaning).
- The discussions page lives under `app/` (not `docs/`), so `theme-toggle.js` was vendored into `app/discussions/` rather than referencing a `docs/` copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)