### PR TITLE
Add three ingredient role facet enums (Nutritional/Physicochemical/CellularMetabolic)

### DIFF
--- a/src/mediaingredientmech/schema/mediaingredientmech.yaml
+++ b/src/mediaingredientmech/schema/mediaingredientmech.yaml
@@ -904,9 +904,7 @@ enums:
         mappings:
           - METPO:2000010
       LIGHT_SOURCE:
-        description: Radiant-energy source for phototrophic growth.
-        mappings:
-          - METPO:1000656
+        description: Radiant-energy source for phototrophic growth. No CHEBI or METPO term yet describes a radiant-energy *supply* role (METPO:1000656 is the organism metabolic-mode `photoautotrophic`, not a supply-side role); METPO submission pending.
 
   PhysicochemicalRoleEnum:
     description: >-
@@ -978,7 +976,7 @@ enums:
         description: Acts as an intracellular enzyme cofactor (contrast with NutritionalRoleEnum.COFACTOR_PROVIDER, the supply-side role).
         meaning: CHEBI:23357
       PROSTHETIC_GROUP_PRECURSOR:
-        description: Precursor for a covalently-bound cofactor / prosthetic group (e.g., δ-aminolevulinate for heme).
+        description: Precursor for a covalently-bound cofactor / prosthetic group (e.g., δ-aminolevulinate for heme). Note the mapping below points at the parent role `prosthetic group` — CHEBI has no dedicated `prosthetic group precursor` role class, so the mapping is a hierarchy pointer, not identity.
         mappings:
           - CHEBI:26348
       MEMBRANE_COMPONENT:

--- a/src/mediaingredientmech/schema/mediaingredientmech.yaml
+++ b/src/mediaingredientmech/schema/mediaingredientmech.yaml
@@ -19,6 +19,7 @@ prefixes:
   MESH: http://id.nlm.nih.gov/mesh/
   UBERON: http://purl.obolibrary.org/obo/UBERON_
   ENVO: http://purl.obolibrary.org/obo/ENVO_
+  METPO: http://purl.obolibrary.org/obo/METPO_
   rdfs: http://www.w3.org/2000/01/rdf-schema#
 
 default_prefix: mediaingredientmech
@@ -857,6 +858,144 @@ enums:
         description: Lowers redox potential / poises anaerobic media (e.g., sodium sulfide, cysteine, thioglycolate, dithiothreitol)
       CHELATOR:
         description: Sequesters/chelates metal ions to control availability or toxicity (e.g., EDTA, NTA, citrate)
