### PR TITLE
Step 7b PR1: ingredient role research template + Edison shim + template_vars extension

### DIFF
--- a/justfile
+++ b/justfile
@@ -290,6 +290,25 @@ research-ingredient-edison-batch batch *args="":
         --out-dir {{research_dir}}/ingredients \
         {{args}}
 
+# Step 7b — Edison deep research for the ROLE facets of one ingredient. Same
+# runner as research-ingredient-edison but pinned to the role-research template
+# and a separate output directory (research/ingredients/roles/) so identity-
+# mapping and role-research runs never clobber each other.
+# Examples:
+#   just research-ingredient-roles-edison L-cysteine --dry-run
+#   just research-ingredient-roles-edison Glucose --job literature-high
+research-ingredient-roles-edison target *args="":
+    uv run --extra dev python scripts/research_ingredient_roles_edison.py \
+        --target {{target}} \
+        {{args}}
+
+# Step 7b — Edison role research for a batch of ingredients. Typically driven
+# by the CultureMech prioritizer output (`prioritize_role_research_candidates.py`).
+research-ingredient-roles-edison-batch batch *args="":
+    uv run --extra dev python scripts/research_ingredient_roles_edison.py \
+        --batch {{batch}} \
+        {{args}}
+
 # Retroactively backfill Edison provenance sidecars (no re-billing).
 enrich-edison-response *args="":
     uv run --extra dev python scripts/enrich_edison_response.py {{args}}

--- a/scripts/research_ingredient.py
+++ b/scripts/research_ingredient.py
@@ -184,12 +184,149 @@ def summarize_curation_history(doc: dict[str, Any], limit: int = 8) -> str:
     return _join_values(values)
 
 
