### PR TITLE
Route validate_roles through iter_role_assignments (#136)

### DIFF
--- a/scripts/validate_roles.py
+++ b/scripts/validate_roles.py
@@ -94,7 +94,12 @@ def validate_file(file_path: Path, label: str) -> dict:
                         if cite.get("doi"):
                             stats["roles_with_doi"] += 1
 
-        community_organism_roles = record.get("community_organism_roles", [])
+        # community_organism_roles is organism-level, not an ingredient facet, so
+        # it is counted as its own category — but still walked via the shared
+        # iterator (explicit single-slot filter) rather than a hard-coded get().
+        community_organism_roles = [
+            a for _slot, a in iter_role_assignments(record, slots=("community_organism_roles",))
+        ]
         if community_organism_roles:
             stats["with_community_organism_roles"] += 1
             stats["total_community_organism_roles"] += len(community_organism_roles)


### PR DESCRIPTION
Closes #136. Final piece of the "scripts should walk role slots via `iter_role_assignments`" sweep from the #132 audit.

The #128 work already converted 15 of the 17 listed scripts. This handles the last hard-coded slot access: `validate_roles.py` read `record.get("community_organism_roles", [])` directly. That slot is organism-level (not an ingredient facet), so it stays its own reported category — but it now goes through the shared iterator with an explicit single-slot filter, so no script reaches into a role slot by hardcoded key.

Two scripts keep concrete slot names, both correctly out of scope:
- `migrate_media_roles_to_facets.py` — the migration itself; it must name the retired `media_roles` source and each specific facet target.
- `build_water_hierarchy.py` — dead code (non-runnable, documented in #128); its only role usage is a literal record it builds plus a debug print of that literal, not cross-record iteration.

Verified: `validate_roles.py` reports 994 ingredient roles (matches the corpus), 0 validation errors; role test suite 97 passed; full suite 416 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)