### PR TITLE
Wire the three ingredient role facets: assignment classes, slots, writer methods (Step 3)

### DIFF
--- a/src/mediaingredientmech/curation/ingredient_curator.py
+++ b/src/mediaingredientmech/curation/ingredient_curator.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 import yaml
+from linkml_runtime.utils.schemaview import SchemaView
 
 from mediaingredientmech.curate.curation_event import now_iso, record_curation_event
 from mediaingredientmech.utils.ontology_client import OntologyCandidate, OntologyClient
@@ -16,6 +17,29 @@ from mediaingredientmech.utils.yaml_handler import save_yaml
 logger = logging.getLogger(__name__)
 
 DEFAULT_UNMAPPED_PATH = Path("data/curated/unmapped_ingredients.yaml")
+
+_SCHEMA_PATH = Path(__file__).resolve().parent.parent / "schema" / "mediaingredientmech.yaml"
+_SCHEMA_VIEW: Optional[SchemaView] = None
+
+
+def _schema_view() -> SchemaView:
+    """Lazy SchemaView over the LinkML source. Cached at module scope."""
+    global _SCHEMA_VIEW
+    if _SCHEMA_VIEW is None:
+        _SCHEMA_VIEW = SchemaView(str(_SCHEMA_PATH))
+    return _SCHEMA_VIEW
+
+
+def _enum_permissible_values(enum_name: str) -> frozenset[str]:
+    """Return the permissible-value name set for a schema enum. Source of truth for validation sets below."""
+    enum_def = _schema_view().get_enum(enum_name)
+    if enum_def is None:
+        raise RuntimeError(
+            f"Enum '{enum_name}' not found in {_SCHEMA_PATH}. "
+            "Schema and curator have drifted — investigate before proceeding."
+        )
+    return frozenset(enum_def.permissible_values.keys())
+
 
 VALID_STATUSES = {
     "MAPPED",
@@ -45,64 +69,13 @@ VALID_MATCH_LEVEL = {
     "UNKNOWN",
 }
 
-VALID_MEDIA_ROLES = {
-    "CARBON_SOURCE",
-    "NITROGEN_SOURCE",
-    "MINERAL",
-    "TRACE_ELEMENT",
-    "BUFFER",
-    "VITAMIN_SOURCE",
-    "SALT",
-    "PROTEIN_SOURCE",
-    "AMINO_ACID_SOURCE",
-    "SOLIDIFYING_AGENT",
-    "ENERGY_SOURCE",
-    "ELECTRON_ACCEPTOR",
-    "ELECTRON_DONOR",
-    "COFACTOR_PROVIDER",
-    # Kept in sync with IngredientRoleEnum in the LinkML schema
-    # (src/mediaingredientmech/schema/mediaingredientmech.yaml).
-    "REDOX_INDICATOR",
-    "PH_INDICATOR",
-    "SELECTIVE_AGENT",
-    "SURFACTANT",
-    "REDUCING_AGENT",
-    "CHELATOR",
-}
-
-VALID_COMMUNITY_ORGANISM_ROLES = {
-    "PRIMARY_DEGRADER",
-    "REDUCTIVE_DEGRADER",
-    "OXIDATIVE_DEGRADER",
-    "BIOTRANSFORMER",
-    "SYNERGIST",
-    "BRIDGE_ORGANISM",
-    "ELECTRON_SHUTTLE",
-    "DETOXIFIER",
-    "COMMENSAL",
-    "COMPETITOR",
-}
-
-VALID_SOLUTION_TYPES = {
-    "VITAMIN_MIX",
-    "TRACE_METAL_MIX",
-    "AMINO_ACID_MIX",
-    "BUFFER_SOLUTION",
-    "CARBON_SOURCE_MIX",
-    "MINERAL_STOCK",
-    "COFACTOR_MIX",
-    "COMPLEX_UNDEFINED",
-    "OTHER",
-}
-
-VALID_CITATION_TYPES = {
-    "PEER_REVIEWED_PUBLICATION",
-    "PREPRINT",
-    "DATABASE_ENTRY",
-    "TECHNICAL_REPORT",
-    "MANUAL_CURATION",
-    "COMPUTATIONAL_PREDICTION",
-}
+VALID_MEDIA_ROLES = _enum_permissible_values("IngredientRoleEnum")
+VALID_NUTRITIONAL_ROLES = _enum_permissible_values("NutritionalRoleEnum")
+VALID_PHYSICOCHEMICAL_ROLES = _enum_permissible_values("PhysicochemicalRoleEnum")
+VALID_CELLULAR_METABOLIC_ROLES = _enum_permissible_values("CellularMetabolicRoleEnum")
+VALID_COMMUNITY_ORGANISM_ROLES = _enum_permissible_values("CommunityOrganismRoleEnum")
+VALID_SOLUTION_TYPES = _enum_permissible_values("SolutionTypeEnum")
+VALID_CITATION_TYPES = _enum_permissible_values("CitationTypeEnum")
 
 DOI_PATTERN = re.compile(r"^10\.\d{4,}/[-._;()/:A-Za-z0-9]+$")
 
@@ -630,6 +603,278 @@ class IngredientCurator:
         self._dirty = True
         return record
 
+    def add_nutritional_role(
+        self,
+        record: dict[str, Any],
+        role: str,
+        confidence: float = 0.9,
+        doi: Optional[str] = None,
+        pmid: Optional[str] = None,
+        reference_text: Optional[str] = None,
+        reference_type: str = "MANUAL_CURATION",
+        url: Optional[str] = None,
+        excerpt: Optional[str] = None,
+        curator_note: Optional[str] = None,
+        notes: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Add a nutritional-facet role assignment (what element/macronutrient the ingredient supplies).
+
+        Args:
+            record: The ingredient record dict to update.
+            role: NutritionalRoleEnum value (e.g., "CARBON_SOURCE", "SULFUR_SOURCE", "VITAMIN_SOURCE").
+            confidence: Confidence score (0.0-1.0). Defaults to 0.9.
+            doi: Digital Object Identifier.
+            pmid: PubMed ID.
+            reference_text: Human-readable citation text.
+            reference_type: CitationTypeEnum value. Defaults to "MANUAL_CURATION".
+            url: Web URL for the reference.
+            excerpt: Relevant excerpt from the source.
+            curator_note: Explanation of why this supports the role.
+            notes: Additional context about the role assignment.
+
+        Returns:
+            The updated record.
+
+        Raises:
+            ValueError: If role, confidence, DOI format, or reference_type is invalid.
+        """
+        if role not in VALID_NUTRITIONAL_ROLES:
+            raise ValueError(
+                f"Invalid nutritional role: {role}. Must be one of {VALID_NUTRITIONAL_ROLES}"
+            )
+        if not (0.0 <= confidence <= 1.0):
+            raise ValueError(f"Confidence out of range: {confidence}. Must be between 0.0 and 1.0")
+        if doi and not DOI_PATTERN.match(doi):
+            raise ValueError(f"Invalid DOI format: {doi}. Must match pattern: 10.XXXX/...")
+        if reference_type not in VALID_CITATION_TYPES:
+            raise ValueError(
+                f"Invalid reference_type: {reference_type}. Must be one of {VALID_CITATION_TYPES}"
+            )
+
+        role_assignment: dict[str, Any] = {
+            "role": role,
+            "confidence": confidence,
+            "evidence": [],
+        }
+        if notes:
+            role_assignment["notes"] = notes
+
+        if doi or pmid or reference_text or url:
+            citation: dict[str, Any] = {"reference_type": reference_type}
+            if doi:
+                citation["doi"] = doi
+            if pmid:
+                citation["pmid"] = pmid
+            if reference_text:
+                citation["reference_text"] = reference_text
+            elif doi:
+                citation["reference_text"] = f"DOI: {doi}"
+            if url:
+                citation["url"] = url
+            if excerpt:
+                citation["excerpt"] = excerpt
+            if curator_note:
+                citation["curator_note"] = curator_note
+
+            role_assignment["evidence"].append(citation)
+
+        if "nutritional_roles" not in record or record["nutritional_roles"] is None:
+            record["nutritional_roles"] = []
+        record["nutritional_roles"].append(role_assignment)
+
+        changes_msg = f"Added nutritional role: {role} (confidence: {confidence:.2f})"
+        if doi:
+            changes_msg += f" with DOI: {doi}"
+        self._add_event(record, action="ANNOTATED", changes=changes_msg)
+
+        self._dirty = True
+        return record
+
+    def add_physicochemical_role(
+        self,
+        record: dict[str, Any],
+        role: str,
+        confidence: float = 0.9,
+        doi: Optional[str] = None,
+        pmid: Optional[str] = None,
+        reference_text: Optional[str] = None,
+        reference_type: str = "MANUAL_CURATION",
+        url: Optional[str] = None,
+        excerpt: Optional[str] = None,
+        curator_note: Optional[str] = None,
+        notes: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Add a physicochemical-facet role assignment (chemical/physical job the ingredient does in the medium).
+
+        Args:
+            record: The ingredient record dict to update.
+            role: PhysicochemicalRoleEnum value (e.g., "BUFFER", "CHELATOR", "REDUCING_AGENT").
+            confidence: Confidence score (0.0-1.0). Defaults to 0.9.
+            doi: Digital Object Identifier.
+            pmid: PubMed ID.
+            reference_text: Human-readable citation text.
+            reference_type: CitationTypeEnum value. Defaults to "MANUAL_CURATION".
+            url: Web URL for the reference.
+            excerpt: Relevant excerpt from the source.
+            curator_note: Explanation of why this supports the role.
+            notes: Additional context about the role assignment.
+
+        Returns:
+            The updated record.
+
+        Raises:
+            ValueError: If role, confidence, DOI format, or reference_type is invalid.
+        """
+        if role not in VALID_PHYSICOCHEMICAL_ROLES:
+            raise ValueError(
+                f"Invalid physicochemical role: {role}. Must be one of {VALID_PHYSICOCHEMICAL_ROLES}"
+            )
+        if not (0.0 <= confidence <= 1.0):
+            raise ValueError(f"Confidence out of range: {confidence}. Must be between 0.0 and 1.0")
+        if doi and not DOI_PATTERN.match(doi):
+            raise ValueError(f"Invalid DOI format: {doi}. Must match pattern: 10.XXXX/...")
+        if reference_type not in VALID_CITATION_TYPES:
+            raise ValueError(
+                f"Invalid reference_type: {reference_type}. Must be one of {VALID_CITATION_TYPES}"
+            )
+
+        role_assignment: dict[str, Any] = {
+            "role": role,
+            "confidence": confidence,
+            "evidence": [],
+        }
+        if notes:
+            role_assignment["notes"] = notes
+
+        if doi or pmid or reference_text or url:
+            citation: dict[str, Any] = {"reference_type": reference_type}
+            if doi:
+                citation["doi"] = doi
+            if pmid:
+                citation["pmid"] = pmid
+            if reference_text:
+                citation["reference_text"] = reference_text
+            elif doi:
+                citation["reference_text"] = f"DOI: {doi}"
+            if url:
+                citation["url"] = url
+            if excerpt:
+                citation["excerpt"] = excerpt
+            if curator_note:
+                citation["curator_note"] = curator_note
+
+            role_assignment["evidence"].append(citation)
+
+        if "physicochemical_roles" not in record or record["physicochemical_roles"] is None:
+            record["physicochemical_roles"] = []
+        record["physicochemical_roles"].append(role_assignment)
+
+        changes_msg = f"Added physicochemical role: {role} (confidence: {confidence:.2f})"
+        if doi:
+            changes_msg += f" with DOI: {doi}"
+        self._add_event(record, action="ANNOTATED", changes=changes_msg)
+
+        self._dirty = True
+        return record
+
+    def add_cellular_metabolic_role(
+        self,
+        record: dict[str, Any],
+        role: str,
+        metabolic_context: Optional[str] = None,
+        confidence: float = 0.9,
+        doi: Optional[str] = None,
+        pmid: Optional[str] = None,
+        reference_text: Optional[str] = None,
+        reference_type: str = "MANUAL_CURATION",
+        url: Optional[str] = None,
+        excerpt: Optional[str] = None,
+        curator_note: Optional[str] = None,
+        notes: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Add a cellular-metabolic-facet role assignment (what the ingredient does inside/on the cultured microbe).
+
+        Assignments in this facet are often organism-conditional (e.g., methanol is an
+        ELECTRON_DONOR only for methylotrophs); capture that context in `metabolic_context`.
+
+        Args:
+            record: The ingredient record dict to update.
+            role: CellularMetabolicRoleEnum value (e.g., "SUBSTRATE", "ELECTRON_DONOR", "COFACTOR").
+            metabolic_context: Organism/pathway scope for this assignment (e.g., "methylotrophs only",
+                "anaerobic sulfate reduction"). Recommended when the role does not hold universally.
+            confidence: Confidence score (0.0-1.0). Defaults to 0.9.
+            doi: Digital Object Identifier.
+            pmid: PubMed ID.
+            reference_text: Human-readable citation text.
+            reference_type: CitationTypeEnum value. Defaults to "MANUAL_CURATION".
+            url: Web URL for the reference.
+            excerpt: Relevant excerpt from the source.
+            curator_note: Explanation of why this supports the role.
+            notes: Additional context about the role assignment.
+
+        Returns:
+            The updated record.
+
+        Raises:
+            ValueError: If role, confidence, DOI format, or reference_type is invalid.
+        """
+        if role not in VALID_CELLULAR_METABOLIC_ROLES:
+            raise ValueError(
+                f"Invalid cellular-metabolic role: {role}. "
+                f"Must be one of {VALID_CELLULAR_METABOLIC_ROLES}"
+            )
+        if not (0.0 <= confidence <= 1.0):
+            raise ValueError(f"Confidence out of range: {confidence}. Must be between 0.0 and 1.0")
+        if doi and not DOI_PATTERN.match(doi):
+            raise ValueError(f"Invalid DOI format: {doi}. Must match pattern: 10.XXXX/...")
+        if reference_type not in VALID_CITATION_TYPES:
+            raise ValueError(
+                f"Invalid reference_type: {reference_type}. Must be one of {VALID_CITATION_TYPES}"
+            )
+
+        role_assignment: dict[str, Any] = {
+            "role": role,
+            "confidence": confidence,
+            "evidence": [],
+        }
+        if metabolic_context:
+            role_assignment["metabolic_context"] = metabolic_context
+        if notes:
+            role_assignment["notes"] = notes
+
+        if doi or pmid or reference_text or url:
+            citation: dict[str, Any] = {"reference_type": reference_type}
+            if doi:
+                citation["doi"] = doi
+            if pmid:
+                citation["pmid"] = pmid
+            if reference_text:
+                citation["reference_text"] = reference_text
+            elif doi:
+                citation["reference_text"] = f"DOI: {doi}"
+            if url:
+                citation["url"] = url
+            if excerpt:
+                citation["excerpt"] = excerpt
+            if curator_note:
+                citation["curator_note"] = curator_note
+
+            role_assignment["evidence"].append(citation)
+
+        if "cellular_metabolic_roles" not in record or record["cellular_metabolic_roles"] is None:
+            record["cellular_metabolic_roles"] = []
+        record["cellular_metabolic_roles"].append(role_assignment)
+
+        changes_msg = f"Added cellular-metabolic role: {role} (confidence: {confidence:.2f})"
+        if metabolic_context:
+            changes_msg += f" in context: {metabolic_context}"
+        if doi:
+            changes_msg += f" with DOI: {doi}"
+        self._add_event(record, action="ANNOTATED", changes=changes_msg)
+
+        self._dirty = True
+        return record
+
     def set_solution_type(self, record: dict[str, Any], solution_type: str) -> dict[str, Any]:
         """Set the solution type for mixture ingredients.
 
@@ -712,7 +957,35 @@ class IngredientCurator:
                         f"Invalid reference_type at cellular role {i}, evidence {j}: {ref_type}"
                     )
 
-        # Validate solution_type
+        for slot, valid_set, label in (
+            ("nutritional_roles", VALID_NUTRITIONAL_ROLES, "nutritional"),
+            ("physicochemical_roles", VALID_PHYSICOCHEMICAL_ROLES, "physicochemical"),
+            ("cellular_metabolic_roles", VALID_CELLULAR_METABOLIC_ROLES, "cellular-metabolic"),
+        ):
+            for i, role_assignment in enumerate(record.get(slot, [])):
+                role = role_assignment.get("role")
+                if role and role not in valid_set:
+                    errors.append(f"Invalid {label} role at index {i}: {role}")
+
+                confidence = role_assignment.get("confidence")
+                if confidence is not None and not (0.0 <= confidence <= 1.0):
+                    errors.append(
+                        f"Confidence out of range at {label} role {i}: {confidence}"
+                    )
+
+                for j, evidence in enumerate(role_assignment.get("evidence", [])):
+                    doi = evidence.get("doi")
+                    if doi and not DOI_PATTERN.match(doi):
+                        errors.append(
+                            f"Invalid DOI format at {label} role {i}, evidence {j}: {doi}"
+                        )
+
+                    ref_type = evidence.get("reference_type")
+                    if ref_type and ref_type not in VALID_CITATION_TYPES:
+                        errors.append(
+                            f"Invalid reference_type at {label} role {i}, evidence {j}: {ref_type}"
+                        )
+
         solution_type = record.get("solution_type")
         if solution_type and solution_type not in VALID_SOLUTION_TYPES:
             errors.append(f"Invalid solution type: {solution_type}")

--- a/src/mediaingredientmech/curation/ingredient_curator.py
+++ b/src/mediaingredientmech/curation/ingredient_curator.py
@@ -954,7 +954,7 @@ class IngredientCurator:
                 ref_type = evidence.get("reference_type")
                 if ref_type and ref_type not in VALID_CITATION_TYPES:
                     errors.append(
-                        f"Invalid reference_type at cellular role {i}, evidence {j}: {ref_type}"
+                        f"Invalid reference_type at community-organism role {i}, evidence {j}: {ref_type}"
                     )
 
         for slot, valid_set, label in (

--- a/src/mediaingredientmech/schema/mediaingredientmech.yaml
+++ b/src/mediaingredientmech/schema/mediaingredientmech.yaml
@@ -126,6 +126,21 @@ classes:
         multivalued: true
         inlined_as_list: true
         description: Role(s) this organism plays in a microbial community (e.g., PRIMARY_DEGRADER, SYNERGIST, COMPETITOR). Formerly `cellular_roles`; renamed to disambiguate from ingredient-level cellular metabolic roles.
+      nutritional_roles:
+        range: NutritionalRoleAssignment
+        multivalued: true
+        inlined_as_list: true
+        description: What element or macronutrient this ingredient supplies to the medium (e.g., CARBON_SOURCE, SULFUR_SOURCE, VITAMIN_SOURCE). Facet 1 of 3 orthogonal ingredient-role facets — a single ingredient may carry multiple values (e.g., L-cysteine → AMINO_ACID_SOURCE + SULFUR_SOURCE).
+      physicochemical_roles:
+        range: PhysicochemicalRoleAssignment
+        multivalued: true
+        inlined_as_list: true
+        description: Chemical or physical function this ingredient performs in the medium (e.g., BUFFER, CHELATOR, REDUCING_AGENT). Facet 2 of 3 orthogonal ingredient-role facets — independent of what element the ingredient supplies.
+      cellular_metabolic_roles:
+        range: CellularMetabolicRoleAssignment
+        multivalued: true
+        inlined_as_list: true
+        description: Role of this ingredient inside/on the cultured microbe (e.g., SUBSTRATE, ELECTRON_DONOR, COFACTOR). Facet 3 of 3 orthogonal ingredient-role facets — often organism-conditional (e.g., ELECTRON_DONOR applies only for organisms that oxidize the compound for energy).
       solution_type:
         range: SolutionTypeEnum
         description: Type of solution if this is a stock/pre-mix rather than individual chemical
@@ -506,6 +521,62 @@ classes:
         description: The community/ecological role of the organism (e.g., PRIMARY_DEGRADER, SYNERGIST, COMMENSAL, COMPETITOR).
       metabolic_context:
         description: Pathway or metabolic context (e.g., "denitrification", "aromatic degradation")
+      confidence:
+        range: float
+        description: Confidence score for this role assignment (0.0-1.0)
+      evidence:
+        range: RoleCitation
+        multivalued: true
+        inlined_as_list: true
+        description: Citations and references supporting this role
+      notes:
+        description: Additional context about this role assignment
+
+  NutritionalRoleAssignment:
+    description: Assignment of a nutritional facet role (what element or macronutrient the ingredient supplies) with supporting evidence.
+    attributes:
+      role:
+        range: NutritionalRoleEnum
+        required: true
+        description: The nutritional role (e.g., CARBON_SOURCE, SULFUR_SOURCE, VITAMIN_SOURCE).
+      confidence:
+        range: float
+        description: Confidence score for this role assignment (0.0-1.0)
+      evidence:
+        range: RoleCitation
+        multivalued: true
+        inlined_as_list: true
+        description: Citations and references supporting this role
+      notes:
+        description: Additional context about this role assignment
+
+  PhysicochemicalRoleAssignment:
+    description: Assignment of a physicochemical facet role (the chemical or physical function the ingredient performs in the medium) with supporting evidence.
+    attributes:
+      role:
+        range: PhysicochemicalRoleEnum
+        required: true
+        description: The physicochemical role (e.g., BUFFER, CHELATOR, REDUCING_AGENT).
+      confidence:
+        range: float
+        description: Confidence score for this role assignment (0.0-1.0)
+      evidence:
+        range: RoleCitation
+        multivalued: true
+        inlined_as_list: true
+        description: Citations and references supporting this role
+      notes:
+        description: Additional context about this role assignment
+
+  CellularMetabolicRoleAssignment:
+    description: Assignment of a cellular-metabolic facet role (what the ingredient does inside or to the cultured microbe) with supporting evidence. Assignments in this facet are often organism-conditional (e.g., ELECTRON_DONOR applies only for organisms that oxidize the compound for energy); capture that in `metabolic_context`.
+    attributes:
+      role:
+        range: CellularMetabolicRoleEnum
+        required: true
+        description: The cellular-metabolic role (e.g., SUBSTRATE, ELECTRON_DONOR, COFACTOR).
+      metabolic_context:
+        description: Pathway or organism context that scopes this assignment (e.g., "methanol → ELECTRON_DONOR in methylotrophs only", "sulfate → ELECTRON_ACCEPTOR under anaerobic sulfate reduction"). Important when a role only holds for a subset of organisms or conditions.
       confidence:
         range: float
         description: Confidence score for this role assignment (0.0-1.0)

--- a/tests/test_enum_sync.py
+++ b/tests/test_enum_sync.py
@@ -1,14 +1,16 @@
-"""Guard tests: the curator's hardcoded validation sets must stay in sync with
-the LinkML schema enums.
+"""Guard tests: the curator's role/citation validation sets must match the schema.
 
-`IngredientCurator` validates roles / citation types against module-level sets
-(`VALID_MEDIA_ROLES`, `VALID_COMMUNITY_ORGANISM_ROLES`, `VALID_CITATION_TYPES`).
-These are hand-maintained copies of the schema's permissible values; if a value
-is added to the schema enum but not to the set, `add_media_role` /
-`add_community_organism_role` raise ValueError on a perfectly valid value (this
-exact drift bug shipped once — REDOX_INDICATOR / PH_INDICATOR / SELECTIVE_AGENT
-/ SURFACTANT were in the schema but not the curator set). These tests fail
-loudly when the two diverge.
+Historically the sets were hand-maintained copies of the schema permissible values;
+a drift bug shipped once (REDOX_INDICATOR / PH_INDICATOR / SELECTIVE_AGENT /
+SURFACTANT were in the schema but not the curator set) and these tests were the
+guard against a recurrence.
+
+The sets are now derived at import time from the schema via `SchemaView`, so
+"drift" in the old sense is impossible — but these tests still guard against
+regressions: SchemaView failing to load, the schema path resolving to the wrong
+file (e.g., after a package restructure), or an enum being renamed on one side
+only. The comparison uses a fresh YAML-load path instead of SchemaView so
+that a SchemaView bug can't silently satisfy both sides of the assertion.
 """
 
 import sys
@@ -19,9 +21,12 @@ import yaml
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from mediaingredientmech.curation.ingredient_curator import (
+    VALID_CELLULAR_METABOLIC_ROLES,
     VALID_CITATION_TYPES,
     VALID_COMMUNITY_ORGANISM_ROLES,
     VALID_MEDIA_ROLES,
+    VALID_NUTRITIONAL_ROLES,
+    VALID_PHYSICOCHEMICAL_ROLES,
 )
 
 SCHEMA_PATH = (
@@ -49,6 +54,24 @@ def test_community_organism_roles_match_schema():
     assert VALID_COMMUNITY_ORGANISM_ROLES == _schema_enum("CommunityOrganismRoleEnum"), (
         "VALID_COMMUNITY_ORGANISM_ROLES is out of sync with CommunityOrganismRoleEnum. "
         "Update the set in curation/ingredient_curator.py to match the schema."
+    )
+
+
+def test_nutritional_roles_match_schema():
+    assert VALID_NUTRITIONAL_ROLES == _schema_enum("NutritionalRoleEnum"), (
+        "VALID_NUTRITIONAL_ROLES is out of sync with NutritionalRoleEnum."
+    )
+
+
+def test_physicochemical_roles_match_schema():
+    assert VALID_PHYSICOCHEMICAL_ROLES == _schema_enum("PhysicochemicalRoleEnum"), (
+        "VALID_PHYSICOCHEMICAL_ROLES is out of sync with PhysicochemicalRoleEnum."
+    )
+
+
+def test_cellular_metabolic_roles_match_schema():
+    assert VALID_CELLULAR_METABOLIC_ROLES == _schema_enum("CellularMetabolicRoleEnum"), (
+        "VALID_CELLULAR_METABOLIC_ROLES is out of sync with CellularMetabolicRoleEnum."
     )
 
 

--- a/tests/test_role_methods.py
+++ b/tests/test_role_methods.py
@@ -302,6 +302,7 @@ def test_add_nutritional_role():
         doi="10.1128/jb.00456-20",
         reference_type="PEER_REVIEWED_PUBLICATION",
         curator_note="L-cysteine supplies cysteine + sulfur simultaneously in defined media.",
+        notes="Round-trip check for notes preservation.",
     )
 
     assert "nutritional_roles" in result
@@ -309,18 +310,27 @@ def test_add_nutritional_role():
     assignment = result["nutritional_roles"][0]
     assert assignment["role"] == "AMINO_ACID_SOURCE"
     assert assignment["confidence"] == 0.98
+    assert assignment["notes"] == "Round-trip check for notes preservation."
     assert len(assignment["evidence"]) == 1
     assert assignment["evidence"][0]["doi"] == "10.1128/jb.00456-20"
 
     curator.add_nutritional_role(record, role="SULFUR_SOURCE", confidence=0.9)
     assert len(result["nutritional_roles"]) == 2
     assert result["nutritional_roles"][1]["role"] == "SULFUR_SOURCE"
+    # No-citation branch must NOT leak a phantom empty citation.
+    assert result["nutritional_roles"][1]["evidence"] == []
 
     print("✓ test_add_nutritional_role passed")
 
 
 def test_add_physicochemical_role():
-    """Test adding a physicochemical-facet role."""
+    """Test adding a physicochemical-facet role.
+
+    Includes the no-citation branch (no doi/pmid/reference_text/url provided) —
+    `evidence` must be an empty list. Note: passing `curator_note`/`excerpt`
+    alone does not trigger citation creation (inherited from add_media_role);
+    a real citation needs at least one of doi/pmid/reference_text/url.
+    """
     curator = IngredientCurator(curator_name="test_curator")
     record = {
         "ontology_id": "CHEBI:64755",
@@ -332,7 +342,7 @@ def test_add_physicochemical_role():
         record,
         role="CHELATOR",
         confidence=0.99,
-        curator_note="EDTA is the canonical divalent-cation chelator in media.",
+        notes="Round-trip check for notes preservation.",
     )
 
     assert "physicochemical_roles" in result
@@ -340,6 +350,21 @@ def test_add_physicochemical_role():
     assignment = result["physicochemical_roles"][0]
     assert assignment["role"] == "CHELATOR"
     assert assignment["confidence"] == 0.99
+    assert assignment["notes"] == "Round-trip check for notes preservation."
+    # No-citation branch must NOT leak a phantom empty citation.
+    assert assignment["evidence"] == []
+
+    # Second call WITH a DOI must attach a citation.
+    curator.add_physicochemical_role(
+        record,
+        role="SURFACTANT",
+        confidence=0.9,
+        doi="10.1128/aem.02345-19",
+        reference_type="PEER_REVIEWED_PUBLICATION",
+    )
+    assert len(result["physicochemical_roles"]) == 2
+    assert len(result["physicochemical_roles"][1]["evidence"]) == 1
+    assert result["physicochemical_roles"][1]["evidence"][0]["doi"] == "10.1128/aem.02345-19"
 
     print("✓ test_add_physicochemical_role passed")
 
@@ -361,6 +386,7 @@ def test_add_cellular_metabolic_role():
         doi="10.1128/mmbr.00012-16",
         reference_type="PEER_REVIEWED_PUBLICATION",
         curator_note="Methanol is the electron donor for MDH in methylotrophic C1 metabolism.",
+        notes="Round-trip check for notes preservation.",
     )
 
     assert "cellular_metabolic_roles" in result
@@ -369,10 +395,18 @@ def test_add_cellular_metabolic_role():
     assert assignment["role"] == "ELECTRON_DONOR"
     assert assignment["metabolic_context"] == "methylotrophs only"
     assert assignment["confidence"] == 0.95
+    assert assignment["notes"] == "Round-trip check for notes preservation."
     assert len(assignment["evidence"]) == 1
     assert assignment["evidence"][0]["doi"] == "10.1128/mmbr.00012-16"
 
     assert "methylotrophs only" in result["curation_history"][0]["changes"]
+
+    # No-citation, no-metabolic_context branch: evidence == [] and no metabolic_context key.
+    curator.add_cellular_metabolic_role(record, role="SUBSTRATE", confidence=0.9)
+    assert len(result["cellular_metabolic_roles"]) == 2
+    second = result["cellular_metabolic_roles"][1]
+    assert second["evidence"] == []
+    assert "metabolic_context" not in second
 
     print("✓ test_add_cellular_metabolic_role passed")
 

--- a/tests/test_role_methods.py
+++ b/tests/test_role_methods.py
@@ -286,10 +286,148 @@ def test_multiple_roles():
     print("✓ test_multiple_roles passed")
 
 
+def test_add_nutritional_role():
+    """Test adding a nutritional-facet role."""
+    curator = IngredientCurator(curator_name="test_curator")
+    record = {
+        "ontology_id": "CHEBI:17561",
+        "preferred_term": "L-cysteine",
+        "mapping_status": "MAPPED",
+    }
+
+    result = curator.add_nutritional_role(
+        record,
+        role="AMINO_ACID_SOURCE",
+        confidence=0.98,
+        doi="10.1128/jb.00456-20",
+        reference_type="PEER_REVIEWED_PUBLICATION",
+        curator_note="L-cysteine supplies cysteine + sulfur simultaneously in defined media.",
+    )
+
+    assert "nutritional_roles" in result
+    assert len(result["nutritional_roles"]) == 1
+    assignment = result["nutritional_roles"][0]
+    assert assignment["role"] == "AMINO_ACID_SOURCE"
+    assert assignment["confidence"] == 0.98
+    assert len(assignment["evidence"]) == 1
+    assert assignment["evidence"][0]["doi"] == "10.1128/jb.00456-20"
+
+    curator.add_nutritional_role(record, role="SULFUR_SOURCE", confidence=0.9)
+    assert len(result["nutritional_roles"]) == 2
+    assert result["nutritional_roles"][1]["role"] == "SULFUR_SOURCE"
+
+    print("✓ test_add_nutritional_role passed")
+
+
+def test_add_physicochemical_role():
+    """Test adding a physicochemical-facet role."""
+    curator = IngredientCurator(curator_name="test_curator")
+    record = {
+        "ontology_id": "CHEBI:64755",
+        "preferred_term": "EDTA(2-)",
+        "mapping_status": "MAPPED",
+    }
+
+    result = curator.add_physicochemical_role(
+        record,
+        role="CHELATOR",
+        confidence=0.99,
+        curator_note="EDTA is the canonical divalent-cation chelator in media.",
+    )
+
+    assert "physicochemical_roles" in result
+    assert len(result["physicochemical_roles"]) == 1
+    assignment = result["physicochemical_roles"][0]
+    assert assignment["role"] == "CHELATOR"
+    assert assignment["confidence"] == 0.99
+
+    print("✓ test_add_physicochemical_role passed")
+
+
+def test_add_cellular_metabolic_role():
+    """Test adding a cellular-metabolic-facet role with metabolic_context."""
+    curator = IngredientCurator(curator_name="test_curator")
+    record = {
+        "ontology_id": "CHEBI:17790",
+        "preferred_term": "methanol",
+        "mapping_status": "MAPPED",
+    }
+
+    result = curator.add_cellular_metabolic_role(
+        record,
+        role="ELECTRON_DONOR",
+        metabolic_context="methylotrophs only",
+        confidence=0.95,
+        doi="10.1128/mmbr.00012-16",
+        reference_type="PEER_REVIEWED_PUBLICATION",
+        curator_note="Methanol is the electron donor for MDH in methylotrophic C1 metabolism.",
+    )
+
+    assert "cellular_metabolic_roles" in result
+    assert len(result["cellular_metabolic_roles"]) == 1
+    assignment = result["cellular_metabolic_roles"][0]
+    assert assignment["role"] == "ELECTRON_DONOR"
+    assert assignment["metabolic_context"] == "methylotrophs only"
+    assert assignment["confidence"] == 0.95
+    assert len(assignment["evidence"]) == 1
+    assert assignment["evidence"][0]["doi"] == "10.1128/mmbr.00012-16"
+
+    assert "methylotrophs only" in result["curation_history"][0]["changes"]
+
+    print("✓ test_add_cellular_metabolic_role passed")
+
+
+def test_facet_role_validation_rejects_wrong_facet_value():
+    """A physicochemical role token must not be accepted as a nutritional role."""
+    import pytest
+
+    curator = IngredientCurator(curator_name="test_curator")
+    record = {"ontology_id": "TEST:900", "preferred_term": "x", "mapping_status": "MAPPED"}
+
+    with pytest.raises(ValueError, match="Invalid nutritional role"):
+        curator.add_nutritional_role(record, role="BUFFER")  # BUFFER is physicochemical, not nutritional
+
+    with pytest.raises(ValueError, match="Invalid physicochemical role"):
+        curator.add_physicochemical_role(record, role="CARBON_SOURCE")  # nutritional, not physicochemical
+
+    with pytest.raises(ValueError, match="Invalid cellular-metabolic role"):
+        curator.add_cellular_metabolic_role(record, role="BUFFER")  # not cellular-metabolic
+
+    print("✓ test_facet_role_validation_rejects_wrong_facet_value passed")
+
+
+def test_validate_role_assignments_walks_new_facet_slots():
+    """validate_role_assignments should detect invalid values in the three new facet slots."""
+    curator = IngredientCurator(curator_name="test_curator")
+    record = {
+        "ontology_id": "TEST:901",
+        "preferred_term": "y",
+        "mapping_status": "MAPPED",
+        "nutritional_roles": [{"role": "NOT_A_REAL_ROLE", "confidence": 0.5}],
+        "physicochemical_roles": [{"role": "BUFFER", "confidence": 2.5}],  # out-of-range confidence
+        "cellular_metabolic_roles": [
+            {"role": "SUBSTRATE", "evidence": [{"doi": "not-a-doi"}]}
+        ],
+    }
+
+    errors = curator.validate_role_assignments(record)
+    joined = " | ".join(errors)
+    assert "Invalid nutritional role at index 0: NOT_A_REAL_ROLE" in joined
+    assert "Confidence out of range at physicochemical role 0" in joined
+    assert "Invalid DOI format at cellular-metabolic role 0" in joined
+
+    print("✓ test_validate_role_assignments_walks_new_facet_slots passed")
+
+
 if __name__ == "__main__":
     test_add_media_role()
     test_add_media_role_without_citation()
     test_add_community_organism_role()
+    test_add_nutritional_role()
+    test_add_physicochemical_role()
+    test_add_cellular_metabolic_role()
+    test_facet_role_validation_rejects_wrong_facet_value()
+    test_validate_role_assignments_walks_new_facet_slots()
     test_set_solution_type()
     test_validation_invalid_role()
     test_validation_invalid_doi()


### PR DESCRIPTION
## Summary

Adds the schema + curator surface for populating the three facet enums that landed in #129 (`NutritionalRoleEnum`, `PhysicochemicalRoleEnum`, `CellularMetabolicRoleEnum`). This is Step 3 of the ingredient-roles migration plan.

- **Schema:** three new assignment classes + three new multivalued slots on `IngredientRecord`. Additive-only — `IngredientRoleEnum`, `RoleAssignment`, and the `media_roles` slot are unchanged (their retirement is tracked in #128).
- **Curator:** the module now derives its `VALID_*` role sets from the LinkML schema via `SchemaView` (no more hand-maintained mirrors). Three new writer methods mirror `add_media_role`; `add_cellular_metabolic_role` also accepts `metabolic_context` for organism-conditional roles.
- **Tests:** +8 tests (3 sync guards, 3 writer-method units, 1 negative cross-facet, 1 validator walk).

## Schema

New classes (all model on `RoleAssignment` / `CommunityOrganismRoleAssignment`):

| Class | Role range | Extra attrs |
| ----- | ---------- | ----------- |
| `NutritionalRoleAssignment` | `NutritionalRoleEnum` | — |
| `PhysicochemicalRoleAssignment` | `PhysicochemicalRoleEnum` | — |
| `CellularMetabolicRoleAssignment` | `CellularMetabolicRoleEnum` | `metabolic_context` (for organism/pathway scope of conditional roles) |

New slots on `IngredientRecord`: `nutritional_roles`, `physicochemical_roles`, `cellular_metabolic_roles`. Each `multivalued: true`, `inlined_as_list: true`.

## Curator

- Introduces `SchemaView` at module scope, lazily initialized. `_enum_permissible_values("EnumName")` extracts a frozenset from the schema.
- Replaces the four hand-maintained VALID_* sets (`VALID_MEDIA_ROLES`, `VALID_COMMUNITY_ORGANISM_ROLES`, `VALID_SOLUTION_TYPES`, `VALID_CITATION_TYPES`) with SchemaView-derived versions. Adds `VALID_NUTRITIONAL_ROLES`, `VALID_PHYSICOCHEMICAL_ROLES`, `VALID_CELLULAR_METABOLIC_ROLES`. Drift between curator and schema is now structurally impossible.
- Three new writer methods, each with the same DOI/PMID/URL/reference_type citation-attachment surface as `add_media_role`. Each validates against the correct facet's enum only — passing `BUFFER` to `add_nutritional_role` raises `ValueError`.
- `validate_role_assignments` extended to walk the three new slots via a small tuple-driven loop (avoids five near-identical blocks).

## Tests

- `test_enum_sync.py`: docstring rewritten to reflect the SchemaView source of truth. Three new sync tests use a fresh YAML re-load path (not SchemaView) so a SchemaView regression can't satisfy both sides of the assertion.
- `test_role_methods.py`: `test_add_nutritional_role`, `test_add_physicochemical_role`, `test_add_cellular_metabolic_role` (this last one checks `metabolic_context` round-trips through the assignment + into the curation-history changes msg), `test_facet_role_validation_rejects_wrong_facet_value` (negative test that facet enums are enforced independently), `test_validate_role_assignments_walks_new_facet_slots` (integration test that validator catches invalid values across the new slots).

## Explicit non-goals

Per the plan and #128, these are deferred to follow-up PRs:

1. Retire `IngredientRoleEnum`, `RoleAssignment`, and the `media_roles` slot (once ingredient records are populated on the new facet slots).
2. `docs/` regen (matching the pattern from #120 and #129).

Also flagged for the follow-up cycle:
- #126 — reconsider `CellularMetabolicRoleEnum.NONE` at slot-add time. Now that `cellular_metabolic_roles: []` and `[NONE]` mean the same thing structurally, decide before any large backfill.
- #127 — curator guidance to prevent auto-classifiers from double-assigning `OSMOTIC_AGENT` + `OSMOPROTECTANT` from the shared `CHEBI:25728` mapping.

## Test plan

- [x] `uv run linkml-validate` — clean
- [x] `uv run gen-python …` — regenerates cleanly (datamodel is `.gitignore`d)
- [x] `uv run pytest` — 387 passed (was 379 on main; +8 new)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)