### PR TITLE
Step 7b PR2: apply_role_research_results.py — write rich RoleAssignments back to MIM records

### DIFF
--- a/justfile
+++ b/justfile
@@ -294,6 +294,16 @@ research-ingredient-edison-batch batch *args="":
 enrich-edison-response *args="":
     uv run --extra dev python scripts/enrich_edison_response.py {{args}}
 
+# Step 7b — Apply role research results extracted from Edison output.
+# Input: JSON batch emitted by CultureMech's `extract_roles_from_edison.py`.
+# Writes rich RoleAssignments (with per-role confidence + evidence citations)
+# to `data/ingredients/**/*.yaml`. Per-facet never-overwrite guard.
+# Examples:
+#   just apply-role-research-results reports/edison_role_extraction.json --dry-run
+#   just apply-role-research-results reports/edison_role_extraction.json
+apply-role-research-results batch *args="":
+    uv run python scripts/apply_role_research_results.py {{batch}} {{args}}
+
 # Full workflow: export, validate, aggregate
 sync-individual:
     just export-individual && just validate-individual && just aggregate-collections

--- a/scripts/apply_role_research_results.py
+++ b/scripts/apply_role_research_results.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""Apply Step 7b Edison-derived role research results to MIM ingredient records.
+
+Reads a JSON batch (emitted by CultureMech `scripts/extract_roles_from_edison.py`
+from `research/ingredients/roles/*-edison-literature.md` output) and writes
+faceted role assignments back to `MediaIngredientMech/data/ingredients/**/*.yaml`
+with full `RoleCitation` evidence.
+
+Per-facet "never overwrite" guard: an ingredient whose `nutritional_roles`
+slot is already populated will NOT receive new nutritional-role proposals
+(but is still eligible for `physicochemical_roles` / `cellular_metabolic_roles`
+if those are empty). Matches the `apply_insession_role_curation.py` pattern.
+
+Idempotent: re-running against the same batch on an already-populated record
+skips it silently.
+
+Companion of `apply_insession_role_curation.py` — differs in:
+  - `curator: "edison-deep-research"` (vs `claude_in_session_curation`).
+  - Confidence sourced FROM Edison output (per-role field), not a fixed 0.6.
+  - `reference_type` per-evidence (typically PEER_REVIEWED_PUBLICATION with DOI)
+    rather than the flat `COMPUTATIONAL_PREDICTION`.
+  - Input is a JSON batch keyed by ingredient identifier, not a hard-coded
+    dict — the input is data, not code.
+
+Input JSON shape (produced by PR4's extractor):
+
+    {
+      "proposals": [
+        {
+          "ingredient_identifier": "CHEBI:17561",         # or a MIM/MICRO/… identifier
+          "ingredient_path": "data/ingredients/mapped/L-cysteine.yaml",  # optional
+          "source_run": "research/ingredients/roles/L-cysteine-edison-literature.md",
+          "role_assignments": {
+            "nutritional_roles": [
+              {
+                "role": "AMINO_ACID_SOURCE",
+                "confidence": 0.95,
+                "metabolic_context": "...",     # optional, cellular-metabolic only
+                "evidence": [                   # optional, list may be empty
+                  {
+                    "reference_type": "PEER_REVIEWED_PUBLICATION",
+                    "doi": "10.1128/jb.00456-20",
+                    "pmid": "12345678",         # optional if doi given
+                    "reference_text": "...",
+                    "excerpt": "...",
+                    "curator_note": "..."
+                  }
+                ]
+              }
+            ],
+            "physicochemical_roles": [...],
+            "cellular_metabolic_roles": [...]
+          }
+        }
+      ]
+    }
+
+Usage:
+
+    just apply-role-research-results reports/edison_role_extraction.json --dry-run
+    just apply-role-research-results reports/edison_role_extraction.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from mediaingredientmech.utils.role_facets import (
+    CELLULAR_METABOLIC,
+    NUTRITIONAL,
+    PHYSICOCHEMICAL,
+    facet_slot_for,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INGREDIENTS_DIR = REPO_ROOT / "data" / "ingredients"
+
+DEFAULT_CURATOR = "edison-deep-research"
+DEFAULT_REFERENCE_TYPE = "PEER_REVIEWED_PUBLICATION"
+
+FACET_SLOTS = (NUTRITIONAL, PHYSICOCHEMICAL, CELLULAR_METABOLIC)
+
+
+def _load_batch(path: Path) -> list[dict[str, Any]]:
+    """Load and shape-check the extractor JSON batch."""
+    data = json.loads(path.read_text())
+    if not isinstance(data, dict) or "proposals" not in data:
+        raise SystemExit(
+            f"Batch file {path} must be a JSON object with a top-level 'proposals' list."
+        )
+    proposals = data["proposals"]
+    if not isinstance(proposals, list):
+        raise SystemExit(f"'proposals' in {path} must be a list, got {type(proposals).__name__}.")
+    return proposals
+
+
+def _resolve_ingredient_path(proposal: dict[str, Any]) -> Path | None:
+    """Return the MIM YAML path for a proposal, or None if unresolvable."""
+    p = proposal.get("ingredient_path")
+    if p:
+        candidate = Path(p) if Path(p).is_absolute() else REPO_ROOT / p
+        if candidate.is_file():
+            return candidate
+    ident = proposal.get("ingredient_identifier") or ""
+    if not ident:
+        return None
+    # Try both status buckets (mapped/, unmapped/) using identifier as slug/id match.
+    # First cheap check: filename == "{local_part}.yaml".
+    if ":" in ident:
+        local = ident.split(":", 1)[1]
+    else:
+        local = ident
+    for status_dir in sorted(p for p in INGREDIENTS_DIR.iterdir() if p.is_dir()):
+        # Try the local part directly, then a case-insensitive search.
+        candidate = status_dir / f"{local}.yaml"
+        if candidate.is_file():
+            return candidate
+    # Slow path — walk and match by `identifier:` field inside each YAML.
+    import yaml
+    for yml in INGREDIENTS_DIR.rglob("*.yaml"):
+        try:
+            doc = yaml.safe_load(yml.read_text())
+        except Exception:
+            continue
+        if isinstance(doc, dict) and doc.get("identifier") == ident:
+            return yml
+    return None
+
+
+def _build_assignment(
+    role: str,
+    confidence: float,
+    metabolic_context: str | None,
+    evidence_entries: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Build a single RoleAssignment dict matching the LinkML schema shape."""
+    assignment: dict[str, Any] = {"role": role, "confidence": confidence, "evidence": []}
+    for ev in evidence_entries:
+        cite: dict[str, Any] = {}
+        for k in ("reference_type", "doi", "pmid", "reference_text", "url", "excerpt", "curator_note"):
+            if ev.get(k):
+                cite[k] = ev[k]
+        if cite:
+            assignment["evidence"].append(cite)
+    if metabolic_context:
+        # Schema note: metabolic_context is only on `CellularMetabolicRoleAssignment`.
+        # Caller must have already vetted the slot; we just carry the value through.
+        assignment["metabolic_context"] = metabolic_context
+    return assignment
+
+
+def _add_curation_event(
+    record: dict[str, Any],
+    curator_name: str,
+    fields_changed: list[str],
+    notes: str,
+) -> None:
+    """Append a curation_history event to the record."""
+    history = record.setdefault("curation_history", [])
+    history.append({
+        "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "curator": curator_name,
+        "action": "ANNOTATED",
+        "changes": ", ".join(fields_changed),
+        "notes": notes,
+    })
+
+
+def _apply_proposal(
+    record: dict[str, Any],
+    proposal: dict[str, Any],
+    curator_name: str,
+    dry_run: bool,
+) -> tuple[int, list[str], bool]:
+    """Apply one proposal to one record. Returns (roles_applied, skip_reasons, dirty)."""
+    role_assignments = proposal.get("role_assignments") or {}
+    applied = 0
+    reasons: list[str] = []
+    dirty = False
+    source_run = proposal.get("source_run") or ""
+    fields_changed: list[str] = []
+
+    for slot in FACET_SLOTS:
+        proposals_for_slot = role_assignments.get(slot) or []
+        if not proposals_for_slot:
+            continue
+        # Per-facet never-overwrite guard.
+        if record.get(slot):
+            reasons.append(f"skipped {slot}: already populated ({len(record[slot])} existing)")
+            continue
+
+        new_assignments: list[dict[str, Any]] = []
+        for role_prop in proposals_for_slot:
+            if not isinstance(role_prop, dict):
+                continue
+            role = role_prop.get("role")
+            if not role:
+                continue
+
+            # Cross-check: role name must belong to this facet.
+            try:
+                expected_slot = facet_slot_for(role)
+            except Exception:
+                expected_slot = None
+            if expected_slot is not None and expected_slot != slot:
+                reasons.append(
+                    f"skipped {slot}[{role}]: role belongs to {expected_slot}, not {slot}"
+                )
+                continue
+
+            confidence = float(role_prop.get("confidence", 0.8))
+            metabolic_context = role_prop.get("metabolic_context")
+            if metabolic_context and slot != CELLULAR_METABOLIC:
+                # Schema-illegal placement — drop the field but keep the role.
+                metabolic_context = None
+
+            evidence_list = role_prop.get("evidence") or []
+            if not evidence_list:
+                # Fabricate one COMPUTATIONAL_PREDICTION citation pointing at the source run
+                # so the audit trail is preserved even without primary evidence.
+                evidence_list = [{
+                    "reference_type": "COMPUTATIONAL_PREDICTION",
+                    "reference_text": f"Edison deep-research run (no primary citation given): {source_run}",
+                    "curator_note": "Provisional Edison-derived role; primary citation was not extracted.",
+                }]
+
+            assignment = _build_assignment(role, confidence, metabolic_context, evidence_list)
+            new_assignments.append(assignment)
+            applied += 1
+
+        if new_assignments and not dry_run:
+            record.setdefault(slot, []).extend(new_assignments)
+            fields_changed.append(slot)
+            dirty = True
+
+    if dirty:
+        _add_curation_event(
+            record,
+            curator_name,
+            fields_changed,
+            f"Applied Edison role research results ({source_run})",
+        )
+
+    return applied, reasons, dirty
+
+
+def _summary(applied: int, files_written: int, skipped: list[str], errors: list[str]) -> str:
+    lines = [
+        f"Role assignments applied: {applied}",
+        f"Ingredient records written: {files_written}",
+    ]
+    if skipped:
+        lines.append(f"Records with per-facet skips: {len(skipped)}")
+        for line in skipped[:10]:
+            lines.append(f"  - {line}")
+        if len(skipped) > 10:
+            lines.append(f"  - ... {len(skipped) - 10} more")
+    if errors:
+        lines.append(f"Errors: {len(errors)}")
+        for err in errors[:10]:
+            lines.append(f"  - {err}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("batch", type=Path, help="JSON batch from extract_roles_from_edison.py")
+    parser.add_argument("--curator", default=DEFAULT_CURATOR,
+                        help=f"Curator name for the curation-history event (default: {DEFAULT_CURATOR})")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Compute + report what would apply; write nothing.")
+    parser.add_argument("--limit", type=int, default=None,
+                        help="Cap number of proposals processed (for smoke tests).")
+    parser.add_argument("--verbose", "-v", action="store_true")
+    args = parser.parse_args(argv)
+
+    if not args.batch.is_file():
+        print(f"Batch file not found: {args.batch}", file=sys.stderr)
+        return 2
+
+    proposals = _load_batch(args.batch)
+    if args.limit is not None:
+        proposals = proposals[: args.limit]
+    print(f"Loaded {len(proposals)} proposals from {args.batch}")
+
+    total_applied = 0
+    total_skipped: list[str] = []
+    total_errors: list[str] = []
+    # {path: (record_dict, dirty_flag)} — MIM per-ingredient YAMLs are one
+    # record per file (top-level mapping, not a `ingredients:` collection).
+    records_by_path: dict[Path, dict[str, Any]] = {}
+    dirty_paths: set[Path] = set()
+
+    for proposal in proposals:
+        ing_path = _resolve_ingredient_path(proposal)
+        if ing_path is None:
+            total_errors.append(
+                f"unresolved ingredient: identifier={proposal.get('ingredient_identifier')!r} "
+                f"path={proposal.get('ingredient_path')!r}"
+            )
+            continue
+
+        if ing_path not in records_by_path:
+            try:
+                records_by_path[ing_path] = yaml.safe_load(ing_path.read_text()) or {}
+            except Exception as exc:
+                total_errors.append(f"failed to load {ing_path}: {exc}")
+                continue
+            if not isinstance(records_by_path[ing_path], dict):
+                total_errors.append(f"{ing_path} is not a YAML mapping")
+                records_by_path.pop(ing_path)
+                continue
+        record = records_by_path[ing_path]
+
+        applied, reasons, dirty = _apply_proposal(record, proposal, args.curator, args.dry_run)
+        total_applied += applied
+        if dirty:
+            dirty_paths.add(ing_path)
+        for reason in reasons:
+            total_skipped.append(f"{ing_path.name}: {reason}")
+        if args.verbose:
+            print(f"  {ing_path.name}: applied {applied} role(s)")
+            for reason in reasons:
+                print(f"    - {reason}")
+
+    files_written = 0
+    if not args.dry_run:
+        for path in dirty_paths:
+            path.write_text(yaml.safe_dump(records_by_path[path], sort_keys=False, allow_unicode=True))
+            files_written += 1
+
+    print()
+    print(_summary(total_applied, files_written, total_skipped, total_errors))
+    if args.dry_run:
+        print("\n[dry-run] no files were written.")
+    return 0 if not total_errors else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/apply_role_research_results.py
+++ b/scripts/apply_role_research_results.py
@@ -206,12 +206,20 @@ def _apply_proposal(
             if not role:
                 continue
 
-            # Cross-check: role name must belong to this facet.
+            # Cross-check: role name must be a permissible value of THIS facet.
+            # facet_slot_for raises for a token that is not a value of any facet
+            # enum (a typo, a hallucinated name, or a retired value like MINERAL/
+            # SALT); those must be skipped, not written — otherwise the tool
+            # emits a schema-invalid record that only the downstream validator
+            # catches. An unknown role and a wrong-facet role are both rejected.
             try:
                 expected_slot = facet_slot_for(role)
             except Exception:
-                expected_slot = None
-            if expected_slot is not None and expected_slot != slot:
+                reasons.append(
+                    f"skipped {slot}[{role}]: not a permissible value of any role facet"
+                )
+                continue
+            if expected_slot != slot:
                 reasons.append(
                     f"skipped {slot}[{role}]: role belongs to {expected_slot}, not {slot}"
                 )

--- a/tests/test_apply_role_research_results.py
+++ b/tests/test_apply_role_research_results.py
@@ -1,0 +1,349 @@
+"""Tests for scripts/apply_role_research_results.py — Step 7b MIM applier."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "apply_role_research_results.py"
+
+if str(_REPO_ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT / "src"))
+_SPEC = importlib.util.spec_from_file_location("_apply_roles", _SCRIPT_PATH)
+_apply = importlib.util.module_from_spec(_SPEC)
+sys.modules["_apply_roles"] = _apply
+_SPEC.loader.exec_module(_apply)  # type: ignore[union-attr]
+
+
+def _write_batch(tmp_path: Path, proposals: list[dict]) -> Path:
+    p = tmp_path / "batch.json"
+    p.write_text(json.dumps({"proposals": proposals}))
+    return p
+
+
+def _write_ingredient(tmp_path: Path, slug: str, doc: dict) -> Path:
+    (tmp_path / "data" / "ingredients" / "mapped").mkdir(parents=True, exist_ok=True)
+    p = tmp_path / "data" / "ingredients" / "mapped" / f"{slug}.yaml"
+    p.write_text(yaml.safe_dump(doc))
+    return p
+
+
+# ---------------- batch loader ----------------
+
+
+def test_load_batch_requires_proposals_key(tmp_path):
+    p = tmp_path / "bad.json"
+    p.write_text('{"other": []}')
+    with pytest.raises(SystemExit, match="proposals"):
+        _apply._load_batch(p)
+
+
+def test_load_batch_requires_list(tmp_path):
+    p = tmp_path / "bad.json"
+    p.write_text('{"proposals": "not a list"}')
+    with pytest.raises(SystemExit, match="must be a list"):
+        _apply._load_batch(p)
+
+
+def test_load_batch_accepts_valid_shape(tmp_path):
+    p = _write_batch(tmp_path, [{"ingredient_identifier": "CHEBI:17561"}])
+    proposals = _apply._load_batch(p)
+    assert len(proposals) == 1
+    assert proposals[0]["ingredient_identifier"] == "CHEBI:17561"
+
+
+# ---------------- _build_assignment ----------------
+
+
+def test_build_assignment_shape():
+    a = _apply._build_assignment(
+        "AMINO_ACID_SOURCE", 0.95, None,
+        [{"reference_type": "PEER_REVIEWED_PUBLICATION", "doi": "10.1234/x", "reference_text": "cite"}],
+    )
+    assert a == {
+        "role": "AMINO_ACID_SOURCE", "confidence": 0.95,
+        "evidence": [{"reference_type": "PEER_REVIEWED_PUBLICATION", "doi": "10.1234/x", "reference_text": "cite"}],
+    }
+
+
+def test_build_assignment_carries_metabolic_context_when_given():
+    a = _apply._build_assignment("SUBSTRATE", 0.9, "methylotrophs only", [])
+    assert a["metabolic_context"] == "methylotrophs only"
+    assert a["evidence"] == []
+
+
+def test_build_assignment_drops_empty_evidence_dicts():
+    a = _apply._build_assignment("BUFFER", 0.9, None, [{}, {"doi": "10.1/x"}])
+    # Empty {} filtered; the {"doi": ...} kept.
+    assert len(a["evidence"]) == 1
+    assert a["evidence"][0]["doi"] == "10.1/x"
+
+
+# ---------------- _apply_proposal ----------------
+
+
+def _min_proposal_cysteine():
+    return {
+        "ingredient_identifier": "CHEBI:17561",
+        "source_run": "research/ingredients/roles/L-cysteine-edison-literature.md",
+        "role_assignments": {
+            "nutritional_roles": [
+                {"role": "AMINO_ACID_SOURCE", "confidence": 0.95,
+                 "evidence": [{"reference_type": "PEER_REVIEWED_PUBLICATION",
+                               "doi": "10.1128/jb.00456-20", "reference_text": "Smith 2020"}]},
+                {"role": "SULFUR_SOURCE", "confidence": 0.9, "evidence": []},
+            ],
+            "physicochemical_roles": [
+                {"role": "REDUCING_AGENT", "confidence": 0.85,
+                 "evidence": [{"pmid": "12345678"}]},
+            ],
+            "cellular_metabolic_roles": [
+                {"role": "SUBSTRATE", "confidence": 0.9,
+                 "metabolic_context": "assimilatory sulfate reduction",
+                 "evidence": []},
+            ],
+        },
+    }
+
+
+def test_apply_proposal_writes_all_three_facets():
+    record = {"identifier": "CHEBI:17561", "preferred_term": "L-cysteine"}
+    applied, reasons, dirty = _apply._apply_proposal(
+        record, _min_proposal_cysteine(), "edison-deep-research", dry_run=False,
+    )
+    assert applied == 4  # 2 nut + 1 phys + 1 cell-met
+    assert reasons == []
+    assert dirty is True
+
+    assert len(record["nutritional_roles"]) == 2
+    assert record["nutritional_roles"][0]["role"] == "AMINO_ACID_SOURCE"
+    assert record["nutritional_roles"][0]["evidence"][0]["doi"] == "10.1128/jb.00456-20"
+    # SULFUR_SOURCE had empty evidence → fabricated COMPUTATIONAL_PREDICTION citation.
+    sulfur = record["nutritional_roles"][1]
+    assert sulfur["role"] == "SULFUR_SOURCE"
+    assert sulfur["evidence"][0]["reference_type"] == "COMPUTATIONAL_PREDICTION"
+    assert "L-cysteine-edison-literature.md" in sulfur["evidence"][0]["reference_text"]
+
+    assert len(record["physicochemical_roles"]) == 1
+    assert record["physicochemical_roles"][0]["role"] == "REDUCING_AGENT"
+    assert record["physicochemical_roles"][0]["evidence"][0]["pmid"] == "12345678"
+    # Schema-legal: metabolic_context is NOT on physicochemical roles.
+    assert "metabolic_context" not in record["physicochemical_roles"][0]
+
+    assert len(record["cellular_metabolic_roles"]) == 1
+    cell_met = record["cellular_metabolic_roles"][0]
+    assert cell_met["role"] == "SUBSTRATE"
+    assert cell_met["metabolic_context"] == "assimilatory sulfate reduction"
+
+    # Curation-history event appended, listing exactly the fields touched.
+    history = record["curation_history"]
+    assert len(history) == 1
+    assert history[0]["curator"] == "edison-deep-research"
+    assert history[0]["action"] == "ANNOTATED"
+    for slot in ("nutritional_roles", "physicochemical_roles", "cellular_metabolic_roles"):
+        assert slot in history[0]["changes"]
+
+
+def test_apply_proposal_drops_illegal_metabolic_context_on_non_cellular_facet():
+    """metabolic_context on a physicochemical role must be silently dropped, not raise."""
+    record = {"identifier": "CHEBI:17561"}
+    proposal = {
+        "role_assignments": {
+            "physicochemical_roles": [
+                {"role": "BUFFER", "confidence": 0.9,
+                 "metabolic_context": "nope, not schema-legal here"},  # should be dropped
+            ],
+        },
+    }
+    applied, reasons, dirty = _apply._apply_proposal(record, proposal, "edison-deep-research", dry_run=False)
+    assert applied == 1
+    assert "metabolic_context" not in record["physicochemical_roles"][0]
+
+
+def test_apply_proposal_rejects_wrong_facet_role_name():
+    """A role name that belongs to another facet is skipped with a reason string."""
+    record = {"identifier": "CHEBI:17561"}
+    proposal = {
+        "role_assignments": {
+            # BUFFER is physicochemical, not nutritional.
+            "nutritional_roles": [{"role": "BUFFER", "confidence": 0.9}],
+        },
+    }
+    applied, reasons, dirty = _apply._apply_proposal(record, proposal, "edison-deep-research", dry_run=False)
+    assert applied == 0
+    assert dirty is False
+    assert any("belongs to physicochemical_roles" in r for r in reasons)
+
+
+def test_apply_proposal_never_overwrites_populated_facet():
+    """Facet slots that already carry any entries are skipped for that facet only."""
+    record = {
+        "identifier": "CHEBI:17561",
+        "nutritional_roles": [{"role": "CARBON_SOURCE", "confidence": 1.0}],  # pre-existing
+    }
+    proposal = {
+        "role_assignments": {
+            "nutritional_roles": [{"role": "AMINO_ACID_SOURCE", "confidence": 0.95}],
+            "physicochemical_roles": [{"role": "BUFFER", "confidence": 0.9}],
+        },
+    }
+    applied, reasons, dirty = _apply._apply_proposal(record, proposal, "edison-deep-research", dry_run=False)
+    assert applied == 1  # only the physicochemical
+    assert any("nutritional_roles: already populated" in r for r in reasons)
+    # Pre-existing preserved untouched.
+    assert record["nutritional_roles"] == [{"role": "CARBON_SOURCE", "confidence": 1.0}]
+    # Physicochemical newly added.
+    assert record["physicochemical_roles"][0]["role"] == "BUFFER"
+
+
+def test_apply_proposal_empty_role_assignments_is_noop():
+    record = {"identifier": "CHEBI:17561"}
+    applied, reasons, dirty = _apply._apply_proposal(
+        record, {"role_assignments": {}}, "edison-deep-research", dry_run=False,
+    )
+    assert applied == 0
+    assert reasons == []
+    assert dirty is False
+    assert "curation_history" not in record  # no event on no-op
+
+
+def test_apply_proposal_dry_run_writes_nothing_to_record():
+    record = {"identifier": "CHEBI:17561"}
+    proposal = {
+        "role_assignments": {
+            "nutritional_roles": [{"role": "AMINO_ACID_SOURCE", "confidence": 0.9,
+                                    "evidence": [{"doi": "10.1234/x"}]}],
+        },
+    }
+    applied, _, dirty = _apply._apply_proposal(record, proposal, "edison-deep-research", dry_run=True)
+    assert applied == 1  # still counted
+    assert record.get("nutritional_roles") is None
+    assert "curation_history" not in record
+    assert dirty is False
+
+
+def test_apply_proposal_rejects_non_dict_role_entries():
+    record = {"identifier": "CHEBI:17561"}
+    proposal = {
+        "role_assignments": {
+            "nutritional_roles": ["not-a-dict", None, {"role": "AMINO_ACID_SOURCE", "confidence": 0.9}],
+        },
+    }
+    applied, _, _ = _apply._apply_proposal(record, proposal, "edison-deep-research", dry_run=False)
+    assert applied == 1
+
+
+def test_apply_proposal_role_without_role_field_is_skipped():
+    record = {"identifier": "CHEBI:17561"}
+    proposal = {
+        "role_assignments": {
+            "nutritional_roles": [
+                {"confidence": 0.9, "evidence": []},  # no role field — skip
+                {"role": "AMINO_ACID_SOURCE", "confidence": 0.9},  # ok
+            ],
+        },
+    }
+    applied, _, _ = _apply._apply_proposal(record, proposal, "edison-deep-research", dry_run=False)
+    assert applied == 1
+
+
+# ---------------- resolver ----------------
+
+
+def test_resolve_ingredient_path_uses_explicit_path(monkeypatch, tmp_path):
+    yml = _write_ingredient(tmp_path, "L-cysteine", {"identifier": "CHEBI:17561"})
+    monkeypatch.setattr(_apply, "INGREDIENTS_DIR", tmp_path / "data" / "ingredients")
+    monkeypatch.setattr(_apply, "REPO_ROOT", tmp_path)
+    got = _apply._resolve_ingredient_path({
+        "ingredient_path": str(yml.relative_to(tmp_path)),
+    })
+    assert got == yml
+
+
+def test_resolve_ingredient_path_uses_local_part_of_curie(monkeypatch, tmp_path):
+    yml = _write_ingredient(tmp_path, "17561", {"identifier": "CHEBI:17561"})
+    monkeypatch.setattr(_apply, "INGREDIENTS_DIR", tmp_path / "data" / "ingredients")
+    monkeypatch.setattr(_apply, "REPO_ROOT", tmp_path)
+    got = _apply._resolve_ingredient_path({"ingredient_identifier": "CHEBI:17561"})
+    assert got == yml
+
+
+def test_resolve_ingredient_path_returns_none_on_miss(monkeypatch, tmp_path):
+    (tmp_path / "data" / "ingredients" / "mapped").mkdir(parents=True)
+    monkeypatch.setattr(_apply, "INGREDIENTS_DIR", tmp_path / "data" / "ingredients")
+    monkeypatch.setattr(_apply, "REPO_ROOT", tmp_path)
+    got = _apply._resolve_ingredient_path({"ingredient_identifier": "CHEBI:99999999"})
+    assert got is None
+
+
+# ---------------- CLI end-to-end ----------------
+
+
+def test_main_dry_run_produces_summary(tmp_path, monkeypatch, capsys):
+    """End-to-end CLI dry-run against a tiny synthetic MIM tree."""
+    yml = _write_ingredient(tmp_path, "L-cysteine", {
+        "identifier": "CHEBI:17561", "preferred_term": "L-cysteine",
+        "mapping_status": "MAPPED",
+    })
+    batch = _write_batch(tmp_path, [{
+        "ingredient_identifier": "CHEBI:17561",
+        "ingredient_path": str(yml.relative_to(tmp_path)),
+        "source_run": "research/ingredients/roles/L-cysteine-edison-literature.md",
+        "role_assignments": {
+            "nutritional_roles": [
+                {"role": "AMINO_ACID_SOURCE", "confidence": 0.95,
+                 "evidence": [{"doi": "10.1234/x", "reference_type": "PEER_REVIEWED_PUBLICATION"}]},
+            ],
+        },
+    }])
+    monkeypatch.setattr(_apply, "INGREDIENTS_DIR", tmp_path / "data" / "ingredients")
+    monkeypatch.setattr(_apply, "REPO_ROOT", tmp_path)
+    rc = _apply.main([str(batch), "--dry-run"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Loaded 1 proposals" in out
+    assert "Role assignments applied: 1" in out
+    assert "[dry-run]" in out
+    # File not mutated.
+    assert yaml.safe_load(yml.read_text()) == {
+        "identifier": "CHEBI:17561", "preferred_term": "L-cysteine", "mapping_status": "MAPPED",
+    }
+
+
+def test_main_real_write(tmp_path, monkeypatch, capsys):
+    """Full CLI (not dry-run) writes the facet slots + curation_history back to disk."""
+    yml = _write_ingredient(tmp_path, "L-cysteine", {
+        "identifier": "CHEBI:17561", "preferred_term": "L-cysteine",
+        "mapping_status": "MAPPED",
+    })
+    batch = _write_batch(tmp_path, [{
+        "ingredient_identifier": "CHEBI:17561",
+        "ingredient_path": str(yml.relative_to(tmp_path)),
+        "source_run": "research/ingredients/roles/L-cysteine-edison-literature.md",
+        "role_assignments": {
+            "nutritional_roles": [
+                {"role": "AMINO_ACID_SOURCE", "confidence": 0.95,
+                 "evidence": [{"doi": "10.1234/x", "reference_type": "PEER_REVIEWED_PUBLICATION"}]},
+            ],
+        },
+    }])
+    monkeypatch.setattr(_apply, "INGREDIENTS_DIR", tmp_path / "data" / "ingredients")
+    monkeypatch.setattr(_apply, "REPO_ROOT", tmp_path)
+    rc = _apply.main([str(batch)])
+    assert rc == 0
+
+    round_tripped = yaml.safe_load(yml.read_text())
+    assert round_tripped["nutritional_roles"][0]["role"] == "AMINO_ACID_SOURCE"
+    assert round_tripped["nutritional_roles"][0]["evidence"][0]["doi"] == "10.1234/x"
+    assert round_tripped["curation_history"][0]["curator"] == "edison-deep-research"
+    assert "nutritional_roles" in round_tripped["curation_history"][0]["changes"]
+
+    out = capsys.readouterr().out
+    assert "Ingredient records written: 1" in out

--- a/tests/test_apply_role_research_results.py
+++ b/tests/test_apply_role_research_results.py
@@ -182,6 +182,37 @@ def test_apply_proposal_rejects_wrong_facet_role_name():
     assert any("belongs to physicochemical_roles" in r for r in reasons)
 
 
+def test_apply_proposal_rejects_role_that_is_no_facet_value():
+    """A token that is not a value of ANY facet enum must be skipped, not written.
+
+    facet_slot_for raises for a typo / hallucinated name / retired value
+    (MINERAL, SALT). Writing it would produce a schema-invalid record that only
+    the downstream validator would catch.
+    """
+    record = {"identifier": "CHEBI:1", "preferred_term": "x"}
+    proposal = {
+        "role_assignments": {
+            "nutritional_roles": [{"role": "BOGUS_ROLE", "confidence": 0.9}],
+        },
+    }
+    applied, reasons, dirty = _apply._apply_proposal(record, proposal, "edison-deep-research", dry_run=False)
+    assert applied == 0
+    assert dirty is False
+    assert "nutritional_roles" not in record
+    assert any("not a permissible value" in r for r in reasons)
+
+
+def test_apply_proposal_rejects_retired_mineral_role():
+    """MINERAL was retired in #128 and is not a facet value; it must not be written."""
+    record = {"identifier": "CHEBI:1", "preferred_term": "x"}
+    proposal = {
+        "role_assignments": {"nutritional_roles": [{"role": "MINERAL", "confidence": 0.9}]},
+    }
+    applied, reasons, dirty = _apply._apply_proposal(record, proposal, "edison-deep-research", dry_run=False)
+    assert applied == 0 and dirty is False
+    assert "nutritional_roles" not in record
+
+
 def test_apply_proposal_never_overwrites_populated_facet():
     """Facet slots that already carry any entries are skipped for that facet only."""
     record = {


### PR DESCRIPTION
## Summary

MIM-side applier for the Step 7b literature backfill lane. Consumes the JSON batch that CultureMech's (still-to-land) `extract_roles_from_edison.py` will emit and writes faceted role assignments back to `data/ingredients/**/*.yaml` with full `RoleCitation` evidence.

Companion of the pre-existing `apply_insession_role_curation.py` — same overall shape, different provenance:

| | apply_insession_role_curation.py | **this PR** |
| --- | --- | --- |
| Curator name | `claude_in_session_curation` | `edison-deep-research` |
| Confidence | Fixed 0.6 | Per-role from Edison |
| Reference type | Flat `COMPUTATIONAL_PREDICTION` | Per-evidence (typically `PEER_REVIEWED_PUBLICATION` with DOI) |
| Input | Hardcoded dict in the script | Data-driven JSON batch |

## Key behaviors

- **Per-facet "never overwrite"**: an ingredient whose `nutritional_roles` is populated will not receive new nutritional-role proposals, but is still eligible for the other two facets. Matches PR1's `existing_role_assignments` gap-detection logic.
- **Cross-facet role name check**: `BUFFER` proposed as `nutritional_roles` is skipped (belongs to physicochemical). Uses `facet_slot_for()` from `utils/role_facets.py`.
- **`metabolic_context` schema-safety**: silently dropped when proposed on non-cellular-metabolic slots. Only `CellularMetabolicRoleAssignment` allows it.
- **Missing-primary-citation fallback**: fabricates a `COMPUTATIONAL_PREDICTION` RoleCitation pointing at the source Edison run URL so audit trails always reach the underlying evidence.
- **Direct YAML load/save** rather than `IngredientCurator` — MIM per-ingredient YAMLs are single-record top-level mappings, not `ingredients: []` collections (which is what IngredientCurator expects).

## Files

| File | Change |
| ---- | ------ |
| `scripts/apply_role_research_results.py` **(new, 231 lines)** | CLI + `_load_batch`, `_build_assignment`, `_add_curation_event`, `_apply_proposal`, `_resolve_ingredient_path`, `main`. |
| `tests/test_apply_role_research_results.py` **(new, 19 tests, all pass)** | Batch loader shape checks · `_build_assignment` shape + `metabolic_context` handling · all-three-facets end-to-end · cross-facet role name rejection · never-overwrite · dry-run · illegal-`metabolic_context` drop · CLI end-to-end (dry-run + real write with round-trip). |
| `justfile` | New `apply-role-research-results batch` recipe. |

## Test plan

- [x] `uv run pytest` — 441 passed / 0 failed. (Note: this branch is off origin/main without PR1's +19; PR1 currently in flight as #146.)
- [x] Round-trip test verifies written YAML has `nutritional_roles[0].role`, `evidence[0].doi`, and a `curation_history` event with `curator: edison-deep-research` + `changes: nutritional_roles`.
- [ ] CI green.

## Sequence

- Depends on: nothing landing before it (data-only input). PR1 (#146) is the *producer* of the Edison output that PR4 will *extract into* this PR's input format — but this applier can be exercised today with a hand-crafted JSON batch.
- Blocks: PR6 (real curator run) needs both this PR AND PR4 landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)