### PR TITLE
Dark mode: restore MIM brand pastel pair in hero + cards

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -54,6 +54,15 @@
     :root:not([data-theme="light"]) .stat{background:rgba(255,255,255,.05)}
     :root:not([data-theme="light"]) footer{background:rgba(255,255,255,.05)}
     :root:not([data-theme="light"]) .btn{color:#14121c}
+    /* brand pastel pair, dark-only: darkened fill + vivid top edge */
+    :root:not([data-theme="light"]) .hero{position:relative;
+      background:linear-gradient(135deg,#465358,#504b5c)}
+    :root:not([data-theme="light"]) .hero::before{content:"";position:absolute;
+      top:0;left:0;right:0;height:3px;background:linear-gradient(90deg,#BCEBE4,#DCD0F3)}
+    :root:not([data-theme="light"]) .card{position:relative}
+    :root:not([data-theme="light"]) .card::before{content:"";position:absolute;
+      top:0;left:0;right:0;height:2px;border-radius:16px 16px 0 0;
+      background:linear-gradient(90deg,#BCEBE4,#DCD0F3)}
   }
   :root[data-theme="dark"]{
     --pastel-a:#241d33; --pastel-b:#14121c; --accent:#b499f0;
@@ -62,6 +71,15 @@
   :root[data-theme="dark"] .stat{background:rgba(255,255,255,.05)}
   :root[data-theme="dark"] footer{background:rgba(255,255,255,.05)}
   :root[data-theme="dark"] .btn{color:#14121c}
+  /* brand pastel pair, dark-only: darkened fill + vivid top edge */
+  :root[data-theme="dark"] .hero{position:relative;
+    background:linear-gradient(135deg,#465358,#504b5c)}
+  :root[data-theme="dark"] .hero::before{content:"";position:absolute;
+    top:0;left:0;right:0;height:3px;background:linear-gradient(90deg,#BCEBE4,#DCD0F3)}
+  :root[data-theme="dark"] .card{position:relative}
+  :root[data-theme="dark"] .card::before{content:"";position:absolute;
+    top:0;left:0;right:0;height:2px;border-radius:16px 16px 0 0;
+    background:linear-gradient(90deg,#BCEBE4,#DCD0F3)}
   /* ---- Reduced-motion guard ---- */
   @media (prefers-reduced-motion: reduce){
     *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;


### PR DESCRIPTION
Small dark-mode refinement: bring the MIM brand pastel **pair** (aqua `#BCEBE4` / purple `#DCD0F3`) back into the dark theme, which had neutralized it.

## What changed
`docs/index.html` (static landing) — 18 additive lines, all inside the two dark selectors:
- **Hero**: darkened pastel-pair fill `#465358 → #504b5c` (light-ink contrast ≥6.4:1) + a 3px **vivid** pastel-pair top edge via `::before` (top-only, so the existing bottom divider is untouched).
- **Cards**: subtle 2px vivid pastel-pair top edge via `::before` (respects the 16px corner radius).

Mirrored under both dark selectors: `@media (prefers-color-scheme: dark) :root:not([data-theme="light"])` and `:root[data-theme="dark"]`.

## Verification
- Light theme **byte-identical** — every new rule is scoped to a dark selector (diff is pure insertions, 0 deletions).
- Dark page background **unchanged** — `--pastel-b` / `--card` / `--bg` tokens not touched.
- Hero in dark shows the darkened pastel-pair gradient + vivid pastel-pair top edge; light text stays legible.

**Do not merge** — leader merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)