### PR TITLE
Role migration review follow-ups: halide classification + citation assertions

### DIFF
--- a/data/ingredients/mapped/Kbr.yaml
+++ b/data/ingredients/mapped/Kbr.yaml
@@ -87,6 +87,14 @@ curation_history:
   curator: migrate_media_roles_to_facets
   action: ANNOTATED
   changes: 'Migrated legacy media_roles to role facets (#128): MINERAL -> nutritional_roles.TRACE_ELEMENT'
+- timestamp: '2026-07-20T20:20:38.959489+00:00'
+  curator: migrate_media_roles_to_facets
+  action: CORRECTED
+  changes: 'Reclassified from TRACE_ELEMENT to MINERAL_SOURCE: the #128 migration
+    treated Br/F/I/Li as micronutrients, but they are not established microbial trace
+    elements (NaF and LiCl act as inhibitors / selective agents). MINERAL_SOURCE preserves
+    the original MINERAL claim without asserting micronutrient status; a selective-agent
+    role needs curator evidence.'
 chemical_properties:
   cas_rn: 7758-02-3
   data_source: PubChem API
@@ -97,7 +105,7 @@ chemical_properties:
 kg_microbe_node_id: CHEBI:32030
 ingredient_type: SINGLE_INGREDIENT
 nutritional_roles:
-- role: TRACE_ELEMENT
+- role: MINERAL_SOURCE
   confidence: 1.0
   evidence:
   - reference_text: CultureMech database (295 occurrences as 'Mineral source')

--- a/data/ingredients/mapped/Ki.yaml
+++ b/data/ingredients/mapped/Ki.yaml
@@ -107,6 +107,14 @@ curation_history:
   curator: migrate_media_roles_to_facets
   action: ANNOTATED
   changes: 'Migrated legacy media_roles to role facets (#128): MINERAL -> nutritional_roles.TRACE_ELEMENT'
+- timestamp: '2026-07-20T20:20:38.959489+00:00'
+  curator: migrate_media_roles_to_facets
+  action: CORRECTED
+  changes: 'Reclassified from TRACE_ELEMENT to MINERAL_SOURCE: the #128 migration
+    treated Br/F/I/Li as micronutrients, but they are not established microbial trace
+    elements (NaF and LiCl act as inhibitors / selective agents). MINERAL_SOURCE preserves
+    the original MINERAL claim without asserting micronutrient status; a selective-agent
+    role needs curator evidence.'
 chemical_properties:
   cas_rn: 7681-11-0
   data_source: CultureBotHT compounds_to_cas.csv
@@ -117,7 +125,7 @@ chemical_properties:
 kg_microbe_node_id: CHEBI:8346
 ingredient_type: SINGLE_INGREDIENT
 nutritional_roles:
-- role: TRACE_ELEMENT
+- role: MINERAL_SOURCE
   confidence: 1.0
   evidence:
   - reference_type: DATABASE_ENTRY

--- a/data/ingredients/mapped/Licl.yaml
+++ b/data/ingredients/mapped/Licl.yaml
@@ -73,6 +73,14 @@ curation_history:
   curator: migrate_media_roles_to_facets
   action: ANNOTATED
   changes: 'Migrated legacy media_roles to role facets (#128): MINERAL -> nutritional_roles.TRACE_ELEMENT'
+- timestamp: '2026-07-20T20:20:38.959489+00:00'
+  curator: migrate_media_roles_to_facets
+  action: CORRECTED
+  changes: 'Reclassified from TRACE_ELEMENT to MINERAL_SOURCE: the #128 migration
+    treated Br/F/I/Li as micronutrients, but they are not established microbial trace
+    elements (NaF and LiCl act as inhibitors / selective agents). MINERAL_SOURCE preserves
+    the original MINERAL claim without asserting micronutrient status; a selective-agent
+    role needs curator evidence.'
 chemical_properties:
   cas_rn: 7447-41-8
   data_source: PubChem API
