### PR TITLE
MIM #114 follow-ups: media→DEFINED_MEDIUM reclassification, Carnitine dedup decision, peptone prose

### DIFF
--- a/data/ingredients/mapped/Carnitine_Hydrochloride.yaml
+++ b/data/ingredients/mapped/Carnitine_Hydrochloride.yaml
@@ -55,4 +55,12 @@ curation_history:
     identifier CHEBI:48601 -> kgmicrobe.compound:carnitine_hydrochloride; removed erroneous
     cas_rn 461-05-2 and amide chemistry backfill (molecular_formula/inchi/smiles).'
   llm_assisted: true
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_dedup_review_114
+  action: DEDUP_REVIEWED
+  changes: 'Reviewed for duplication vs Carnitine (Dl) Hydrochloride (cas:461-06-3). Decision:
+    NOT merged - distinct name surface-forms (stereo-unspecified "Carnitine Hydrochloride"
+    from CultureBotHT vs racemic "DL"); both correctly map to the stereo-unspecified parent
+    CHEBI:17126 (carnitine). MIM keeps one record per surface-form.'
+  llm_assisted: true
 ingredient_type: SINGLE_INGREDIENT

--- a/data/ingredients/mapped/Phytone.yaml
+++ b/data/ingredients/mapped/Phytone.yaml
@@ -38,7 +38,7 @@ curation_history:
   curator: cbclaw_followups_114
   action: MAPPED
   changes: 'Mapped residual peptone variant: identifier UNMAPPED_0488 -> FOODON:03315720
