### PR TITLE
Preserve discussions across identifier-changing moves (#144 follow-up)

### DIFF
--- a/scripts/export_individual_records.py
+++ b/scripts/export_individual_records.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import re
 import sys
 from collections import Counter
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import click
@@ -41,21 +42,51 @@ console = Console()
 PER_RECORD_AUTHORED_FIELDS: tuple[str, ...] = ("discussions",)
 
 
-def collect_preserved_fields(ingredients_root: Path) -> dict[str, dict]:
-    """Index per-record-authored fields by `identifier`, before files are cleared.
+@dataclass
+class PreservedFields:
+    """Per-record-authored fields recovered from disk, looked up by a move-stable key.
+
+    Two indexes, because neither key is stable across every move:
+    * `by_identifier` — survives a display-name normalisation (identifier stable,
+      filename/preferred_term change).
+    * `by_preferred_term` — survives an identifier change (promotion
+      UNMAPPED_NNNN->CHEBI:x, demotion, or a CHEBI remap), where the primary key
+      is exactly what moves. Only unambiguous terms are indexed; a preferred_term
+      shared by more than one authored record is dropped rather than risk
+      attributing a discussion to the wrong record.
+    """
+
+    by_identifier: dict[str, dict] = field(default_factory=dict)
+    by_preferred_term: dict[str, dict] = field(default_factory=dict)
+
+    def for_record(self, record: dict) -> dict:
+        """Authored fields to merge into `record`, or {} if none. Identifier first."""
+        ident = record.get("identifier")
+        if ident and ident in self.by_identifier:
+            return self.by_identifier[ident]
+        term = record.get("preferred_term")
+        if term and term in self.by_preferred_term:
+            return self.by_preferred_term[term]
+        return {}
+
+
+def collect_preserved_fields(ingredients_root: Path) -> PreservedFields:
+    """Index per-record-authored fields before files are cleared.
 
     Scans the whole `data/ingredients/` tree (both mapped/ and unmapped/) so a
-    record that moves between them on promotion still keeps its authored fields.
-    Keyed on `identifier` — the stable primary key — not filename, which changes
-    on rename/normalisation.
+    record that moves between them still keeps its authored fields. Indexed by
+    both `identifier` and `preferred_term` — see `PreservedFields`, because in
+    MIM the identifier IS the mapping CURIE and changes on promotion/remap, so
+    identifier alone would miss exactly the moves this preservation exists for.
 
     Rebuilt from current disk state each run, so an edit that removes a
     discussion survives (it is simply absent from the index), while an export
     that would otherwise drop it does not.
     """
-    preserved: dict[str, dict] = {}
+    result = PreservedFields()
     if not ingredients_root.exists():
-        return preserved
+        return result
+    term_collisions: set[str] = set()
     for path in ingredients_root.rglob("*.yaml"):
         try:
             record = load_yaml(path)
@@ -63,17 +94,26 @@ def collect_preserved_fields(ingredients_root: Path) -> dict[str, dict]:
             continue
         if not isinstance(record, dict):
             continue
-        ident = record.get("identifier")
-        if not ident:
-            continue
         authored = {
-            field: record[field]
-            for field in PER_RECORD_AUTHORED_FIELDS
-            if record.get(field)
+            fname: record[fname]
+            for fname in PER_RECORD_AUTHORED_FIELDS
+            if record.get(fname)
         }
-        if authored:
-            preserved[ident] = authored
-    return preserved
+        if not authored:
+            continue
+        ident = record.get("identifier")
+        if ident:
+            result.by_identifier[ident] = authored
+        term = record.get("preferred_term")
+        if term:
+            # Two authored records sharing a term make term-based lookup
+            # ambiguous; drop it entirely rather than guess.
+            if term in result.by_preferred_term or term in term_collisions:
+                result.by_preferred_term.pop(term, None)
+                term_collisions.add(term)
+            else:
+                result.by_preferred_term[term] = authored
+    return result
 
 
 def sanitize_filename(preferred_term: str) -> str:
@@ -125,7 +165,7 @@ def export_collection_to_individual_files(
     collection_path: Path,
     output_dir: Path,
     dry_run: bool = False,
-    preserved: dict[str, dict] | None = None,
+    preserved: PreservedFields | None = None,
 ) -> dict[str, int]:
     """Export a collection YAML file to individual ingredient files.
 
@@ -133,14 +173,14 @@ def export_collection_to_individual_files(
         collection_path: Path to the collection YAML file.
         output_dir: Directory to write individual files.
         dry_run: If True, only show what would be done.
-        preserved: Per-record-authored fields keyed by identifier (from
-            ``collect_preserved_fields``), merged into records whose collection
-            copy lacks them. Pass None to skip preservation.
+        preserved: Per-record-authored fields (from ``collect_preserved_fields``),
+            merged into records whose collection copy lacks them. Pass None to
+            skip preservation.
 
     Returns:
         Dictionary with statistics: 'total', 'created', 'collisions'.
     """
-    preserved = preserved or {}
+    preserved = preserved or PreservedFields()
     stats = {'total': 0, 'created': 0, 'collisions': 0}
 
     # Load collection
@@ -192,11 +232,10 @@ def export_collection_to_individual_files(
         # Re-attach per-record-authored fields (e.g. discussions) that the
         # collection does not carry, so export does not wipe them. Only fill
         # gaps — a value present in the collection wins.
-        authored = preserved.get(identifier)
-        if authored:
-            for field, value in authored.items():
-                if not ingredient.get(field):
-                    ingredient[field] = value
+        authored = preserved.for_record(ingredient)
+        for fname, value in authored.items():
+            if not ingredient.get(fname):
+                ingredient[fname] = value
 
         if dry_run:
             console.print(f"[dim]Would create: {output_path}[/dim]")
@@ -267,10 +306,11 @@ def main(input_dir: str | None, output_dir: str | None, dry_run: bool):
     # Index per-record-authored fields BEFORE the per-category clear loop wipes
     # any files (a record may move mapped<->unmapped, so scan the whole tree).
     preserved = collect_preserved_fields(output_dir_path)
-    if preserved:
+    n_preserved = len(preserved.by_identifier)
+    if n_preserved:
         console.print(
             f"[dim]Preserving per-record fields "
-            f"({', '.join(PER_RECORD_AUTHORED_FIELDS)}) for {len(preserved)} record(s)[/dim]"
+            f"({', '.join(PER_RECORD_AUTHORED_FIELDS)}) for {n_preserved} record(s)[/dim]"
         )
 
     # Process each collection

--- a/tests/test_export_preserves_discussions.py
+++ b/tests/test_export_preserves_discussions.py
@@ -22,6 +22,10 @@ def _load_exporter():
         "export_individual_records", ROOT / "scripts" / "export_individual_records.py"
     )
     mod = importlib.util.module_from_spec(spec)
+    # Register before exec: a @dataclass under `from __future__ import annotations`
+    # resolves its module via sys.modules during class creation, which is absent
+    # for a spec_from_file_location load unless we register it here.
+    sys.modules[spec.name] = mod
     spec.loader.exec_module(mod)
     return mod
 
@@ -58,8 +62,10 @@ def test_collect_preserved_fields_indexes_by_identifier(tmp_path):
                         "mapping_status": "MAPPED"})  # no discussions
     )
     idx = exp.collect_preserved_fields(root)
-    assert set(idx) == {"CHEBI:1"}
-    assert idx["CHEBI:1"]["discussions"] == _discussion("kgscan-a")
+    assert set(idx.by_identifier) == {"CHEBI:1"}
+    assert idx.by_identifier["CHEBI:1"]["discussions"] == _discussion("kgscan-a")
+    # Indexed by preferred_term too, for identifier-changing moves.
+    assert idx.by_preferred_term["a"]["discussions"] == _discussion("kgscan-a")
 
 
 def test_export_reattaches_discussions_absent_from_collection(tmp_path):
@@ -151,3 +157,57 @@ def test_collection_discussions_win_over_stale_per_record(tmp_path):
 
     out = yaml.safe_load((ingredients / "mapped" / "Glucose.yaml").read_text())
     assert out["discussions"] == _discussion("fresh")
+
+
+def test_export_preserves_discussions_across_identifier_change_on_promotion(tmp_path):
+    """The move the identifier key alone misses: promotion changes the primary key.
+
+    The old per-record file is UNMAPPED_0001 in unmapped/; the collection has
+    promoted it to CHEBI:17234 in mapped/. Identifier-keyed lookup misses (old id
+    != new id), so preservation must fall back to the stable preferred_term.
+    """
+    exp = _load_exporter()
+    curated = tmp_path / "curated"
+    curated.mkdir()
+    ingredients = tmp_path / "ingredients"
+    (ingredients / "unmapped").mkdir(parents=True)
+    (ingredients / "mapped").mkdir()
+
+    (ingredients / "unmapped" / "Glucose.yaml").write_text(
+        yaml.safe_dump({"identifier": "UNMAPPED_0001", "preferred_term": "glucose",
+                        "mapping_status": "UNMAPPED", "discussions": _discussion("kgscan-glu")})
+    )
+    _write_collection(
+        curated / "mapped_ingredients.yaml",
+        [{"identifier": "CHEBI:17234", "preferred_term": "glucose", "mapping_status": "MAPPED"}],
+    )
+    _write_collection(curated / "unmapped_ingredients.yaml", [])
+
+    preserved = exp.collect_preserved_fields(ingredients)
+    exp.export_collection_to_individual_files(
+        curated / "mapped_ingredients.yaml", ingredients / "mapped", preserved=preserved
+    )
+
+    out = yaml.safe_load((ingredients / "mapped" / "Glucose.yaml").read_text())
+    assert out["discussions"] == _discussion("kgscan-glu"), "promotion lost the discussion"
+
+
+def test_preferred_term_collision_is_not_indexed(tmp_path):
+    """Two authored records sharing a preferred_term must not attribute to either."""
+    exp = _load_exporter()
+    root = tmp_path / "ingredients"
+    (root / "mapped").mkdir(parents=True)
+    (root / "mapped" / "A.yaml").write_text(
+        yaml.safe_dump({"identifier": "CHEBI:1", "preferred_term": "dup",
+                        "mapping_status": "MAPPED", "discussions": _discussion("kgscan-a")})
+    )
+    (root / "mapped" / "B.yaml").write_text(
+        yaml.safe_dump({"identifier": "CHEBI:2", "preferred_term": "dup",
+                        "mapping_status": "MAPPED", "discussions": _discussion("kgscan-b")})
+    )
+    idx = exp.collect_preserved_fields(root)
+    # Both still resolvable by their (unique) identifiers...
+    assert set(idx.by_identifier) == {"CHEBI:1", "CHEBI:2"}
+    # ...but the ambiguous term is dropped, so a promotion of either does not
+    # silently graft the wrong record's discussion.
+    assert "dup" not in idx.by_preferred_term


### PR DESCRIPTION
Fixes a real defect the #144 review found in that PR's own discussions-preservation fix.

## The bug
`collect_preserved_fields` indexed preserved fields by `identifier`. But in MIM the identifier IS the mapping CURIE, so it **changes** on exactly the moves the preservation exists for: promotion (`UNMAPPED_NNNN` → `CHEBI:x`), demotion, and remap (`CHEBI:X` → `CHEBI:Y`). On any of those the old per-record file was indexed under the old id, the promoted collection record carries the new id, the lookup missed, and the discussion was silently dropped — while the docstring claimed the opposite. Verified empirically: a `UNMAPPED_0001` → `CHEBI:17234` promotion lost its discussion.

Impact was bounded (8 discussions, all on mapped records with stable CHEBI ids, 0 unmapped), but a demotion or CHEBI-id correction of any of those 8 would have dropped it.

## Fix
`collect_preserved_fields` now returns a `PreservedFields` with two indexes:
- `by_identifier` — survives a display-name normalisation (id stable, name changes).
- `by_preferred_term` — survives an identifier change (name stable, id changes).

`for_record` tries identifier first, then preferred_term. A preferred_term shared by more than one authored record is dropped rather than risk grafting the wrong record's discussion.

## Tests
The 4 existing tests updated to the new API; added the promotion case (identifier changes — the exact path that failed) and a preferred_term-collision guard. Full suite 422 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)