+# --- Step 7b role-facet helpers (used by templates/ingredient_role_research.md). ------
+
+def _facet_enum_values(enum_name: str) -> list[str]:
+    """Return the permissible-value token list for a facet enum in the LinkML schema.
+
+    Uses `mediaingredientmech.curation.ingredient_curator` which already exposes
+    SchemaView-derived VALID_* frozensets (added in #135). Kept as a helper so
+    template rendering can compose a candidate menu Edison can pick from.
+    """
+    import sys
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+    from mediaingredientmech.curation.ingredient_curator import (
+        VALID_CELLULAR_METABOLIC_ROLES,
+        VALID_NUTRITIONAL_ROLES,
+        VALID_PHYSICOCHEMICAL_ROLES,
+    )
+    return sorted({
+        "NutritionalRoleEnum":       VALID_NUTRITIONAL_ROLES,
+        "PhysicochemicalRoleEnum":   VALID_PHYSICOCHEMICAL_ROLES,
+        "CellularMetabolicRoleEnum": VALID_CELLULAR_METABOLIC_ROLES,
+    }[enum_name])
+
+
+def summarize_existing_role_assignments(doc: dict[str, Any]) -> str:
+    """Render the three facet slots currently on the IngredientRecord for context.
+
+    Edison sees this so it doesn't propose values that already exist AND so it
+    knows which facets are the actual gaps to fill.
+    """
+    facets = [
+        ("nutritional_roles",       "Nutritional"),
+        ("physicochemical_roles",   "Physicochemical"),
+        ("cellular_metabolic_roles", "Cellular-metabolic"),
+    ]
+    parts: list[str] = []
+    for slot, label in facets:
+        assignments = doc.get(slot) or []
+        if not isinstance(assignments, list) or not assignments:
+            parts.append(f"{label}: (none — GAP)")
+            continue
+        roles = []
+        for a in assignments:
+            if isinstance(a, dict):
+                role = a.get("role", "?")
+                conf = a.get("confidence")
+                roles.append(f"{role}" + (f"@{conf:.2f}" if isinstance(conf, (int, float)) else ""))
+            elif isinstance(a, str):
+                roles.append(a)
+        parts.append(f"{label}: [{', '.join(roles)}]")
+    return "; ".join(parts)
+
+
+def summarize_chebi_role_axioms(doc: dict[str, Any], limit: int = 15) -> str:
+    """Live OAK lookup of CHEBI `has_role` axioms on the ingredient's CHEBI id.
+
+    Returns a human-readable summary of each `has_role` target (id + label)
+    so Edison can confirm or contradict what CHEBI's own hierarchy asserts.
+    Falls back to "None recorded" if no CHEBI id, no OAK adapter, or no axioms.
+
+    Slow — ~2-5s cold-start on the first call in a process. Adapter is cached
+    at module level so subsequent calls are ~ms.
+    """
+    chebi_id = _ingredient_chebi_id(doc)
+    if not chebi_id:
+        return "None recorded (no CHEBI grounding)"
+    adapter = _oak_chebi_adapter()
+    if adapter is None:
+        return "None recorded (OAK adapter unavailable)"
+    try:
+        triples = list(adapter.relationships(subjects=[chebi_id]))
+    except Exception as exc:  # pragma: no cover — OAK failure modes are noisy.
+        return f"None recorded (OAK query failed: {exc!r})"
+
+    axioms = []
+    for triple in triples:
+        if not isinstance(triple, tuple) or len(triple) < 3:
+            continue
+        _s, pred, obj = triple[0], triple[1], triple[2]
+        if pred != "RO:0000087":  # has_role
+            continue
+        if not isinstance(obj, str) or not obj.startswith("CHEBI:"):
+            continue
+        try:
+            lbl = adapter.label(obj) or obj
+        except Exception:
+            lbl = obj
+        axioms.append(f"{obj} ({lbl})")
+    if not axioms:
+        return "None recorded (CHEBI has no has_role axioms on this compound)"
+    if len(axioms) > limit:
+        axioms = axioms[:limit] + [f"... ({len(axioms) - limit} more)"]
+    return "; ".join(axioms)
+
+
+_CHEBI_ID_PATHS = (
+    ("identifier",),           # IngredientRecord's own identifier when it starts with CHEBI:
+    ("ontology_mapping", "ontology_id"),
+)
+
+
+def _ingredient_chebi_id(doc: dict[str, Any]) -> str | None:
+    """Extract CHEBI id from a MIM IngredientRecord."""
+    for path in _CHEBI_ID_PATHS:
+        cur: Any = doc
+        for key in path:
+            if not isinstance(cur, dict):
+                cur = None
+                break
+            cur = cur.get(key)
+        if isinstance(cur, str) and cur.startswith("CHEBI:"):
+            return cur
+    return None
+
+
+_OAK_CACHE: dict[str, Any] = {}
+
+
+def _oak_chebi_adapter():
+    """Return a cached `sqlite:obo:chebi` adapter, or None if oaklib isn't available."""
+    if "chebi" in _OAK_CACHE:
+        return _OAK_CACHE["chebi"]
+    try:
+        from oaklib import get_adapter  # type: ignore
+        adapter = get_adapter("sqlite:obo:chebi")
+    except Exception:  # pragma: no cover — oaklib install / sqlite fetch failures
+        adapter = None
+    _OAK_CACHE["chebi"] = adapter
+    return adapter
+
+
 def template_vars(
     doc: dict[str, Any],
     ingredient_status: str,
     ingredient_slug: str,
 ) -> dict[str, str]:
-    """Build template variables for deep-research-client."""
+    """Build template variables for deep-research-client.
+
+    The five `candidate_*_roles` / `existing_role_assignments` /
+    `chebi_role_axioms` entries below feed the Step 7b role-research
+    template. Existing consumers of `template_vars` (identity/mapping
+    research) ignore the extra keys — `_DefaultEmpty` swallows any
+    placeholder the template doesn't reference.
+    """
     return {
         "ingredient_label": _scalar_text(doc.get("preferred_term")) or ingredient_slug,
         "ingredient_identifier": _scalar_text(doc.get("identifier")) or "None recorded",
@@ -204,6 +341,12 @@ def template_vars(
         "evidence_summary": summarize_evidence(doc),
         "curation_summary": summarize_curation_history(doc),
         "notes": _scalar_text(doc.get("notes")) or "None recorded",
+        # Step 7b (ingredient_role_research.md) additions:
+        "candidate_nutritional_roles":       ", ".join(_facet_enum_values("NutritionalRoleEnum")),
+        "candidate_physicochemical_roles":   ", ".join(_facet_enum_values("PhysicochemicalRoleEnum")),
+        "candidate_cellular_metabolic_roles": ", ".join(_facet_enum_values("CellularMetabolicRoleEnum")),
+        "existing_role_assignments": summarize_existing_role_assignments(doc),
+        "chebi_role_axioms": summarize_chebi_role_axioms(doc),
     }
 
 

--- a/scripts/research_ingredient_roles_edison.py
+++ b/scripts/research_ingredient_roles_edison.py
@@ -1,0 +1,66 @@
+"""Edison-driven role research for one MediaIngredientMech ingredient (Step 7b lane).
+
+Thin shim over `scripts/research_ingredient_edison.py` that pins the role
+research template and the roles output subdirectory. Everything else —
+CLI flags, batch mode, dry-run, capture bundle, cost tallying — is
+inherited unchanged.
+
+Usage (mirrors research_ingredient_edison.py exactly):
+
+    just research-ingredient-roles-edison <target>
+    uv run --extra dev python scripts/research_ingredient_roles_edison.py \\
+        --target data/ingredients/mapped/L-cysteine.yaml [--dry-run]
+
+Batch:
+
+    just research-ingredient-roles-edison-batch <batch.json>
+    uv run --extra dev python scripts/research_ingredient_roles_edison.py \\
+        --batch reports/role_research_priority.json --limit 10
+
+Outputs go to `research/ingredients/roles/<slug>-edison-{job}.md` (+ the
+standard 6-file capture bundle). Keep them separate from identity-mapping
+research (which writes to `research/ingredients/<slug>-edison-{job}.md`)
+so runs never clobber each other.
+
+The template is `templates/ingredient_role_research.md`; extending
+`research_ingredient.py::template_vars()` (also in this PR) is what
+supplies the five role-specific placeholders it references.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+_ROLES_TEMPLATE = REPO_ROOT / "templates" / "ingredient_role_research.md"
+_ROLES_OUT_DIR = REPO_ROOT / "research" / "ingredients" / "roles"
+
+
+def _inject_defaults(argv: list[str]) -> list[str]:
+    """Insert `--template <roles_template>` and `--out-dir <roles_dir>` unless caller overrode."""
+    args = list(argv)
+    if not any(a == "--template" or a.startswith("--template=") for a in args):
+        args.extend(["--template", str(_ROLES_TEMPLATE)])
+    if not any(a == "--out-dir" or a.startswith("--out-dir=") for a in args):
+        args.extend(["--out-dir", str(_ROLES_OUT_DIR)])
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    # Import lazily so `--help` still works even if optional deps (edison-client)
+    # aren't installed.
+    from research_ingredient_edison import main as _upstream_main
+
+    if argv is None:
+        argv = sys.argv[1:]
+    return _upstream_main(_inject_defaults(argv))
+
+
+if __name__ == "__main__":
+    # scripts/ is on sys.path so `import research_ingredient_edison` works when
+    # this file is run directly (matches the pattern used by the tests).
+    _SCRIPTS_DIR = Path(__file__).resolve().parent
+    if str(_SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS_DIR))
+    sys.exit(main())

--- a/templates/ingredient_role_research.md
+++ b/templates/ingredient_role_research.md
@@ -1,0 +1,137 @@
+# Media Ingredient Role Research Template
+
+## Target Ingredient
+- **Ingredient label:** {ingredient_label}
+- **Ingredient identifier:** {ingredient_identifier}
+- **Ingredient status:** {ingredient_status}
+- **Ingredient slug:** {ingredient_slug}
+- **Ingredient type:** {ingredient_type}
+- **Mapping status:** {mapping_status}
+- **Ontology mapping:** {ontology_mapping}
+- **Chemical properties:** {chemical_properties}
+- **Synonyms:** {synonyms}
+- **Occurrence summary:** {occurrence_summary}
+- **Notes:** {notes}
+
+## Existing role assignments on this record
+{existing_role_assignments}
+
+## CHEBI has_role axioms already asserted
+{chebi_role_axioms}
+
+## Research Objective
+
+Research the **functional roles** the ingredient **{ingredient_label}** plays across three
+orthogonal facets, and update
+`data/ingredients/{ingredient_status}/{ingredient_slug}.yaml` with evidence-bearing
+role assignments. Facets are independent — a single ingredient often fills multiple
+(e.g. L-cysteine → `AMINO_ACID_SOURCE` + `SULFUR_SOURCE` nutritionally, `REDUCING_AGENT`
+physicochemically, `SUBSTRATE` cellular-metabolically).
+
+Prefer confirming or refining the existing assignments above rather than replacing them.
+Where CHEBI's own `has_role` axioms already assert a role, cite them alongside the
+literature — an agreement between CHEBI and a primary source is stronger than either alone.
+
+## Required Findings
+
+### 1. Nutritional facet (`NutritionalRoleEnum`)
+
+What element or macronutrient does this ingredient supply to a culture medium?
+
+Candidate values (pick zero or more; use ONLY these tokens): **{candidate_nutritional_roles}**
+
+For each proposed value, cite the strongest primary source (DOI or PMID) that shows the
+ingredient supplies that element in a defined medium. Concentration ranges, media
+categories (marine, soil, human-gut, …), and organism scope belong in `metabolic_context`.
+
+### 2. Physicochemical facet (`PhysicochemicalRoleEnum`)
+
+What chemical or physical job does the ingredient perform in the medium, INDEPENDENT of
+what element it supplies? (Buffering, chelation, indicator, surfactant, gelling, etc.)
+
+Candidate values: **{candidate_physicochemical_roles}**
+
+Recipe-conditional roles (e.g. `BUFFER` only when paired with a conjugate) should still
+be reported with a `metabolic_context` note explaining the condition; the mechanistic
+lane already handles unconditional CHEBI has_role → role hits.
+
+### 3. Cellular-metabolic facet (`CellularMetabolicRoleEnum`)
+
+What does the ingredient do INSIDE or ON the cultured microbe? These are OFTEN
+**organism-conditional** — methanol is `ELECTRON_DONOR` only for methylotrophs; sulfide
+is only for sulfide-oxidising chemolithotrophs.
+
+Candidate values: **{candidate_cellular_metabolic_roles}**
+
+Always populate `metabolic_context` when a value applies only to a subset of organisms
+or growth modes.
+
+### 4. Cross-facet conflicts / synonymy
+
+Flag any observed cross-facet double-mapping (e.g. `OSMOTIC_AGENT` + `OSMOPROTECTANT`
+both point at CHEBI:25728 — they are legitimately distinct facets that share an
+ontology anchor). Do not silently propose the same role in two facets unless the
+literature genuinely supports both interpretations for this specific ingredient.
+
+## Output Format
+
+Return a curation-focused report followed by a **machine-readable fenced YAML block**
+with the exact shape below. The block will be parsed by
+`scripts/extract_roles_from_edison.py` on the CultureMech side and applied via the
+MIM `apply_role_research_results.py` script.
+
+Example (edit fields to reflect your findings — this shape is required):
+
+```yaml
+role_research:
+  ingredient: {ingredient_slug}
+  ingredient_identifier: {ingredient_identifier}
+  nutritional_roles:
+    - role: SULFUR_SOURCE
+      confidence: 0.9
+      metabolic_context: "canonical sulfur source in defined media"
+      evidence:
+        - reference_type: PEER_REVIEWED_PUBLICATION
+          doi: 10.1128/jb.00456-20
+          reference_text: "Smith et al. 2020, J. Bacteriol."
+          excerpt: "L-cysteine supplied at 0.5 g/L served as the sole sulfur source..."
+    - role: AMINO_ACID_SOURCE
+      confidence: 0.95
+      evidence: []
+  physicochemical_roles:
+    - role: REDUCING_AGENT
+      confidence: 0.85
+      metabolic_context: "at ~0.5 g/L in anaerobic media"
+      evidence:
+        - reference_type: PEER_REVIEWED_PUBLICATION
+          pmid: "12345678"
+          excerpt: "..."
+  cellular_metabolic_roles:
+    - role: SUBSTRATE
+      confidence: 0.9
+      metabolic_context: "assimilatory sulfate reduction pathway; NOT for organisms lacking cys biosynthesis"
+      evidence: []
+  warnings:
+    - "Do not confuse with cystine (oxidised dimer) — different CHEBI id, different roles."
+```
+
+Rules for the fenced block:
+
+- Every `role:` value MUST be from the candidate menus above (case-sensitive tokens).
+  Do NOT invent tokens; if none fit, omit the entry rather than guess.
+- `confidence` is a 0.0-1.0 float. Use 0.9-1.0 only when a primary source explicitly
+  asserts the role for this specific ingredient in a culture-media context.
+- `evidence[]` list order matches citation strength — put the strongest source first.
+- `metabolic_context` is required for organism-conditional or concentration-conditional
+  values; optional for unconditional supply roles.
+- Leave a facet's list EMPTY (`[]`) if the literature doesn't support any value there —
+  never fabricate to fill a gap.
+- The curation-focused prose report above is for human review; the fenced YAML block
+  is what actually applies to the record. Both are required.
+
+Also include:
+
+- Scope summary (2-3 sentences).
+- Source-backed evidence table (one row per citation).
+- DOI-first bibliography (PMID only when DOI unavailable).
+- Warnings for claims not yet ripe for curation.

--- a/tests/test_research_ingredient_roles.py
+++ b/tests/test_research_ingredient_roles.py
@@ -1,0 +1,246 @@
+"""Tests for the Step 7b role-research template + template_vars extension + Edison shim."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPTS_DIR = _REPO_ROOT / "scripts"
+
+# Ensure scripts/ is on sys.path so `research_ingredient_edison` imports resolve
+# inside the shim's `_upstream_main` call.
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+
+def _load(script: str):
+    spec = importlib.util.spec_from_file_location(f"_test_{script}", _SCRIPTS_DIR / f"{script}.py")
+    module = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+    sys.modules[f"_test_{script}"] = module
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+ri = _load("research_ingredient")
+
+
+# ---------------- template_vars extensions ----------------
+
+
+def _minimal_doc() -> dict:
+    return {
+        "identifier": "MediaIngredientMech:000042",
+        "preferred_term": "Test ingredient",
+        "ingredient_type": "SINGLE",
+        "mapping_status": "MAPPED",
+    }
+
+
+def test_template_vars_carries_role_placeholders():
+    tv = ri.template_vars(_minimal_doc(), "mapped", "test-ingredient")
+    for key in (
+        "candidate_nutritional_roles",
+        "candidate_physicochemical_roles",
+        "candidate_cellular_metabolic_roles",
+        "existing_role_assignments",
+        "chebi_role_axioms",
+    ):
+        assert key in tv, f"template_vars missing {key!r}"
+
+
+def test_candidate_menus_are_the_full_facet_enum_values():
+    tv = ri.template_vars(_minimal_doc(), "mapped", "t")
+    # NutritionalRoleEnum currently has 12 values; check a few representatives.
+    for tok in ("CARBON_SOURCE", "NITROGEN_SOURCE", "SULFUR_SOURCE", "VITAMIN_SOURCE"):
+        assert tok in tv["candidate_nutritional_roles"], f"{tok} missing from nutritional menu"
+    # PhysicochemicalRoleEnum
+    for tok in ("BUFFER", "CHELATOR", "SURFACTANT", "REDUCING_AGENT"):
+        assert tok in tv["candidate_physicochemical_roles"], f"{tok} missing from physicochem menu"
+    # CellularMetabolicRoleEnum
+    for tok in ("SUBSTRATE", "ELECTRON_DONOR", "COFACTOR", "INHIBITOR"):
+        assert tok in tv["candidate_cellular_metabolic_roles"], f"{tok} missing from cellular menu"
+
+
+def test_existing_role_assignments_flags_gaps():
+    """A record with zero facet slots populated should be described as all-GAP."""
+    tv = ri.template_vars(_minimal_doc(), "mapped", "t")
+    assert "Nutritional: (none — GAP)" in tv["existing_role_assignments"]
+    assert "Physicochemical: (none — GAP)" in tv["existing_role_assignments"]
+    assert "Cellular-metabolic: (none — GAP)" in tv["existing_role_assignments"]
+
+
+def test_existing_role_assignments_reports_populated_facets():
+    doc = _minimal_doc()
+    doc["nutritional_roles"] = [
+        {"role": "CARBON_SOURCE", "confidence": 1.0},
+        {"role": "ENERGY_SOURCE", "confidence": 0.7},
+    ]
+    doc["physicochemical_roles"] = [{"role": "BUFFER", "confidence": 0.9}]
+    # cellular_metabolic_roles left empty
+    tv = ri.template_vars(doc, "mapped", "t")
+    summary = tv["existing_role_assignments"]
+    assert "CARBON_SOURCE@1.00" in summary
+    assert "ENERGY_SOURCE@0.70" in summary
+    assert "BUFFER@0.90" in summary
+    assert "Cellular-metabolic: (none — GAP)" in summary
+
+
+def test_existing_role_assignments_handles_plain_string_roles():
+    """The MIM schema stores rich assignments, but scalar-list callers must still render."""
+    doc = _minimal_doc()
+    doc["nutritional_roles"] = ["CARBON_SOURCE", "ENERGY_SOURCE"]
+    tv = ri.template_vars(doc, "mapped", "t")
+    summary = tv["existing_role_assignments"]
+    assert "CARBON_SOURCE" in summary and "ENERGY_SOURCE" in summary
+
+
+def test_chebi_role_axioms_no_grounding_returns_placeholder():
+    doc = _minimal_doc()  # identifier is `MediaIngredientMech:000042` — not CHEBI:*
+    tv = ri.template_vars(doc, "mapped", "t")
+    assert "no chebi grounding" in tv["chebi_role_axioms"].lower()
+
+
+def test_chebi_role_axioms_reads_from_ontology_mapping():
+    doc = _minimal_doc()
+    doc["ontology_mapping"] = {"ontology_id": "CHEBI:99999", "ontology_label": "notarealchebi"}
+    # Live OAK call — either returns empty (unknown id) or "OAK adapter unavailable"
+    # depending on whether sqlite:obo:chebi is warmed. Both are acceptable; the test
+    # asserts the code path runs without raising and returns a string.
+    tv = ri.template_vars(doc, "mapped", "t")
+    assert isinstance(tv["chebi_role_axioms"], str)
+
+
+def test_ingredient_chebi_id_extraction_prefers_identifier_when_chebi():
+    doc = {"identifier": "CHEBI:17234"}
+    assert ri._ingredient_chebi_id(doc) == "CHEBI:17234"
+
+
+def test_ingredient_chebi_id_falls_back_to_ontology_mapping():
+    doc = {"identifier": "MIM:00042", "ontology_mapping": {"ontology_id": "CHEBI:17234"}}
+    assert ri._ingredient_chebi_id(doc) == "CHEBI:17234"
+
+
+def test_ingredient_chebi_id_returns_none_when_no_chebi():
+    assert ri._ingredient_chebi_id({}) is None
+    assert ri._ingredient_chebi_id({"identifier": "MIM:00042"}) is None
+
+
+# ---------------- template file itself ----------------
+
+
+def test_role_template_references_all_new_placeholders():
+    """The template must reference every new placeholder template_vars() emits, so
+    that a template drift can be caught by test rather than silent empty renders.
+    """
+    template = (_REPO_ROOT / "templates" / "ingredient_role_research.md").read_text()
+    for placeholder in (
+        "{candidate_nutritional_roles}",
+        "{candidate_physicochemical_roles}",
+        "{candidate_cellular_metabolic_roles}",
+        "{existing_role_assignments}",
+        "{chebi_role_axioms}",
+    ):
+        assert placeholder in template, f"role template missing {placeholder!r}"
+
+
+def test_role_template_names_the_three_facet_enums():
+    """Guard that the enum names in the template stay aligned with mim_roles.yaml
+    class names — a rename upstream would be caught here.
+    """
+    template = (_REPO_ROOT / "templates" / "ingredient_role_research.md").read_text()
+    for enum_name in ("NutritionalRoleEnum", "PhysicochemicalRoleEnum", "CellularMetabolicRoleEnum"):
+        assert enum_name in template, f"role template missing enum name {enum_name}"
+
+
+def test_role_template_shows_worked_yaml_example():
+    """The fenced YAML block must appear so PaperQA has a shape to fill."""
+    template = (_REPO_ROOT / "templates" / "ingredient_role_research.md").read_text()
+    assert "```yaml" in template
+    assert "role_research:" in template
+    assert "nutritional_roles:" in template
+    assert "reference_type: PEER_REVIEWED_PUBLICATION" in template
+
+
+# ---------------- Edison shim ----------------
+
+
+roles_shim = _load("research_ingredient_roles_edison")
+
+
+def test_shim_injects_template_when_missing():
+    args = roles_shim._inject_defaults(["--target", "data/ingredients/mapped/foo.yaml"])
+    assert "--template" in args
+    template_idx = args.index("--template")
+    assert args[template_idx + 1].endswith("templates/ingredient_role_research.md")
+
+
+def test_shim_injects_out_dir_when_missing():
+    args = roles_shim._inject_defaults(["--target", "x.yaml"])
+    assert "--out-dir" in args
+    out_idx = args.index("--out-dir")
+    assert args[out_idx + 1].endswith("research/ingredients/roles")
+
+
+def test_shim_preserves_user_template_override():
+    args = roles_shim._inject_defaults([
+        "--target", "x.yaml",
+        "--template", "/custom/path/tpl.md",
+    ])
+    # Only ONE --template flag present, and it's the user's.
+    assert args.count("--template") == 1
+    assert "/custom/path/tpl.md" in args
+
+
+def test_shim_preserves_user_out_dir_override():
+    args = roles_shim._inject_defaults([
+        "--target", "x.yaml",
+        "--out-dir", "/tmp/scratch",
+    ])
+    assert args.count("--out-dir") == 1
+    assert "/tmp/scratch" in args
+
+
+def test_shim_dry_run_flag_passthrough():
+    args = roles_shim._inject_defaults(["--target", "x.yaml", "--dry-run"])
+    assert "--dry-run" in args
+
+
+# ---------------- End-to-end template render (dry, no OAK, no API) ----------------
+
+
+def test_template_renders_with_all_placeholders_filled(tmp_path):
+    """Load the real roles template and .format_map it with real template_vars output.
+
+    Fails LOUDLY if any placeholder in the template is missing from template_vars —
+    even though _DefaultEmpty would silently swallow it in production, we want the
+    test to catch this. Compare rendered length to a baseline; a missing placeholder
+    would leave a `{name}` literal in the output.
+    """
+    doc = _minimal_doc()
+    tv = ri.template_vars(doc, "mapped", "t")
+    template = (_REPO_ROOT / "templates" / "ingredient_role_research.md").read_text()
+
+    # Substitute — use plain format_map with a real dict (no _DefaultEmpty fallback),
+    # so a missing placeholder would raise KeyError.
+    rendered = template.format_map(tv)
+
+    # No leftover `{placeholder}` literals from the top-level facets/existing/chebi keys.
+    for leftover in (
+        "{candidate_nutritional_roles}",
+        "{candidate_physicochemical_roles}",
+        "{candidate_cellular_metabolic_roles}",
+        "{existing_role_assignments}",
+        "{chebi_role_axioms}",
+    ):
+        assert leftover not in rendered, f"unrendered placeholder in output: {leftover}"
+
+    # Rendered content should have the enum candidate values substituted in.
+    assert "CARBON_SOURCE" in rendered
+    assert "BUFFER" in rendered
+    assert "SUBSTRATE" in rendered


### PR DESCRIPTION
## Summary

Foundation for the **Step 7b literature backfill lane** (per the plan file). Adds a new role-facet research template + the Edison runner shim that pins it, plus the 5-placeholder extension of `template_vars()` that supplies the vocabulary and CHEBI evidence context. Everything ships in `--dry-run` — no API credit spent.

## What ships

| File | Change |
| ---- | ------ |
| `templates/ingredient_role_research.md` **(new)** | PaperQA3 prompt structured around the three facet enums. Section 3 (Required Findings) reworked into per-facet rubrics with organism-conditional guidance. Section 4 demands a machine-readable **fenced YAML block** matching `NutritionalRoleAssignment` / `PhysicochemicalRoleAssignment` / `CellularMetabolicRoleAssignment` — a new Edison-output convention with a worked example embedded. |
| `scripts/research_ingredient_roles_edison.py` **(new)** | Thin shim over `research_ingredient_edison.py`; injects `--template templates/ingredient_role_research.md` and `--out-dir research/ingredients/roles`. Dedicated subdirectory so role and identity-mapping runs never collide by filename. |
| `scripts/research_ingredient.py` | `template_vars()` gains 5 placeholders: `candidate_nutritional_roles`, `candidate_physicochemical_roles`, `candidate_cellular_metabolic_roles`, `existing_role_assignments`, `chebi_role_axioms`. Enum values sourced from `VALID_*_ROLES` frozensets (SchemaView-derived, PR #135). `chebi_role_axioms` does a **live OAK lookup** against `sqlite:obo:chebi` — adapter cached at module scope so batch runs amortize the ~2-5s cold-start. |
| `justfile` | New recipes `research-ingredient-roles-edison target` and `research-ingredient-roles-edison-batch batch`. |
| `tests/test_research_ingredient_roles.py` **(new)** | 19 tests: template_vars extension, existing-role-assignments summary (empty gaps + rich dicts + scalar strings), CHEBI has_role live-OAK code path, template placeholder wiring, shim flag injection + override preservation, end-to-end template render. |

## Deferred (called out for later)

- **DRC-provider shim** (`research_ingredient_roles.py`) — upstream DRC runner hardcodes an output path that would collide with identity-mapping DRC outputs by filename. Needs an upstream refactor first; Edison is the primary lane.
- **`enrich_edison_response.py` recursive glob** — enricher's default doesn't walk `research/ingredients/roles/`. Explicit `--research-dir` invocation works today; a small default bump is the follow-up.

## Verified

- [x] `just research-ingredient-roles-edison L-cysteine --dry-run` — renders an 8108-char query (template + live CHEBI has_role axioms for CHEBI:17561), writes `research/ingredients/roles/L-cysteine-edison-literature-meta.yaml`. No API call.
- [x] `uv run pytest` — 435 passed / 0 failed (+19 new).
- [ ] CI green.

## Next in the Step 7b sequence

- **PR2 (MIM)** `apply_role_research_results.py` — writes rich `RoleAssignment` back to `IngredientRecord` with full evidence.
- **PR3 (CultureMech)** `prioritize_role_research_candidates.py` — scans MIM corpus, feeds batch JSON to this PR's runner.
- **PR4 (CultureMech)** `extract_roles_from_edison.py` — parses the fenced YAML block.
- **PR5 (CultureMech)** `apply_ingredient_roles` scalar-projection + skill.
- **PR6 (curator)** real Edison run on top-10 prioritizer output (~\$5-20 in credits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)