-    (vegetable protein, hydrolyzed), EXACT_MATCH, mirroring sibling Soy_Peptone (Phytone
+    (vegetable protein, hydrolyzed), CLOSE_MATCH, mirroring sibling Soy_Peptone (Phytone
     = BD papaic soy-meal digest). mapping_status UNMAPPED -> MAPPED.'
   previous_status: UNMAPPED
   new_status: MAPPED

--- a/data/ingredients/mapped/Soya_Pepton.yaml
+++ b/data/ingredients/mapped/Soya_Pepton.yaml
@@ -39,7 +39,7 @@ curation_history:
   curator: cbclaw_followups_114
   action: MAPPED
   changes: 'Mapped residual peptone variant: identifier UNMAPPED_0531 -> FOODON:03315720
-    (vegetable protein, hydrolyzed), EXACT_MATCH, mirroring sibling Soy_Peptone (''Soya
+    (vegetable protein, hydrolyzed), CLOSE_MATCH, mirroring sibling Soy_Peptone (''Soya
     pepton'' = misspelled soy peptone). mapping_status UNMAPPED -> MAPPED.'
   previous_status: UNMAPPED
   new_status: MAPPED

--- a/data/ingredients/mapped/Soya_Peptone.yaml
+++ b/data/ingredients/mapped/Soya_Peptone.yaml
@@ -49,7 +49,7 @@ curation_history:
   curator: cbclaw_followups_114
   action: MAPPED
   changes: 'Registry->ontology upgrade: identifier cas:91079-46-8 (FALLBACK_REGISTRY)
-    -> FOODON:03315720 (vegetable protein, hydrolyzed), EXACT_MATCH, mirroring sibling
+    -> FOODON:03315720 (vegetable protein, hydrolyzed), CLOSE_MATCH, mirroring sibling
     Soy_Peptone. Removed bogus PubChem structure backfill (molecular_formula
     C290H252N8O72 / smiles / inchi / pubchem_cid 167312541 resolved from a wrong CID);
     ingredient_type SINGLE_INGREDIENT -> UNDEFINED_MIXTURE. CAS 91079-46-8 retained.'

--- a/data/ingredients/unmapped/Anaerobe_Basal_Broth_CM0957.yaml
+++ b/data/ingredients/unmapped/Anaerobe_Basal_Broth_CM0957.yaml
@@ -21,6 +21,12 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Broth')
   llm_assisted: false
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Imported from mim-queue (source_id=mediadive.ingredient:1473); no CAS-RN or
   CHEBI/NCIT match. Curator review needed.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/BCYE_Agar.yaml
+++ b/data/ingredients/unmapped/BCYE_Agar.yaml
@@ -25,6 +25,12 @@ curation_history:
   previous_status: UNMAPPED
   new_status: UNMAPPED
   llm_assisted: true
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Extracted from over-conflated Agar.yaml synonyms; reviewed on 2026-05-11 as
   a named agar medium/base preparation, not agar identity.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/BL_Agar.yaml
+++ b/data/ingredients/unmapped/BL_Agar.yaml
@@ -25,6 +25,12 @@ curation_history:
   previous_status: UNMAPPED
   new_status: UNMAPPED
   llm_assisted: true
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Extracted from over-conflated Agar.yaml synonyms; reviewed on 2026-05-11 as
   a named agar medium/base preparation, not agar identity.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/Bacto_Heart_Infusion_Broth.yaml
+++ b/data/ingredients/unmapped/Bacto_Heart_Infusion_Broth.yaml
@@ -21,6 +21,12 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Infusion')
   llm_assisted: false
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Imported from mim-queue (source_id=mediadive.ingredient:1460); no CAS-RN or
   CHEBI/NCIT match. Curator review needed.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/Bacto_M_TGE_Broth.yaml
+++ b/data/ingredients/unmapped/Bacto_M_TGE_Broth.yaml
@@ -21,6 +21,12 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'broth')
   llm_assisted: false
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Imported from mim-queue (source_id=mediadive.ingredient:1896); no CAS-RN or
   CHEBI/NCIT match. Curator review needed.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/Bacto_Middlebrook_7H10_Agar.yaml
+++ b/data/ingredients/unmapped/Bacto_Middlebrook_7H10_Agar.yaml
@@ -25,6 +25,12 @@ curation_history:
   previous_status: UNMAPPED
   new_status: UNMAPPED
   llm_assisted: true
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Extracted from over-conflated Agar.yaml synonyms; reviewed on 2026-05-11 as
   a commercial agar medium/base preparation, not agar identity.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/Blood_Agar_Base.yaml
+++ b/data/ingredients/unmapped/Blood_Agar_Base.yaml
@@ -24,7 +24,13 @@ curation_history:
   previous_status: UNMAPPED
   new_status: UNMAPPED
   llm_assisted: true
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Imported from mim-queue (source_id=mediadive.ingredient:2130); no CAS-RN or
   CHEBI/NCIT match. Reviewed on 2026-05-11 as a blood agar base preparation pending
   product- or recipe-level curation.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/Blood_Agar_No_2.yaml
+++ b/data/ingredients/unmapped/Blood_Agar_No_2.yaml
@@ -24,7 +24,13 @@ curation_history:
   previous_status: UNMAPPED
   new_status: UNMAPPED
   llm_assisted: true
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Imported from mim-queue (source_id=mediadive.ingredient:2111); no CAS-RN or
   CHEBI/NCIT match. Reviewed on 2026-05-11 as a blood agar medium/base preparation
   pending product- or recipe-level curation.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/Bordet-Gengou-Agar-Base.yaml
+++ b/data/ingredients/unmapped/Bordet-Gengou-Agar-Base.yaml
@@ -24,7 +24,13 @@ curation_history:
   previous_status: UNMAPPED
   new_status: UNMAPPED
   llm_assisted: true
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Imported from mim-queue (source_id=mediadive.ingredient:2112); no CAS-RN or
   CHEBI/NCIT match. Reviewed on 2026-05-11 as an agar base preparation pending product-
   or recipe-level curation.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/Brewer_Anaerobic_Agar.yaml
+++ b/data/ingredients/unmapped/Brewer_Anaerobic_Agar.yaml
@@ -25,6 +25,12 @@ curation_history:
   previous_status: UNMAPPED
   new_status: UNMAPPED
   llm_assisted: true
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Extracted from over-conflated Agar.yaml synonyms; reviewed on 2026-05-11 as
   a named agar medium/base preparation, not agar identity.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/Brucella_Broth.yaml
+++ b/data/ingredients/unmapped/Brucella_Broth.yaml
@@ -21,6 +21,12 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Broth')
   llm_assisted: false
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Imported from mim-queue (source_id=mediadive.ingredient:1136); no CAS-RN or
   CHEBI/NCIT match. Curator review needed.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/Casman-Agar-Base.yaml
+++ b/data/ingredients/unmapped/Casman-Agar-Base.yaml
@@ -24,7 +24,13 @@ curation_history:
   previous_status: UNMAPPED
   new_status: UNMAPPED
   llm_assisted: true
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Imported from mim-queue (source_id=mediadive.ingredient:2099); no CAS-RN or
   CHEBI/NCIT match. Reviewed on 2026-05-11 as an agar base preparation pending product-
   or recipe-level curation.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/Columbia_Blood_Agar_Base.yaml
+++ b/data/ingredients/unmapped/Columbia_Blood_Agar_Base.yaml
@@ -25,6 +25,12 @@ curation_history:
   previous_status: UNMAPPED
   new_status: UNMAPPED
   llm_assisted: true
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Extracted from over-conflated Agar.yaml synonyms; reviewed on 2026-05-11 as
   a blood agar base preparation, not agar identity.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/Corn_Meal_Agar.yaml
+++ b/data/ingredients/unmapped/Corn_Meal_Agar.yaml
@@ -25,6 +25,12 @@ curation_history:
   previous_status: UNMAPPED
   new_status: UNMAPPED
   llm_assisted: true
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Extracted from over-conflated Agar.yaml synonyms; reviewed on 2026-05-11 as
   a corn meal agar medium preparation, not agar identity.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/Dehydrated_RCM_Medium.yaml
+++ b/data/ingredients/unmapped/Dehydrated_RCM_Medium.yaml
@@ -24,7 +24,13 @@ curation_history:
   previous_status: UNMAPPED
   new_status: UNMAPPED
   llm_assisted: true
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Imported from mim-queue (source_id=mediadive.ingredient:2126); no CAS-RN or
   CHEBI/NCIT match. Reviewed on 2026-05-11 as a dehydrated medium preparation pending
   product- or recipe-level curation.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/Dehydrated_Wilkins-Chalgren_Medium.yaml
+++ b/data/ingredients/unmapped/Dehydrated_Wilkins-Chalgren_Medium.yaml
@@ -24,7 +24,13 @@ curation_history:
   previous_status: UNMAPPED
   new_status: UNMAPPED
   llm_assisted: true
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Imported from mim-queue (source_id=mediadive.ingredient:2095); no CAS-RN or
   CHEBI/NCIT match. Reviewed on 2026-05-11 as a dehydrated medium preparation pending
   product- or recipe-level curation.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/Dichloran-Glycerol-agar_Base.yaml
+++ b/data/ingredients/unmapped/Dichloran-Glycerol-agar_Base.yaml
@@ -24,7 +24,13 @@ curation_history:
   previous_status: UNMAPPED
   new_status: UNMAPPED
   llm_assisted: true
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Imported from mim-queue (source_id=mediadive.ingredient:2177); no CAS-RN or
   CHEBI/NCIT match. Reviewed on 2026-05-11 as an agar base preparation pending product-
   or recipe-level curation.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/Difco_Marine_Broth.yaml
+++ b/data/ingredients/unmapped/Difco_Marine_Broth.yaml
@@ -21,6 +21,12 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'broth')
   llm_assisted: false
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Imported from mim-queue (source_id=mediadive.ingredient:530); no CAS-RN or
   CHEBI/NCIT match. Curator review needed.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/Enriched_Seawater_Medium.yaml