@@ -83,7 +91,7 @@ chemical_properties:
 kg_microbe_node_id: CHEBI:48607
 ingredient_type: SINGLE_INGREDIENT
 nutritional_roles:
-- role: TRACE_ELEMENT
+- role: MINERAL_SOURCE
   confidence: 1.0
   evidence:
   - reference_type: DATABASE_ENTRY

--- a/data/ingredients/mapped/Nabr.yaml
+++ b/data/ingredients/mapped/Nabr.yaml
@@ -94,6 +94,14 @@ curation_history:
   curator: migrate_media_roles_to_facets
   action: ANNOTATED
   changes: 'Migrated legacy media_roles to role facets (#128): MINERAL -> nutritional_roles.TRACE_ELEMENT'
+- timestamp: '2026-07-20T20:20:38.959489+00:00'
+  curator: migrate_media_roles_to_facets
+  action: CORRECTED
+  changes: 'Reclassified from TRACE_ELEMENT to MINERAL_SOURCE: the #128 migration
+    treated Br/F/I/Li as micronutrients, but they are not established microbial trace
+    elements (NaF and LiCl act as inhibitors / selective agents). MINERAL_SOURCE preserves
+    the original MINERAL claim without asserting micronutrient status; a selective-agent
+    role needs curator evidence.'
 chemical_properties:
   cas_rn: 7647-15-6
   data_source: PubChem API
@@ -104,7 +112,7 @@ chemical_properties:
 kg_microbe_node_id: CHEBI:63004
 ingredient_type: SINGLE_INGREDIENT
 nutritional_roles:
-- role: TRACE_ELEMENT
+- role: MINERAL_SOURCE
   confidence: 1.0
   evidence:
   - reference_text: CultureMech database (233 occurrences as 'Mineral source')

--- a/data/ingredients/mapped/Naf.yaml
+++ b/data/ingredients/mapped/Naf.yaml
@@ -72,6 +72,14 @@ curation_history:
   curator: migrate_media_roles_to_facets
   action: ANNOTATED
   changes: 'Migrated legacy media_roles to role facets (#128): MINERAL -> nutritional_roles.TRACE_ELEMENT'
+- timestamp: '2026-07-20T20:20:38.959489+00:00'
+  curator: migrate_media_roles_to_facets
+  action: CORRECTED
+  changes: 'Reclassified from TRACE_ELEMENT to MINERAL_SOURCE: the #128 migration
+    treated Br/F/I/Li as micronutrients, but they are not established microbial trace
+    elements (NaF and LiCl act as inhibitors / selective agents). MINERAL_SOURCE preserves
+    the original MINERAL claim without asserting micronutrient status; a selective-agent
+    role needs curator evidence.'
 chemical_properties:
   cas_rn: 7681-49-4
   data_source: PubChem API
@@ -82,7 +90,7 @@ chemical_properties:
 kg_microbe_node_id: CHEBI:28741
 ingredient_type: SINGLE_INGREDIENT
 nutritional_roles:
-- role: TRACE_ELEMENT
+- role: MINERAL_SOURCE
   confidence: 1.0
   evidence:
   - reference_text: CultureMech database (260 occurrences as 'Mineral source')

--- a/scripts/migrate_media_roles_to_facets.py
+++ b/scripts/migrate_media_roles_to_facets.py
@@ -83,12 +83,21 @@ DIRECT_ROUTING: dict[str, tuple[str, str]] = {
     "ELECTRON_ACCEPTOR": (CELLULAR, "ELECTRON_ACCEPTOR"),
 }
 
-#: Micronutrient metals/halogens supplied in trace amounts. Presence of any of
-#: these in the formula makes TRACE_ELEMENT the salient nutritional role.
+#: Micronutrient metals supplied in trace amounts. Presence of any of these in
+#: the formula makes TRACE_ELEMENT the salient nutritional role.
 TRACE_ELEMENTS = (
     "Co", "Cu", "Mn", "Zn", "Ni", "Mo", "W", "V", "Se", "B",
-    "Al", "Ba", "Sr", "Sn", "Li", "Cr", "I", "F", "Br",
+    "Al", "Ba", "Sr", "Sn", "Cr",
 )
