### PR TITLE
Extend drift check to mech_shared.yaml; retire schema-pin

### DIFF
--- a/justfile
+++ b/justfile
@@ -138,27 +138,13 @@ report-label-drift:
 # CultureBotAI/CultureMech@<scripts/.vendored_canon_ref>. To propagate a change:
 # PR into that hub → merge → bump .vendored_canon_ref here.
 
-# Durability guard for the shared LinkML module (Discussion + Dataset), vendored
-# byte-identical across the Mech repos — see culturebotai-claw#7. The pinned
-# sha256 is identical in every Mech; fail if this copy drifts.
-SHARED_SCHEMA_MODULE := "src/mediaingredientmech/schema/mech_shared.yaml"
-verify-schema-pin:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    if command -v sha256sum >/dev/null 2>&1; then
-        sha256sum -c src/mediaingredientmech/schema/.mech_shared.sha256
-    else
-        shasum -a 256 -c src/mediaingredientmech/schema/.mech_shared.sha256
-    fi
-
-# Intentional sync only: re-pin after a deliberate, all-repos byte-identical update.
-refresh-schema-pin:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    f={{SHARED_SCHEMA_MODULE}}
-    if command -v sha256sum >/dev/null 2>&1; then h=$(sha256sum "$f" | cut -d' ' -f1); else h=$(shasum -a 256 "$f" | cut -d' ' -f1); fi
-    printf '%s  %s\n' "$h" "$f" > src/mediaingredientmech/schema/.mech_shared.sha256
-    echo "re-pinned $f to $h"
+# NOTE: the shared LinkML module (mech_shared.yaml) is vendored byte-identical
+# across the Mech repos (package-namespaced path per repo). Its self-generated
+# sha256 pin (verify-/refresh-schema-pin) was retired — same self-referential
+# flaw as the id-label pin. It is now covered by the shared-reference drift check
+# (scripts/check_vendored_sync.sh diffs src/*/schema/mech_shared.yaml against the
+# hub's copy at CultureBotAI/CultureMech@<scripts/.vendored_canon_ref>) plus the
+# hub's nightly vendored-fleet-audit.yml.
 
 # Composite QC: schema validation + strict closed-schema check +
 # evidence reference validation + SSSOM invariants.

--- a/scripts/check_vendored_sync.sh
+++ b/scripts/check_vendored_sync.sh
@@ -6,23 +6,31 @@
 # copy from the canonical hub at a pinned commit and diffs. A repo that edits
 # its vendored copy now fails CI, because the reference lives elsewhere.
 #
-# Dependency-free: bash + curl + diff only (no uv/OAK), so it runs as a fast
-# blocking CI job before any heavy setup. The pinned canonical commit lives in
-# scripts/.vendored_canon_ref; the file list is embedded (this script is itself
-# vendored byte-identical across the spokes). Bump .vendored_canon_ref in the
-# same PR that syncs a changed file from the hub — that bump is the deliberate
-# propagation act.
+# The hub is the PUBLIC CultureBotAI/CultureMech (culturebotai-claw is private,
+# so public Mech CI cannot fetch raw content from it). Dependency-free: bash +
+# curl + diff only (no uv/OAK), so it runs as a fast blocking CI job before any
+# heavy setup. The pinned canonical commit lives in scripts/.vendored_canon_ref;
+# the file list is embedded (this script is itself vendored byte-identical across
+# the spokes). Bump .vendored_canon_ref in the same PR that syncs a changed file
+# from the hub — that bump is the deliberate propagation act.
 set -euo pipefail
 
 CANON_REPO="CultureBotAI/CultureMech"
 REF_FILE="scripts/.vendored_canon_ref"
 