+++ b/data/ingredients/unmapped/Enriched_Seawater_Medium.yaml
@@ -20,5 +20,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Seawater')
   llm_assisted: false
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: 'CultureMech placeholder_id: 1'
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/Fastidious_Anaerobe_Agar.yaml
+++ b/data/ingredients/unmapped/Fastidious_Anaerobe_Agar.yaml
@@ -25,5 +25,11 @@ curation_history:
   previous_status: UNMAPPED
   new_status: UNMAPPED
   llm_assisted: true
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Extracted from over-conflated Agar.yaml synonyms
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/Fastidious_Anaerobe_Basal_Broth.yaml
+++ b/data/ingredients/unmapped/Fastidious_Anaerobe_Basal_Broth.yaml
@@ -21,6 +21,12 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Broth')
   llm_assisted: false
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Imported from mim-queue (source_id=mediadive.ingredient:1079); no CAS-RN or
   CHEBI/NCIT match. Curator review needed.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/GAM_Agar.yaml
+++ b/data/ingredients/unmapped/GAM_Agar.yaml
@@ -25,6 +25,12 @@ curation_history:
   previous_status: UNMAPPED
   new_status: UNMAPPED
   llm_assisted: true
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Extracted from over-conflated Agar.yaml synonyms; reviewed on 2026-05-11 as
   a GAM agar medium/base preparation, not agar identity.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/GAM_Broth.yaml
