### PR TITLE
Restore the Edison credential for --provider falcon (reverts #140/#141 regression)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,43 @@
+# MediaIngredientMech environment variables
+# Copy this file to .env and fill in your values.
+# .env is gitignored — DO NOT commit it.
+#
+# `just` loads .env automatically (`set dotenv-load := true`). Scripts run
+# directly with `python scripts/...` do NOT get it unless they call
+# load_dotenv() themselves, so prefer the `just` recipes.
+
+# ---------------------------------------------------------------------------
+# Edison Scientific (formerly FutureHouse) — deep research
+# ---------------------------------------------------------------------------
+# Used by scripts/research_ingredient_edison.py + `just research-ingredient-edison*`
+# (Edison-direct), and by scripts/research_ingredient.py + deep-research-client
+# (`--provider falcon`, which IS the Edison provider — "falcon" is the old
+# FutureHouse brand name).
+#
+# Create a key at https://platform.edisonscientific.com/
+#
+# EDISON_API_KEY is the canonical name and what belongs here. The SDK also reads
+# EDISON_PLATFORM_API_KEY natively, and FUTUREHOUSE_API_KEY is a deprecated
+# alias — set only EDISON_API_KEY unless you have a specific reason not to.
+# Keeping a second Edison key exported in your shell profile causes
+# `python scripts/...` and `just <recipe>` to authenticate as *different
+# accounts*, which silently splits your research history.
+EDISON_API_KEY=
+
+# ---------------------------------------------------------------------------
+# Anthropic — LLM-assisted curation
+# ---------------------------------------------------------------------------
+# Get a key at https://console.anthropic.com/
+ANTHROPIC_API_KEY=
+
+# ---------------------------------------------------------------------------
+# Optional
+# ---------------------------------------------------------------------------
+# Contact email sent to Crossref when resolving DOIs (their API asks for one
+# so they can reach you about heavy usage). Falls back to an anonymous request.
+# MIM_CROSSREF_EMAIL=you@example.org
+
+# Absolute path to the kg-microbe deepwalk embeddings used by
+# scripts/generate_ingredient_umap.py. Defaults to the repo-relative location;
+# set this only if your embeddings live elsewhere.
+# KG_MICROBE_EMBEDDINGS=/path/to/embeddings.tsv

--- a/scripts/research_ingredient.py
+++ b/scripts/research_ingredient.py
@@ -211,9 +211,8 @@ def normalize_provider(provider: str) -> str:
     """Canonical form of a ``--provider`` value.
 
     ``--provider`` is free-text (no argparse ``choices``), so the value reaching
-    the credential guard below is whatever the caller typed. Case- and
-    whitespace-fold it before any provider comparison, otherwise ``--provider
-    Falcon`` misses the lookup while still routing to FutureHouse.
+    the comparisons below is whatever the caller typed. Case- and whitespace-fold
+    it so ``--provider Falcon`` behaves like ``falcon``.
     """
     return (provider or "").strip().lower()
 
@@ -225,36 +224,29 @@ def provider_args(provider: str) -> list[str]:
     return ["--provider", provider]
 
 
-# Providers that are NOT Edison, and so must never receive an Edison credential.
-# ``deep-research-client`` reads whatever is in ``EDISON_API_KEY`` and forwards it
-# to whichever provider was selected, so the credential lookup has to be
-# provider-aware.
-_NON_EDISON_PROVIDER_KEYS = {"falcon": "FUTUREHOUSE_API_KEY"}
-
-
 def research_env(provider: str) -> dict[str, str]:
-    """Build the subprocess environment, resolving the credential for ``provider``.
+    """Build the subprocess environment, honouring the deprecated FutureHouse alias.
 
-    For a non-Edison provider (Falcon → FutureHouse) the credential comes *only*
-    from that provider's own variable. Any Edison-named key in the environment is
-    dropped, and if the provider has no key of its own ``EDISON_API_KEY`` is left
-    unset so the client fails cleanly.
+    ``--provider falcon`` IS the Edison provider. "Falcon"/"FutureHouse" is the
+    former brand: ``deep_research_client/client.py`` registers it as
+    ``# Edison provider (formerly Falcon/FutureHouse)`` and resolves its
+    credential as ``os.getenv("EDISON_API_KEY") or os.getenv("FUTUREHOUSE_API_KEY")``,
+    then hands it to ``EdisonClient``. One Edison credential covers both names,
+    and ``FUTUREHOUSE_API_KEY`` is a deprecated alias for that same key — the
+    client emits a DeprecationWarning when it falls back to it.
 
-    This matters because this repo's ``.env`` sets ``EDISON_API_KEY`` and ``just``
-    injects it via ``dotenv-load``. The previous version honoured that ambient
-    value for Falcon too, so a ``--provider falcon`` run transmitted an Edison
-    credential to FutureHouse: wrong vendor, and it could not authenticate anyway.
-    An Edison-named variable is repo configuration, not the caller asking for that
-    key to be used with FutureHouse. To pin a credential for Falcon, set
-    ``FUTUREHOUSE_API_KEY``.
+    So there is no cross-vendor credential question here, and nothing to
+    withhold: passing ``EDISON_API_KEY`` to ``--provider falcon`` sends an Edison
+    key to Edison. The only thing worth doing is honouring the deprecated alias
+    when the canonical variable is unset, for client versions that don't.
     """
     env = os.environ.copy()
-    provider_key = _NON_EDISON_PROVIDER_KEYS.get(normalize_provider(provider))
-    if provider_key:
-        env.pop("EDISON_API_KEY", None)
-        env.pop("EDISON_PLATFORM_API_KEY", None)
-        if env.get(provider_key):
-            env["EDISON_API_KEY"] = env[provider_key]
+    if (
+        normalize_provider(provider) == "falcon"
+        and not env.get("EDISON_API_KEY")
+        and env.get("FUTUREHOUSE_API_KEY")
+    ):
+        env["EDISON_API_KEY"] = env["FUTUREHOUSE_API_KEY"]
     return env
 
 

--- a/tests/test_research_ingredient.py
+++ b/tests/test_research_ingredient.py
@@ -97,28 +97,31 @@ def test_research_env_maps_futurehouse_key_to_edison(monkeypatch):
 
 
 def test_research_env_keeps_existing_edison_key(monkeypatch):
-    """CONTRACT CHANGE: an ambient EDISON_API_KEY is no longer forwarded to Falcon.
+    """The canonical EDISON_API_KEY wins over the deprecated alias.
 
-    This previously asserted the opposite — that an existing EDISON_API_KEY wins
-    for every provider. That is unsafe in practice: this repo's `.env` sets
-    EDISON_API_KEY and `just` injects it via dotenv-load, so the "existing" key is
-    ambient repo configuration rather than a caller instruction, and forwarding it
-    to `--provider falcon` transmitted an Edison credential to FutureHouse.
-
-    Edison-named variables are now dropped for non-Edison providers. To pin a
-    credential for Falcon, set FUTUREHOUSE_API_KEY.
+    `--provider falcon` IS the Edison provider (deep_research_client/client.py
+    registers it as "Edison provider (formerly Falcon/FutureHouse)" and resolves
+    `EDISON_API_KEY or FUTUREHOUSE_API_KEY` into an EdisonClient), so an Edison
+    key is exactly the right credential for it. FUTUREHOUSE_API_KEY is a
+    deprecated alias for that same key and must not override it.
     """
     monkeypatch.setenv("EDISON_API_KEY", "edison-key")
     monkeypatch.setenv("FUTUREHOUSE_API_KEY", "futurehouse-key")
-    env = research_env("falcon")
-    assert env["EDISON_API_KEY"] == "futurehouse-key"
+    assert research_env("falcon")["EDISON_API_KEY"] == "edison-key"
 
 
-def test_research_env_withholds_edison_key_from_falcon(monkeypatch):
-    """With no FutureHouse key, leave it unset rather than substitute Edison's."""
+def test_research_env_passes_edison_key_to_falcon(monkeypatch):
+    """Regression guard: falcon must not be starved of the Edison credential.
+
+    A previous change stripped EDISON_API_KEY for `--provider falcon` on the
+    false premise that falcon was a third-party FutureHouse endpoint. It is not,
+    and the effect was that the falcon provider stopped registering at all
+    (client.py only registers it when a key resolves), so every Falcon run
+    failed.
+    """
     monkeypatch.setenv("EDISON_API_KEY", "edison-key")
-    env = research_env("falcon")
-    assert "EDISON_API_KEY" not in env
+    monkeypatch.delenv("FUTUREHOUSE_API_KEY", raising=False)
+    assert research_env("falcon")["EDISON_API_KEY"] == "edison-key"
 
 
 def test_research_env_leaves_edison_providers_untouched(monkeypatch):
@@ -127,16 +130,8 @@ def test_research_env_leaves_edison_providers_untouched(monkeypatch):
 
 
 @pytest.mark.parametrize("spelling", ["Falcon", "FALCON", " falcon ", "FaLcOn"])
-def test_research_env_withholds_edison_key_regardless_of_provider_spelling(
-    monkeypatch, spelling
-):
-    """The guard must not be defeated by capitalisation.
-
-    `--provider` takes free text (no argparse `choices`), and the value is passed
-    to deep-research-client verbatim. So `--provider Falcon` still routes to
-    FutureHouse; if the credential lookup were case-sensitive it would miss and
-    forward the Edison key — the exact leak this guard exists to prevent.
-    """
-    monkeypatch.setenv("EDISON_API_KEY", "edison-key")
-    monkeypatch.delenv("FUTUREHOUSE_API_KEY", raising=False)
-    assert "EDISON_API_KEY" not in research_env(spelling)
+def test_research_env_alias_applies_regardless_of_provider_spelling(monkeypatch, spelling):
+    """`--provider` is free text, so the alias must not hinge on capitalisation."""
+    monkeypatch.delenv("EDISON_API_KEY", raising=False)
+    monkeypatch.setenv("FUTUREHOUSE_API_KEY", "futurehouse-key")
+    assert research_env(spelling)["EDISON_API_KEY"] == "futurehouse-key"


### PR DESCRIPTION
Reverts the credential change from #140, hardened in #141. **The premise was wrong, and the change broke Falcon on `main`.**

## `--provider falcon` IS the Edison provider

From `deep_research_client/client.py:66` (v0.2.4, installed in this repo):

```python
# Edison provider (formerly Falcon/FutureHouse)
edison_key = os.getenv("EDISON_API_KEY") or os.getenv("FUTUREHOUSE_API_KEY")
if edison_key:
    if not os.getenv("EDISON_API_KEY") and os.getenv("FUTUREHOUSE_API_KEY"):
        warnings.warn("FUTUREHOUSE_API_KEY is deprecated. Please use EDISON_API_KEY instead.", ...)
    config = ProviderConfig(name="falcon", api_key=edison_key, enabled=True)
```

And `providers/falcon.py` does `from edison_client import EdisonClient` / `EdisonClient(api_key=...)`, raising `"Edison provider not available"`. `cli.py:542` maps `"falcon": "EDISON_API_KEY"`.

"Falcon"/"FutureHouse" is the former brand — still visible inside the SDK itself (`job-futurehouse-paperqa3`). `FUTUREHOUSE_API_KEY` is a **deprecated alias for the same Edison credential**, not a separate vendor’s key.

So passing `EDISON_API_KEY` to `--provider falcon` sends an Edison key to Edison. There was no cross-vendor disclosure, and nothing to withhold. Both repo `.env.example` files (MIM and TraitMech) already documented this correctly.

## The change broke Falcon

Stripping `EDISON_API_KEY` meant no credential resolved, and `client.py` only registers the falcon provider *when one does*. With no `FUTUREHOUSE_API_KEY` anywhere on the machine, `just research-ingredient falcon ...` failed outright:

```
EDISON_API_KEY seen by deep-research-client: None
-> falcon provider registers? False
```

## This PR

Restores the original semantics — pass the environment through, and alias the deprecated `FUTUREHOUSE_API_KEY` onto `EDISON_API_KEY` only when the canonical variable is unset.

Keeps `normalize_provider` from #141, which is independently useful (it also fixes the `"cborg"` comparison), so the alias is now case-insensitive.

Tests: the two that pinned the withhold contract are replaced by a regression guard asserting falcon still receives the Edison key; the spelling parametrisation now checks the alias applies for any capitalisation.

`.claude/skills/mediaingredientmech-agentic-curation/skill.md:27` needed no edit — it described this behaviour correctly all along, and #140 is what made it false.

## Not affected

`CultureMech/scripts/research_media.py` and `TraitMech/scripts/research_trait.py` still have the original correct logic and need no change. Porting the #140 "fix" to them, as I had proposed, would have broken Falcon in both.

## Verification

416 tests pass; `validate_all --mode both` 0 errors. Falcon receives the Edison key for `falcon`/`Falcon`/`FALCON`, and the deprecated alias still works when `EDISON_API_KEY` is unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)