+# Same-path vendored files: identical relative path in the hub and here.
 FILES=(
   scripts/validate_id_label_correspondence.py
   scripts/chem_formula.py
   tests/test_id_label_empty_adapter.py
   tests/test_id_label_unknown_prefix.py
   tests/test_id_label_plausibility.py
+)
+
+# Package-namespaced shared files: same bytes, but the local path is namespaced
+# by this repo's package while the hub's is culturemech. Format "local_glob|hub".
+MAPPED=(
+  "src/*/schema/mech_shared.yaml|src/culturemech/schema/mech_shared.yaml"
 )
 
 [ -f "$REF_FILE" ] || { echo "ERROR: $REF_FILE missing (pinned canonical commit)"; exit 2; }
@@ -32,6 +40,7 @@ REF="$(tr -d '[:space:]' < "$REF_FILE")"
 tmp="$(mktemp)"
 trap 'rm -f "$tmp"' EXIT
 fail=0
+checked=0
 for f in "${FILES[@]}"; do
   [ -f "$f" ] || { echo "MISSING: $f not present locally"; fail=1; continue; }
   url="https://raw.githubusercontent.com/${CANON_REPO}/${REF}/${f}"
@@ -42,10 +51,27 @@ for f in "${FILES[@]}"; do
   if ! cmp -s "$tmp" "$f"; then
     echo "DRIFT: $f differs from ${CANON_REPO}@${REF:0:8}"; fail=1
   fi
+  checked=$((checked + 1))
+done
+
+# Path-mapped files: resolve the single local match via glob, diff the hub copy.
+for entry in "${MAPPED[@]}"; do
+  glob="${entry%%|*}"; hubf="${entry#*|}"
+  local=""
+  for cand in $glob; do [ -f "$cand" ] && local="$cand" && break; done
+  if [ -z "$local" ]; then echo "MISSING: no local file matching $glob"; fail=1; continue; fi
+  url="https://raw.githubusercontent.com/${CANON_REPO}/${REF}/${hubf}"
+  if ! curl -fsSL "$url" -o "$tmp"; then
+    echo "ERROR: could not fetch $hubf from ${CANON_REPO}@${REF:0:8} ($url)"; fail=1; continue
+  fi
+  if ! cmp -s "$tmp" "$local"; then
+    echo "DRIFT: $local differs from ${CANON_REPO}@${REF:0:8}:$hubf"; fail=1
+  fi
+  checked=$((checked + 1))
 done
 
 if [ "$fail" -eq 0 ]; then
-  echo "OK: all ${#FILES[@]} vendored files match ${CANON_REPO}@${REF:0:8}"
+  echo "OK: all ${checked} vendored files match ${CANON_REPO}@${REF:0:8}"
 else
   echo ""
   echo "To resolve: copy the canonical files from ${CANON_REPO}@${REF:0:8}, and if the"

--- a/src/mediaingredientmech/schema/.mech_shared.sha256
+++ b/src/mediaingredientmech/schema/.mech_shared.sha256
@@ -1,1 +1,0 @@
-1a5e21eb2ee9f3584ff6af3a6906b1d442e18c41de405b1bf907c20f44eafa2a  src/mediaingredientmech/schema/mech_shared.yaml


### PR DESCRIPTION
Folds the shared LinkML module `mech_shared.yaml` into the shared-reference drift check and retires its self-referential sha256 pin — same fix applied to the id-label set.

## Changes
- **`check_vendored_sync.sh`**: adds a path-mapped entry so the package-namespaced `src/*/schema/mech_shared.yaml` is diffed against the hub's `src/culturemech/schema/mech_shared.yaml`. Now covers **6** files. The pinned ref (`6be694f3`) already carries `mech_shared`, so no `.vendored_canon_ref` bump. Verified locally: `OK: all 6 vendored files match CultureBotAI/CultureMech@6be694f3`.
- Retire `verify-/refresh-schema-pin` + `SHARED_SCHEMA_MODULE`; delete `.mech_shared.sha256`.

Companion PRs: CultureMech #112 (hub audit + pin retirement), CommunityMech + TraitMech (same spoke change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)