+++ b/data/ingredients/unmapped/GAM_Broth.yaml
@@ -21,6 +21,12 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'broth')
   llm_assisted: false
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Imported from mim-queue (source_id=mediadive.ingredient:1620); no CAS-RN or
   CHEBI/NCIT match. Curator review needed.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/GAM_Broth_Mod_Powder.yaml
+++ b/data/ingredients/unmapped/GAM_Broth_Mod_Powder.yaml
@@ -21,6 +21,12 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Broth')
   llm_assisted: false
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Imported from mim-queue (source_id=mediadive.ingredient:1564); no CAS-RN or
   CHEBI/NCIT match. Curator review needed.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/GAM_Broth_Powder.yaml
+++ b/data/ingredients/unmapped/GAM_Broth_Powder.yaml
@@ -21,6 +21,12 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Broth')
   llm_assisted: false
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Imported from mim-queue (source_id=mediadive.ingredient:1563); no CAS-RN or
   CHEBI/NCIT match. Curator review needed.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/GYP-sodium_Acetate-mineral_Salts_Broth.yaml
+++ b/data/ingredients/unmapped/GYP-sodium_Acetate-mineral_Salts_Broth.yaml
@@ -21,6 +21,12 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'broth')
   llm_assisted: false
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Imported from mim-queue (source_id=mediadive.ingredient:1618); no CAS-RN or
   CHEBI/NCIT match. Curator review needed.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/Heart_Infusion_Broth.yaml
+++ b/data/ingredients/unmapped/Heart_Infusion_Broth.yaml
@@ -21,6 +21,12 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Infusion')
   llm_assisted: false
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Imported from mim-queue (source_id=mediadive.ingredient:1104); no CAS-RN or
   CHEBI/NCIT match. Curator review needed.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/Infusion_Broth.yaml
+++ b/data/ingredients/unmapped/Infusion_Broth.yaml
@@ -21,6 +21,12 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Infusion')
   llm_assisted: false
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Imported from mim-queue (source_id=mediadive.ingredient:930); no CAS-RN or
   CHEBI/NCIT match. Curator review needed.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/Lactobacilli_MRS_Broth.yaml
+++ b/data/ingredients/unmapped/Lactobacilli_MRS_Broth.yaml
@@ -21,6 +21,12 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'broth')
   llm_assisted: false
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Imported from mim-queue (source_id=mediadive.ingredient:1711); no CAS-RN or
   CHEBI/NCIT match. Curator review needed.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/Lactobacillus_MRS_Broth.yaml