+
+#: Elements that are minerals but not microbial micronutrients, so TRACE_ELEMENT
+#: would over-claim. Bromide and iodide appear in some trace-element recipes
+#: without an established requirement; fluoride and lithium are not nutrients at
+#: all (NaF and LiCl act as inhibitors / selective agents). These route to the
+#: generic MINERAL_SOURCE, which preserves the curator's original "this is a
+#: mineral" claim without asserting micronutrient status. Reclassifying LiCl or
+#: NaF as SELECTIVE_AGENT needs a curator, not a migration.
+NON_NUTRIENT_MINERALS = ("Br", "F", "I", "Li")
 
 #: Bulk mineral cations -> the residual MINERAL_SOURCE bucket.
 BULK_CATIONS = ("Mg", "Ca", "K", "Na")
@@ -172,14 +181,19 @@ def mineral_targets(record: dict[str, Any]) -> Optional[list[tuple[str, str]]]:
     if "S" in elements and not (has_trace or has_iron):
         targets.append((NUTRITIONAL, "SULFUR_SOURCE"))
 
-    # Bulk cations fill the residual bucket. The guard is on the *cation* roles,
-    # not on `targets` being empty: TRACE_ELEMENT and IRON_SOURCE already name
-    # the cation (Na2MoO4 is a molybdenum source, its sodium is a counter-ion),
-    # but SULFUR_SOURCE and PHOSPHATE_SOURCE name the anion, so a bulk cation
-    # alongside them is a second, distinct nutrient. MgSO4 supplies magnesium
-    # *and* sulfur; suppressing the cation there would lose the single most
-    # common magnesium source in defined media.
-    if (elements & set(BULK_CATIONS)) and not (has_trace or has_iron):
+    # The residual MINERAL_SOURCE bucket, earned two ways: a bulk cation, or a
+    # mineral that is not a micronutrient. KBr qualifies on both counts (K and
+    # Br), so this is one condition rather than two appends.
+    #
+    # The guard is on the *cation* roles, not on `targets` being empty:
+    # TRACE_ELEMENT and IRON_SOURCE already name the cation (Na2MoO4 is a
+    # molybdenum source, its sodium is a counter-ion), but SULFUR_SOURCE and
+    # PHOSPHATE_SOURCE name the anion, so a bulk cation alongside them is a
+    # second, distinct nutrient. MgSO4 supplies magnesium *and* sulfur;
+    # suppressing the cation there would lose the single most common magnesium
+    # source in defined media.
+    residual = set(BULK_CATIONS) | set(NON_NUTRIENT_MINERALS)
+    if (elements & residual) and not (has_trace or has_iron):
         targets.append((NUTRITIONAL, "MINERAL_SOURCE"))
 
     # Formula-free records (e.g. elemental sulfur has no formula on the record)

--- a/tests/test_role_methods.py
+++ b/tests/test_role_methods.py
@@ -226,7 +226,19 @@ def test_add_nutritional_role():
     assert assignment["confidence"] == 0.98
     assert assignment["notes"] == "Round-trip check for notes preservation."
     assert len(assignment["evidence"]) == 1
-    assert assignment["evidence"][0]["doi"] == "10.1128/jb.00456-20"
+    # Every citation field must survive the round trip, not just the DOI: a
+    # writer that silently stopped recording curator_note or reference_type
+    # would otherwise pass.
+    citation = assignment["evidence"][0]
+    assert citation["doi"] == "10.1128/jb.00456-20"
+    assert citation["reference_type"] == "PEER_REVIEWED_PUBLICATION"
+    assert citation["reference_text"] == "DOI: 10.1128/jb.00456-20"
+    assert citation["curator_note"].startswith("L-cysteine supplies")
+
+    # The history entry must name both the role and the DOI.
+    changes = result["curation_history"][0]["changes"]
+    assert "AMINO_ACID_SOURCE" in changes
+    assert "10.1128/jb.00456-20" in changes
 
     curator.add_nutritional_role(record, role="SULFUR_SOURCE", confidence=0.9)
     assert len(result["nutritional_roles"]) == 2