+
+  NutritionalRoleEnum:
+    description: >-
+      What element or macronutrient an ingredient supplies to the medium.
+      One of three orthogonal role facets (with PhysicochemicalRoleEnum and
+      CellularMetabolicRoleEnum). A single ingredient may carry multiple
+      nutritional roles (e.g. L-cysteine supplies both amino-acid and sulfur).
+    permissible_values:
+      CARBON_SOURCE:
+        description: Provides organic carbon for biosynthesis and energy.
+        mappings:
+          - METPO:2000006
+      NITROGEN_SOURCE:
+        description: Provides nitrogen for amino acids, nucleotides, and other biomass components.
+        mappings:
+          - METPO:2000014
+      SULFUR_SOURCE:
+        description: Provides sulfur (typically for cysteine, methionine, Fe-S clusters).
+        mappings:
+          - METPO:2000020
+      PHOSPHATE_SOURCE:
+        description: Provides phosphate for nucleotides, phospholipids, and energy carriers.
+      IRON_SOURCE:
+        description: Provides iron (typically for cytochromes, Fe-S clusters, and other metalloproteins).
+      TRACE_ELEMENT:
+        description: Provides a micronutrient required in trace amounts (e.g., zinc, cobalt, manganese, molybdenum).
+      VITAMIN_SOURCE:
+        description: Provides vitamins or vitamin precursors.
+        meaning: CHEBI:33229
+      AMINO_ACID_SOURCE:
+        description: Provides one or more specific amino acids as building blocks.
+        mappings:
+          - CHEBI:33709
+      PROTEIN_SOURCE:
+        description: Provides peptides, proteins, or complex amino-acid mixtures (e.g., yeast extract, peptone, tryptone).
+        mappings:
+          - CHEBI:36080
+      COFACTOR_PROVIDER:
+        description: Supplies enzyme cofactors or prosthetic groups to the medium (the compound acts as a source; contrast with CellularMetabolicRoleEnum.COFACTOR, which is the intracellular role).
+        mappings:
+          - CHEBI:23357
+      ENERGY_SOURCE:
+        description: Primary energy substrate for chemotrophic growth.
+        mappings:
+          - METPO:2000010
+      LIGHT_SOURCE:
+        description: Radiant-energy source for phototrophic growth.
+        mappings:
+          - METPO:1000656
+
+  PhysicochemicalRoleEnum:
+    description: >-
+      Chemical or physical function an ingredient performs in the medium,
+      independent of what element it supplies. One of three orthogonal role
+      facets (with NutritionalRoleEnum and CellularMetabolicRoleEnum).
+    permissible_values:
+      BUFFER:
+        description: Maintains stable pH via a conjugate acid–base system.
+        meaning: CHEBI:35225
+      SOLIDIFYING_AGENT:
+        description: Gelling agent for solid or semi-solid media (e.g., agar, gellan gum, silica gel).
+      CHELATOR:
+        description: Sequesters metal ions to control availability, toxicity, or precipitation (e.g., EDTA, NTA, citrate).
+        meaning: CHEBI:38161
+      SURFACTANT:
+        description: Reduces surface tension for emulsification, solubilization, or membrane permeabilization (e.g., Tween, Triton X-100).
+        meaning: CHEBI:35195
+        mappings:
+          - CHEBI:63046
+      REDUCING_AGENT:
+        description: Lowers the redox potential of the medium (e.g., sodium sulfide, cysteine, thioglycolate, dithiothreitol).
+        meaning: CHEBI:63247
+      OXIDIZING_AGENT:
+        description: Raises the redox potential of the medium.
+        meaning: CHEBI:63248
+      PH_INDICATOR:
+        description: Colorimetric acid–base indicator dye (e.g., phenol red, bromothymol blue).
+        meaning: CHEBI:50407
+      REDOX_INDICATOR:
+        description: Colorimetric indicator of redox potential (e.g., resazurin turns pink under mildly oxidizing conditions).
+        mappings:
+          - CHEBI:47867
+      SELECTIVE_AGENT:
+        description: Antimicrobial or otherwise selective agent used to enrich for or against particular organisms (e.g., antibiotics, bile salts, high salt, azide).
+        mappings:
+          - CHEBI:33281
+          - CHEBI:33282
+          - CHEBI:35718
+      ANTIFOAM:
+        description: Suppresses foaming in aerated or vigorously mixed cultures (e.g., silicone antifoam, polypropylene glycol).
+        meaning: CHEBI:77973
+      OSMOTIC_AGENT:
+        description: Contributes primarily to the osmotic strength of the medium (e.g., NaCl at high concentration, sucrose, glycerol as osmolyte).
+        mappings:
+          - CHEBI:25728
+      PRECIPITATION_INHIBITOR:
+        description: Prevents precipitation of otherwise poorly-soluble medium components (e.g., citrate keeping iron soluble at neutral pH).
+
+  CellularMetabolicRoleEnum:
+    description: >-
+      Role of the ingredient inside or on the cultured microbe(s) — the
+      compound's metabolic fate or biochemical function at the cell level.
+      One of three orthogonal role facets (with NutritionalRoleEnum and
+      PhysicochemicalRoleEnum). Values in this facet are often
+      organism-conditional (e.g. ELECTRON_DONOR applies only for organisms
+      that oxidize the compound for energy; methanol is an electron donor
+      for methylotrophs but only a carbon source for others).
+    permissible_values:
+      SUBSTRATE:
+        description: Consumed by the organism for biosynthesis, energy, or both (general-purpose substrate role).
+      ELECTRON_DONOR:
+        description: Electron donor for chemolithotrophic or heterotrophic energy metabolism (organism-conditional).
+        meaning: CHEBI:15022
+      ELECTRON_ACCEPTOR:
+        description: Terminal electron acceptor for respiration (e.g., nitrate, oxygen, sulfate; organism-conditional).
+        meaning: CHEBI:17654
+      COFACTOR:
+        description: Acts as an intracellular enzyme cofactor (contrast with NutritionalRoleEnum.COFACTOR_PROVIDER, the supply-side role).
+        meaning: CHEBI:23357
+      PROSTHETIC_GROUP_PRECURSOR:
+        description: Precursor for a covalently-bound cofactor / prosthetic group (e.g., δ-aminolevulinate for heme).
+        mappings:
+          - CHEBI:26348
+      MEMBRANE_COMPONENT:
+        description: Incorporated into cell membranes (e.g., fatty acids, sterols, isoprenoid lipids).
+      OSMOPROTECTANT:
+        description: Accumulated intracellularly to balance external osmotic stress (e.g., glycine betaine, ectoine, trehalose).
+        mappings:
+          - CHEBI:25728
+      INDUCER:
+        description: Triggers expression of specific genes or pathways when present (e.g., IPTG, arabinose).
+      INHIBITOR:
+        description: Suppresses growth or a specific pathway (e.g., antibiotics targeting cellular processes).
+        meaning: CHEBI:35222
+      QUENCHER:
+        description: Absorbs or dissipates a signal (e.g., quenches fluorescence, radicals, or light).
+      NONE:
+        description: Ingredient has no known cellular metabolic role (e.g., agar is chemically inert; resazurin is a bystander indicator).
 
   CommunityOrganismRoleEnum:
     description: Role an organism plays in a microbial community (formerly `CellularRoleEnum`; renamed 2026-07-19 to disambiguate from cell-level metabolic roles of ingredients — these values describe organisms, not ingredients).