+++ b/data/ingredients/unmapped/Lactobacillus_MRS_Broth.yaml
@@ -21,6 +21,12 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'broth')
   llm_assisted: false
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Imported from mim-queue (source_id=mediadive.ingredient:1776); no CAS-RN or
   CHEBI/NCIT match. Curator review needed.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/Leptospira_Medium_Base_EMJH.yaml
+++ b/data/ingredients/unmapped/Leptospira_Medium_Base_EMJH.yaml
@@ -24,7 +24,13 @@ curation_history:
   previous_status: UNMAPPED
   new_status: UNMAPPED
   llm_assisted: true
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Imported from mim-queue (source_id=mediadive.ingredient:990); no CAS-RN or
   CHEBI/NCIT match. Reviewed on 2026-05-11 as a medium base preparation pending product-
   or recipe-level curation.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/MRS_Broth.yaml
+++ b/data/ingredients/unmapped/MRS_Broth.yaml
@@ -21,6 +21,12 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'broth')
   llm_assisted: false
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Imported from mim-queue (source_id=mediadive.ingredient:1899); no CAS-RN or
   CHEBI/NCIT match. Curator review needed.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/Man_Rogosa_Sharp_Broth.yaml
+++ b/data/ingredients/unmapped/Man_Rogosa_Sharp_Broth.yaml
@@ -21,6 +21,12 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'broth')
   llm_assisted: false
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Imported from mim-queue (source_id=mediadive.ingredient:1112); no CAS-RN or
   CHEBI/NCIT match. Curator review needed.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/Marine_Broth.yaml
+++ b/data/ingredients/unmapped/Marine_Broth.yaml
@@ -21,6 +21,12 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Broth')
   llm_assisted: false
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Imported from mim-queue (source_id=mediadive.ingredient:545); no CAS-RN or
   CHEBI/NCIT match. Curator review needed.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/Marine_Broth_2216.yaml
+++ b/data/ingredients/unmapped/Marine_Broth_2216.yaml
@@ -21,6 +21,12 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'broth')
   llm_assisted: false
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Imported from mim-queue (source_id=mediadive.ingredient:1607); no CAS-RN or
   CHEBI/NCIT match. Curator review needed.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/Mueller_Hinton_II_Agar.yaml
+++ b/data/ingredients/unmapped/Mueller_Hinton_II_Agar.yaml
@@ -25,6 +25,12 @@ curation_history:
   previous_status: UNMAPPED
   new_status: UNMAPPED
   llm_assisted: true
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Extracted from over-conflated Agar.yaml synonyms; reviewed on 2026-05-11 as
   a Mueller Hinton II agar medium/base preparation, not agar identity.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/Nutrient_Agar.yaml
+++ b/data/ingredients/unmapped/Nutrient_Agar.yaml
@@ -24,7 +24,13 @@ curation_history:
   previous_status: UNMAPPED
   new_status: UNMAPPED
   llm_assisted: true
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Imported from mim-queue (source_id=mediadive.ingredient:2364); no CAS-RN or
   CHEBI/NCIT match. Reviewed on 2026-05-11 as a nutrient agar medium/base preparation
   pending recipe- or product-level curation.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/OXOID_Legionella_CYE-Agar_Base.yaml
+++ b/data/ingredients/unmapped/OXOID_Legionella_CYE-Agar_Base.yaml
@@ -24,7 +24,13 @@ curation_history:
   previous_status: UNMAPPED
   new_status: UNMAPPED
   llm_assisted: true
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Imported from mim-queue (source_id=mediadive.ingredient:2125); no CAS-RN or
   CHEBI/NCIT match. Reviewed on 2026-05-11 as an agar base preparation pending product-
   or recipe-level curation.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/Oatmeal_Agar.yaml