@@ -278,7 +290,12 @@ def test_add_physicochemical_role():
     )
     assert len(result["physicochemical_roles"]) == 2
     assert len(result["physicochemical_roles"][1]["evidence"]) == 1
-    assert result["physicochemical_roles"][1]["evidence"][0]["doi"] == "10.1128/aem.02345-19"
+    citation = result["physicochemical_roles"][1]["evidence"][0]
+    assert citation["doi"] == "10.1128/aem.02345-19"
+    assert citation["reference_type"] == "PEER_REVIEWED_PUBLICATION"
+    # With a DOI but no explicit reference_text, the writer synthesises one.
+    assert citation["reference_text"] == "DOI: 10.1128/aem.02345-19"
+    assert "SURFACTANT" in result["curation_history"][-1]["changes"]
 
     print("✓ test_add_physicochemical_role passed")
 


### PR DESCRIPTION
Post-merge review of #139 surfaced two real defects. Both fixed here.

## 1. `TRACE_ELEMENT` over-claimed on halide and lithium salts

The migration’s trace-element list included `Br`, `F`, `I` and `Li`, so five records were recorded as micronutrient sources:

| record | formula | was | now |
|---|---|---|---|
| KBr | `Br.K` | TRACE_ELEMENT | MINERAL_SOURCE |
| NaBr | `Br.Na` | TRACE_ELEMENT | MINERAL_SOURCE |
| NaF | `F.Na` | TRACE_ELEMENT | MINERAL_SOURCE |
| KI | `I.K` | TRACE_ELEMENT | MINERAL_SOURCE |
| LiCl | `Cl.Li` | TRACE_ELEMENT | MINERAL_SOURCE |

None of these is an established microbial trace element. Bromide and iodide turn up in some trace-element recipes without a demonstrated requirement; fluoride and lithium are not nutrients at all — NaF and LiCl act as inhibitors or selective agents.

`MINERAL_SOURCE` preserves the curator’s original `MINERAL` claim without asserting micronutrient status. Reclassifying NaF or LiCl as `SELECTIVE_AGENT` would be a new curation claim needing evidence, so the migration deliberately does not attempt it — that is a curator call.

Counts: TRACE_ELEMENT 93 → 88, MINERAL_SOURCE 37 → 42. Each record carries a `CORRECTED` curation_history event.

The two residual-bucket conditions (bulk cation, non-nutrient mineral) are folded into one condition, since KBr qualifies on both counts and would otherwise append `MINERAL_SOURCE` twice.

## 2. Citation-passthrough coverage regressed

When #139 folded the flat-enum writer tests into the facet tests, some assertions were lost. The deleted `test_add_media_role` asserted that `reference_text`, `reference_type` and `curator_note` all landed in the citation, and that the history entry named both the role and the DOI. The replacements asserted only `evidence[0]["doi"]`.

Concretely: if `add_nutritional_role` stopped writing `curator_note` into the citation, the suite still passed. Those assertions are restored on the nutritional and physicochemical facets. (`test_add_cellular_metabolic_role` already asserted on history text, so that facet was covered.)

## Not reproduced

The review also reported that the generated LinkML datamodel still declares `media_roles`, `RoleAssignment` and `IngredientRoleEnum`. It does not ship: `src/mediaingredientmech/datamodel/` is gitignored (`.gitignore:51`), is absent from the #139 commit, and is regenerated by `just gen-schema`. The reviewer read a stale working-tree copy during a window when the checkout was moving between branches.

## Verification

- 416 tests pass; `validate_all --mode both` 0 errors across 2265 files.
- Routing regression-checked across representative salts: MgSO4 → SULFUR_SOURCE + MINERAL_SOURCE, CuSO4 → TRACE_ELEMENT, Na2MoO4 → TRACE_ELEMENT (sodium correctly suppressed), FePO4 → IRON_SOURCE + PHOSPHATE_SOURCE, no duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)