### PR TITLE
Schema polish: drop NONE from CellularMetabolicRoleEnum (#126), osmolyte cross-facet guidance (#127)

### DIFF
--- a/src/mediaingredientmech/schema/mediaingredientmech.yaml
+++ b/src/mediaingredientmech/schema/mediaingredientmech.yaml
@@ -1019,7 +1019,9 @@ enums:
         description: Suppresses foaming in aerated or vigorously mixed cultures (e.g., silicone antifoam, polypropylene glycol).
         meaning: CHEBI:77973
       OSMOTIC_AGENT:
-        description: Contributes primarily to the osmotic strength of the medium (e.g., NaCl at high concentration, sucrose, glycerol as osmolyte).
+        description: >-
+          Contributes primarily to the osmotic strength of the medium (e.g., NaCl at high concentration, sucrose, glycerol as osmolyte).
+          NOTE: shares `mappings: CHEBI:25728 (osmolyte)` with CellularMetabolicRoleEnum.OSMOPROTECTANT. Auto-classifiers driven by the SSSOM must NOT fan a single CHEBI:25728 annotation out to both facets — this is a medium-side role, whereas OSMOPROTECTANT is an intracellular, organism-conditional role. Assign OSMOPROTECTANT only when there is organism-context evidence.
         mappings:
           - CHEBI:25728
       PRECIPITATION_INHIBITOR:
@@ -1053,7 +1055,9 @@ enums:
       MEMBRANE_COMPONENT:
         description: Incorporated into cell membranes (e.g., fatty acids, sterols, isoprenoid lipids).
       OSMOPROTECTANT:
-        description: Accumulated intracellularly to balance external osmotic stress (e.g., glycine betaine, ectoine, trehalose).
+        description: >-
+          Accumulated intracellularly to balance external osmotic stress (e.g., glycine betaine, ectoine, trehalose). Organism-conditional — assign only with organism-context evidence (e.g., "glycine betaine is imported and accumulated as an osmoprotectant by <organism>").
+          NOTE: shares `mappings: CHEBI:25728 (osmolyte)` with PhysicochemicalRoleEnum.OSMOTIC_AGENT. See that value's description for cross-facet guidance.
         mappings:
           - CHEBI:25728
       INDUCER:
@@ -1063,8 +1067,6 @@ enums:
         meaning: CHEBI:35222
       QUENCHER:
         description: Absorbs or dissipates a signal (e.g., quenches fluorescence, radicals, or light).
-      NONE:
-        description: Ingredient has no known cellular metabolic role (e.g., agar is chemically inert; resazurin is a bystander indicator).
 
   CommunityOrganismRoleEnum:
     description: Role an organism plays in a microbial community (formerly `CellularRoleEnum`; renamed 2026-07-19 to disambiguate from cell-level metabolic roles of ingredients — these values describe organisms, not ingredients).


### PR DESCRIPTION
## Summary

Two small schema polish issues from the #130 review cycle:

- **#126** — drop `CellularMetabolicRoleEnum.NONE` (11 → 10 values). Empty list is the natural encoding for "no known metabolic role"; keeping `NONE` invites ambiguous states like `[NONE, SUBSTRATE]` and inflated query counts.
- **#127** — extend descriptions of `PhysicochemicalRoleEnum.OSMOTIC_AGENT` and `CellularMetabolicRoleEnum.OSMOPROTECTANT` (which both use `mappings: CHEBI:25728` = osmolyte) to warn auto-classifiers against dual-assigning a compound to both facets from that shared mapping. `OSMOTIC_AGENT` is the medium-side role; `OSMOPROTECTANT` is intracellular and organism-conditional — assign only with organism-context evidence.

## Data migration

None. No ingredient currently populates `cellular_metabolic_roles` (the slot was added just three PRs ago in #130 and no record has been written to it yet).

## Test plan

- [x] `uv run linkml-validate` — clean
- [x] `uv run gen-python …` — regenerates cleanly
- [x] `uv run pytest` — 387 passed
- [x] Confirmed `NONE` absent from regenerated `VALID_CELLULAR_METABOLIC_ROLES` (10 values); no downstream Python or test consumers reference `NONE` literally.
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)