+++ b/data/ingredients/unmapped/Oatmeal_Agar.yaml
@@ -25,6 +25,12 @@ curation_history:
   previous_status: UNMAPPED
   new_status: UNMAPPED
   llm_assisted: true
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Extracted from over-conflated Agar.yaml synonyms; reviewed on 2026-05-11 as
   an oatmeal agar medium/base preparation, not agar identity.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/PPLO_Broth.yaml
+++ b/data/ingredients/unmapped/PPLO_Broth.yaml
@@ -21,6 +21,12 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'broth')
   llm_assisted: false
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Imported from mim-queue (source_id=mediadive.ingredient:953); no CAS-RN or
   CHEBI/NCIT match. Curator review needed.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/R_Agar.yaml
+++ b/data/ingredients/unmapped/R_Agar.yaml
@@ -25,6 +25,12 @@ curation_history:
   previous_status: UNMAPPED
   new_status: UNMAPPED
   llm_assisted: true
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Extracted from over-conflated Agar.yaml synonyms; reviewed on 2026-05-11 as
   an R agar medium/base preparation, not agar identity.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/Reinforced_Clostridial_Medium.yaml
+++ b/data/ingredients/unmapped/Reinforced_Clostridial_Medium.yaml
@@ -24,7 +24,13 @@ curation_history:
   previous_status: UNMAPPED
   new_status: UNMAPPED
   llm_assisted: true
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Imported from mim-queue (source_id=mediadive.ingredient:1769); no CAS-RN or
   CHEBI/NCIT match. Reviewed on 2026-05-11 as a medium preparation pending product-
   or recipe-level curation.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/Soilseawater_Medium.yaml
+++ b/data/ingredients/unmapped/Soilseawater_Medium.yaml
@@ -20,5 +20,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Soil')
   llm_assisted: false
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: 'CultureMech placeholder_id: 2'
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/Standard_I_Broth.yaml
+++ b/data/ingredients/unmapped/Standard_I_Broth.yaml
@@ -21,6 +21,12 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Broth')
   llm_assisted: false
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Imported from mim-queue (source_id=mediadive.ingredient:630); no CAS-RN or
   CHEBI/NCIT match. Curator review needed.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/Todd_Hewitt_Broth.yaml
+++ b/data/ingredients/unmapped/Todd_Hewitt_Broth.yaml
@@ -21,6 +21,12 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Broth')
   llm_assisted: false
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Imported from mim-queue (source_id=mediadive.ingredient:1705); no CAS-RN or
   CHEBI/NCIT match. Curator review needed.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/Trypticase_Soy_Agar.yaml
+++ b/data/ingredients/unmapped/Trypticase_Soy_Agar.yaml
@@ -21,6 +21,12 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'soy')
   llm_assisted: false
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Imported from mim-queue (source_id=mediadive.ingredient:1617); no CAS-RN or
   CHEBI/NCIT match. Curator review needed.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/Trypticase_Soy_Broth.yaml
+++ b/data/ingredients/unmapped/Trypticase_Soy_Broth.yaml
@@ -21,6 +21,12 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'soy')
   llm_assisted: false
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Imported from CultureBotHT (compounds_to_cas.csv (no CAS-RN)). No CAS-RN or
   CHEBI mapping available; curator review needed.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/Tryptone_Soya_Broth_Oxoid.yaml
+++ b/data/ingredients/unmapped/Tryptone_Soya_Broth_Oxoid.yaml
@@ -22,5 +22,11 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Tryptone')
   llm_assisted: false
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Extracted from over-conflated Trypticase_Peptone.yaml synonyms
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/Tryptose-phosphate_Broth.yaml
+++ b/data/ingredients/unmapped/Tryptose-phosphate_Broth.yaml
@@ -21,6 +21,12 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'broth')
   llm_assisted: false
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Imported from mim-queue (source_id=mediadive.ingredient:2163); no CAS-RN or
   CHEBI/NCIT match. Curator review needed.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/Veal_Infusion_Broth.yaml