### PR DESCRIPTION
## Summary

- Adds `NutritionalRoleEnum` (12 values), `PhysicochemicalRoleEnum` (12 values), `CellularMetabolicRoleEnum` (11 values) to the LinkML schema.
- Adds `METPO` to the prefix map (used for secondary `mappings:` on element-source roles).
- Additive-only — does **not** modify `IngredientRoleEnum`, the `media_roles` slot, `RoleAssignment`, or any Python surface.

**Reopens** #121 (auto-closed when its base branch `feat/rename-cellular-role-enum` was deleted after #120's squash-merge). Branch was rebased onto current `main`; the rename commit was automatically dropped by rebase (patch already upstream via the squash).

## Why

Per `reports/ingredient-roles-review.md` (Codex, 2026-07-19) in the CultureMech repo: the current flat `IngredientRoleEnum` mixes three orthogonal axes — element supply, physicochemical function, and cell-level metabolic fate. A single ingredient like L-cysteine legitimately spans all three (`{AMINO_ACID_SOURCE, SULFUR_SOURCE}` nutritionally, `{REDUCING_AGENT}` physicochemically, `{SUBSTRATE}` metabolically) and can't be expressed under one flat enum without loss.

## Review fixes already applied

- #124 — dropped incorrect `LIGHT_SOURCE → METPO:1000656` mapping (METPO term is the organism trait "photoautotrophic", not a supply-side role). Value now has description-only, per LinkML's tolerance for unmapped values.
- #125 — extended `PROSTHETIC_GROUP_PRECURSOR` description to note that `CHEBI:26348` is the parent role (`prosthetic group`), not identity — the mapping is a hierarchy pointer.

## Verified CHEBI meaning: CURIEs (all resolve under CHEBI:50906)

`CHEBI:33229` vitamin · `CHEBI:35225` buffer · `CHEBI:38161` chelator · `CHEBI:35195` surfactant · `CHEBI:63247` reducing agent · `CHEBI:63248` oxidising agent · `CHEBI:50407` acid-base indicator · `CHEBI:77973` antifoaming agent · `CHEBI:15022` electron donor · `CHEBI:17654` electron acceptor · `CHEBI:23357` cofactor · `CHEBI:35222` inhibitor. All verified via `runoak -i sqlite:obo:chebi`.

## Deferred to follow-up PRs (tracked as issues)

- #126 `CellularMetabolicRoleEnum.NONE` may compete with empty-list encoding — decide at slot-add time.
- #127 `OSMOTIC_AGENT` + `OSMOPROTECTANT` both map to `CHEBI:25728` — curator-guidance to prevent auto-double-assignment.
- #128 Retire flat `IngredientRoleEnum` after per-facet slots + writer methods land.
- (Docs regen chore, per #120 pattern.)

## Test plan

- [x] `uv run linkml-validate --schema src/mediaingredientmech/schema/mediaingredientmech.yaml` — clean
- [x] `uv run gen-python …` — regenerates cleanly (datamodel is `.gitignore`d)
- [x] `uv run pytest` — 379 passed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)