+++ b/data/ingredients/unmapped/Veal_Infusion_Broth.yaml
@@ -21,6 +21,12 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'infusion')
   llm_assisted: false
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Imported from mim-queue (source_id=mediadive.ingredient:579); no CAS-RN or
   CHEBI/NCIT match. Curator review needed.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/Wilkins-Chalgren-Anaerobe-Broth.yaml
+++ b/data/ingredients/unmapped/Wilkins-Chalgren-Anaerobe-Broth.yaml
@@ -21,6 +21,12 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Broth')
   llm_assisted: false
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Imported from mim-queue (source_id=mediadive.ingredient:2093); no CAS-RN or
   CHEBI/NCIT match. Curator review needed.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/Wilkins_Chalgrene_Anaerobe_Broth.yaml
+++ b/data/ingredients/unmapped/Wilkins_Chalgrene_Anaerobe_Broth.yaml
@@ -21,6 +21,12 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Broth')
   llm_assisted: false
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Imported from mim-queue (source_id=mediadive.ingredient:2140); no CAS-RN or
   CHEBI/NCIT match. Curator review needed.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM

--- a/data/ingredients/unmapped/YM_Broth.yaml
+++ b/data/ingredients/unmapped/YM_Broth.yaml
@@ -21,6 +21,12 @@ curation_history:
   action: AUTO_CLASSIFY_INGREDIENT_TYPE
   changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'broth')
   llm_assisted: false
+- timestamp: '2026-07-05T00:00:00+00:00'
+  curator: cbclaw_media_modeling_114
+  action: RECLASSIFY_INGREDIENT_TYPE
+  changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+    culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+  llm_assisted: true
 notes: Imported from mim-queue (source_id=mediadive.ingredient:1683); no CAS-RN or
   CHEBI/NCIT match. Curator review needed.
-ingredient_type: UNDEFINED_MIXTURE
+ingredient_type: DEFINED_MEDIUM


### PR DESCRIPTION
The final MIM #114 follow-ups. No ontology mappings changed (only `ingredient_type` + curation_history prose); reconcile in-sync, invariants A/B1/B2/B3 pass.

## Media-vs-ingredient modeling
The schema already has `DEFINED_MEDIUM` ("complete medium formulation/recipe, e.g. LB broth") — so no schema change is needed; the commercial-media records just weren't all using it. Reclassified **53** media (broth/agar/medium-named) from `UNDEFINED_MIXTURE` → **`DEFINED_MEDIUM`** (that type is for ingredient-level mixtures like yeast extract, not whole media). 41 media were already correctly `DEFINED_MEDIUM`; the 10 media-named `STOCK_SOLUTION` records are correctly typed (they're stock components/bases *for* a medium — "Macro Component 1 for J Medium", "UW concentrated base", etc.). Precedent exists for mapping specific media to NCIT growth-medium terms (`Middlebrook_7H10_Agar → NCIT:C85509`) — a further optional enhancement, not done here.

## Carnitine Hydrochloride dedup — decision: NOT a duplicate
Both `Carnitine Hydrochloride` and `Carnitine (Dl) Hydrochloride` are 0-occurrence and map to CHEBI:17126, but they're **distinct name surface-forms** (stereo-unspecified, from CultureBotHT, vs racemic "DL"), both correctly grounding to the stereo-unspecified parent. MIM keeps one record per surface-form, so **kept both**; documented with a `DEDUP_REVIEWED` curation_history entry (per-ingredient + aggregate).

## Cosmetic
Fixed the 3 soy-peptone `curation_history` prose that said "EXACT_MATCH" (their `mapping_quality` fields were already correctly CLOSE_MATCH).

🤖 Generated with [Claude Code](https://claude.com/claude-code)