### PR TITLE
Make the record exporter filename-stable (#147); enable the plausibility gate

### DIFF
--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -211,7 +211,7 @@ after every run. Re-running the export also recreates
 putting those three records in two states at once — delete those artifacts or fix
 the collection.
 
-## 4. Flip `plausibility_severity: warn` → `error` — DONE (2026-07-30, PR #160)
+## 4. Flip `plausibility_severity: warn` → `error` — DONE (2026-07-30, PR #159)
 
 `conf/id_label_targets.yaml:60` ships `plausibility_severity: warn` with the
 comment "Flip to `error` once the backlog clears -- the same report-then-enforce

--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -22,7 +22,7 @@ Last reconciled: 2026-07-30.
 
 # Pending & actionable
 
-## 1. `sanitize_filename` casing corruption (#147) — IN PROGRESS (2026-07-30)
+## 1. `sanitize_filename` casing corruption (#147) — DONE (2026-07-30, PR #159)
 
 `scripts/export_individual_records.py:155` ends with
 `name = "_".join(part.capitalize() … )`. Python's `str.capitalize()` **lowercases
@@ -87,7 +87,17 @@ anything already committed.
 stay identical" contract with culturebotai-claw's
 `build_mim_ingredient_sssom._mim_curie`. **The stability fix does not touch it** —
 stems stop changing, so the contract is honoured rather than renegotiated.
-Verify with `just curie-validate` and `tests/test_curie_normalizer.py`.
+
+**Shipped 2026-07-30 (PR #159).** `FilenameIndex` + `collect_existing_filenames`
+mirror the `PreservedFields` pattern the same file already uses for
+`discussions`, indexing by identifier *and* preferred_term and dropping ambiguous
+keys rather than guessing. `sanitize_filename` was corrected to the documented
+first-character-only rule for new records. The two already-drifted working-tree
+filenames were restored, which is what made `tests/test_curie_normalizer.py` fail
+locally while passing in CI. Verified: `just export-individual` rewrites all
+2,260 records with **zero renames**; 490 tests pass; `just curie-validate` green.
+9 new tests in `tests/test_export_filename_stability.py` pin the behaviour,
+including idempotency across repeated runs.
 
 **#149 (non-ASCII α escaping) was a duplicate of this, with a wrong diagnosis —
 closed 2026-07-30.** The diagnosis is kept here because the two Greek-alpha
@@ -175,12 +185,33 @@ Also in scope, found during this reconcile:
   Only `data/curated/` is gated by `conf/id_label_targets.yaml`. Decide: delete,
   or move to `ATTIC/`.
 
-The issue's item 1 (~59 per-record files lagging the collection in *content*)
-is **unverified** — confirming it means actually running `just export-individual`,
-which is exactly what #1 makes unsafe today. The exact 1,879/1,879 mapped match
-means it is at worst content drift, not membership drift.
+**The issue's item 1 is now CONFIRMED and is worse than "stale files" — it is a
+data-destroying landmine. Measured 2026-07-30, once PR #159 made a full export
+safe to run.** A `just export-individual` on current `main` reverts **67 files**
+(197 insertions, 472 deletions). The losses are not cosmetic:
 
-## 4. Flip `plausibility_severity: warn` → `error` — IN PROGRESS (2026-07-30)
+| curation action silently reverted | count | curator |
+|---|---|---|
+| `RECLASSIFY_INGREDIENT_TYPE` (`UNDEFINED_MIXTURE` → `DEFINED_MEDIUM`) | 53 | `cbclaw_media_modeling_114` |
+| `FLAGGED_NON_INGREDIENT` | 2 | `cbclaw_followups_114` |
+
+These are exactly PR #116's 53 media reclassifications. They were written to the
+per-record files and **never aggregated back into `data/curated/`**, so the
+collection still says `UNDEFINED_MIXTURE` and the export — which treats the
+collection as the source — undoes all 55 curation events and drops their history
+entries. `promote_resolved_unmapped.py` calls `just export-individual`, so **any
+routine promotion would have silently reverted them.**
+
+Fix direction: aggregate per-record → collection (`just aggregate-collections`)
+*before* the next export, and verify the resulting collection diff contains only
+those 55 events and the 3 orphan deletions above. Until that lands, treat
+`just export-individual` as unsafe on this corpus and check `git diff --stat`
+after every run. Re-running the export also recreates
+`unmapped/{Phytone,Soya_Pepton,Tryptone_Peptone}.yaml` from the stale entries,
+putting those three records in two states at once — delete those artifacts or fix
+the collection.
+
+## 4. Flip `plausibility_severity: warn` → `error` — DONE (2026-07-30, PR #160)
 
 `conf/id_label_targets.yaml:60` ships `plausibility_severity: warn` with the
 comment "Flip to `error` once the backlog clears -- the same report-then-enforce
@@ -189,10 +220,13 @@ via `label_waiver_mode: plausible`) is currently report-only: the validator
 discards `IMPLAUSIBLE_LABEL` from `error_verdicts` when severity is `warn`
 (`scripts/validate_id_label_correspondence.py:745-748`).
 
-**The backlog it was waiting on is already empty.** `just validate-products` on
-2026-07-30 reports **IMPLAUSIBLE_LABEL: 0**. Flipping the value is a one-line
-change that converts a dormant check into a blocking one at zero curation cost —
-do it before the count can drift back up.
+**The backlog it was waiting on was already empty**, so the flip cost nothing.
+`conf/id_label_targets.yaml` now carries `plausibility_severity: error`, and
+`just validate-products` still exits 0 (OK_CANONICAL 5034 / OK_ID_ONLY 1667 /
+OK_EXCEPTION 16 / SKIPPED_NO_ADAPTER 3357, no implausible pairs). An implausible
+id↔label pair is now build-breaking rather than merely reported. Only the
+per-repo config changed — `scripts/validate_id_label_correspondence.py` is
+vendored and drift-checked, so its `severity != "error"` logic was left alone.
 
 ## 5. Run the ingredient-role research pipeline — all tooling merged, never run
 

--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -22,7 +22,7 @@ Last reconciled: 2026-07-30.
 
 # Pending & actionable
 
-## 1. `sanitize_filename` casing corruption (#147) — highest leverage
+## 1. `sanitize_filename` casing corruption (#147) — IN PROGRESS (2026-07-30)
 
 `scripts/export_individual_records.py:155` ends with
 `name = "_".join(part.capitalize() … )`. Python's `str.capitalize()` **lowercases
@@ -40,25 +40,67 @@ would rename 389 files and desync their SSSOM `MIM:` subjects.
 **Why it is first:** it blocks #2 and #3 below (any corpus-wide re-export today
 would bake in the 389 renames) and it closes #149 outright.
 
-Fix options, from the issue: (1) drop the `.capitalize()` lowercasing so the
-function matches the committed corpus and the `MIM:` subject rule, then reconcile
-the corpus once; or (2) centralize the casing rule so MIM's `sanitize_filename`
-and culturebotai-claw's `build_mim_ingredient_sssom._mim_curie` share one
-implementation. **Option 2 touches claw** — `src/mediaingredientmech/curie.py::mim_curie_for_stem`
-carries a stated "must stay identical" contract with it, so coordinate rather
-than changing the rule unilaterally. Verify after with `just curie-validate` and
-`tests/test_curie_normalizer.py`.
+**⚠ The issue's proposed fix does not work — measured 2026-07-30.** Option 1
+("drop the `.capitalize()` lowercasing so the function matches the committed
+corpus") rests on the assumption that the corpus follows one case-preserving
+rule. It does not: **the corpus is a historical mix of two rules**, so no single
+naming function reproduces it. Simulated over all 2,252 tracked per-record files,
+comparing each candidate against the filename **git tracks** (not the drifted
+on-disk name):
 
-**#149 (non-ASCII α escaping) is a duplicate of this, with a wrong diagnosis.**
+| rule | exact | + `_N` collision suffix | mismatch |
+|---|---|---|---|
+| current — `part.capitalize()` per part | 1859 | 6 | **387** |
+| uppercase first char of each part, preserve rest | 1854 | 3 | **395** |
+| uppercase first char only (the docstring's rule) | 1124 | 3 | 1125 |
+| no case transformation at all | 1079 | 0 | 1173 |
+
+The two leading rules fail on **disjoint** sets. Today's rule mismatches files
+that preserve inner capitals (`1-Kestose`, `14-B-D-Galactobiose`); the
+case-preserving rule mismatches files that were *created by* today's rule and
+carry a lowercased tail (`112-trichloroethane`, `2-mercaptoethanol`). Switching
+to case-preserving would rename **more** files (395) than leaving the bug in
+place (387). Note the function's own docstring is already inconsistent with its
+code — it promises `"NaCl (99%)" -> "NaCl_99"` and `"sodium chloride" ->
+"Sodium_chloride"`, neither of which `capitalize()` produces.
+
+**The fix that actually works: make the exporter filename-stable.**
+`export_collection_to_individual_files` deletes every `*.yaml` in the output
+directory and rewrites from the collection, so the filename is re-derived from
+`preferred_term` on every run — that re-derivation is the whole bug. The file
+already solves this exact class of problem for `discussions` via
+`PreservedFields`, which indexes by identifier *and* by preferred_term because
+neither key survives every move. Apply the same pattern to filenames: capture
+each record's existing filename before the clear, reuse it on rewrite, and fall
+back to `sanitize_filename` only for genuinely new records. That renames nothing,
+keeps every published `MIM:` subject valid, and removes the silent-corruption
+mode outright.
+
+Second, smaller change: `capitalize()` also corrupts chemical casing on *new*
+records — `TAPSO` → `Tapso`, `KI` → `Ki`, `MnCl2` → `Mncl2`, and the corpus
+carries the scars (`Feso43_X_N_H2o`, `Na2moo7_X_2_H2o`, `K2hpo4`). With stability
+in place this only affects newly-added records, so the rule can safely be
+corrected to the documented first-character-only behaviour without touching
+anything already committed.
+
+`src/mediaingredientmech/curie.py::mim_curie_for_stem` carries a stated "must
+stay identical" contract with culturebotai-claw's
+`build_mim_ingredient_sssom._mim_curie`. **The stability fix does not touch it** —
+stems stop changing, so the contract is honoured rather than renegotiated.
+Verify with `just curie-validate` and `tests/test_curie_normalizer.py`.
+
+**#149 (non-ASCII α escaping) was a duplicate of this, with a wrong diagnosis —
+closed 2026-07-30.** The diagnosis is kept here because the two Greek-alpha
+records are a *symptom* of #147 and stay broken until the casing is restored.
 Verified 2026-07-30: `mim_curie_for_stem("Α1-Acid_Glycoprotein_From_Bovine_Plasma")`
 returns `MIM:~3911-Acid_Glycoprotein_From_Bovine_Plasma`, exactly the published
 SSSOM subject — the escaping round-trips fine. The character is U+0391 *capital*
 Greek Alpha (`CE 91` → `~391`), not the lowercase α the issue body claims, and
 `format(945, '02X')` = `'3B1'` (the `02` is a minimum width, nothing truncates).
 The single unresolvable subject is just the working-tree file having been
-lowercased by #147, and it disappears when the casing is restored. **Close #149
-as a duplicate**, or retitle it to cover the two Greek-alpha records (it never
-mentions the second one).
+lowercased by #147, and it disappears when the casing is restored. Note that
+#149 only ever mentioned one of the two Greek-alpha records; fixing #147 covers
+both.
 
 ## 2. Duplicate identifier primary keys — 61 collisions across 86 records (NEW)
 
@@ -138,7 +180,7 @@ is **unverified** — confirming it means actually running `just export-individu
 which is exactly what #1 makes unsafe today. The exact 1,879/1,879 mapped match
 means it is at worst content drift, not membership drift.
 
-## 4. Flip `plausibility_severity: warn` → `error` — ready, zero-cost
+## 4. Flip `plausibility_severity: warn` → `error` — IN PROGRESS (2026-07-30)
 
 `conf/id_label_targets.yaml:60` ships `plausibility_severity: warn` with the
 comment "Flip to `error` once the backlog clears -- the same report-then-enforce
@@ -179,6 +221,15 @@ assignments are `COMPUTATIONAL_PREDICTION` (698) or `DATABASE_ENTRY` (283):
 was built to supply, and `cellular_metabolic_roles` is the facet it should fill.
 
 Order of operations (per the CultureMech skill's documented merge order):
+
+**Both lanes are driven from CultureMech, not from here** (confirmed 2026-07-30:
+`scripts/backfill_ingredient_roles.py` and `scripts/audit_missing_roles.py` are
+CultureMech files, added by its #95 and present on its `origin/main`; MIM only
+supplies the Edison shim, the research template, and the applier). Schedule the
+run there. Note the local CultureMech checkout is on `validate-media-recipes`,
+61 commits ahead of its origin, and those two scripts are missing from its
+working tree despite being at `HEAD` — sort that checkout out before running
+anything.
 
 1. **Mechanistic lane first** — CultureMech's `backfill_ingredient_roles.py`
    (#95) derives facets from CHEBI `has_role` via OAK. It is dry-run-only and its
@@ -296,10 +347,6 @@ Nine items shipped in #108/#109/#111; three remain, all confirmed present:
   Re-run any time with `python scripts/enrich_chemical_properties.py`
   (idempotent), then `just export-individual`. Gotcha still live: OLS4 needs
   **double** URL-encoding of ChEBI IRIs.
-- **Prune 3 stale git worktrees** — `git worktree list` shows `mim-step7b-pr1`,
-  `…-pr2`, `…-pr6` under a CultureMech scratchpad path, all marked prunable, all
-  with their `.git` links gone. Checked 2026-07-30: no uncommitted work in any of
-  them (`research/` and `reports/role_research_batches/` are empty). `git worktree prune`.
 - **`dashboard/` was last generated 2026-07-19**, before the role-facet work
   landed. Re-run `just gen-qc-dashboard` after item 5.
 
@@ -452,8 +499,8 @@ Drift is now caught by `scripts/check_vendored_sync.sh` (dependency-free: bash +
 curl + diff, byte-exact `cmp`), run by the **`vendored-sync`** job in
 `.github/workflows/label-correspondence.yaml`. It covers **6 files** against
 `CultureBotAI/CultureMech@<scripts/.vendored_canon_ref>` — currently
-`6be694f3` — with CultureMech as the hub because culturebotai-claw is private and
-public CI cannot fetch raw from it:
+`6be694f3` — with the public `CultureMech` as the hub because the Mechs' CI is
+itself public and cannot fetch raw content from private culturebotai-claw:
 
 `scripts/validate_id_label_correspondence.py` · `scripts/chem_formula.py` ·
 `tests/test_id_label_empty_adapter.py` · `tests/test_id_label_unknown_prefix.py` ·
@@ -465,6 +512,18 @@ byte-exact into this repo → bump `scripts/.vendored_canon_ref` to the new hub
 commit **in the same PR**. The ref bump is the deliberate propagation act. The
 hub's nightly `vendored-fleet-audit.yml` is the backstop.
 
+**Settled topology — do not re-propose moving the canon into claw.** CultureMech
+is the hub by design, not as a fallback for a private claw: claw's
+`shared/idlabel/` is a passive *mirror* of it (claw #19). Making claw canonical
+was tried and abandoned — claw #21 enforced it (merged 2026-07-22) and claw #22
+reverted it (2026-07-25) as off-model for claw-as-mirror. claw is still private,
+but that is **not** a live blocker on anything, since the plan it blocked no
+longer exists. Two directions are covered: spokes == hub by CultureMech's
+`scripts/audit_vendored_fleet.sh` (nightly `vendored-fleet-audit.yml`), and
+mirror == hub by claw's `matches-hub` job in `id-label-canon.yaml`, which claw
+#24 (merged 2026-07-25, closes claw #23) put on a nightly schedule — it
+previously fired only on claw-side changes, so it could never see the hub move.
+
 **Known gap worth a follow-up:** `scripts/chem_formula.py`,
 `scripts/check_vendored_sync.sh`, `scripts/.vendored_canon_ref` and the
 `tests/test_id_label_*.py` files are **not** in the workflow's `trigger_paths`,
@@ -473,7 +532,11 @@ stays unpinned **by design** — it is intentionally per-repo (different adapter
 targets, exceptions), not a drift risk.
 
 Cross-repo companion status for #157 (CultureMech #112 plus the CommunityMech and
-TraitMech spokes) is not verifiable from this repo — confirm from the hub.
+TraitMech spokes), confirmed from the hub on 2026-07-30: all three spokes — MIM,
+CommunityMech, TraitMech — pin the same `scripts/.vendored_canon_ref`
+(`6be694f3d6308ac0f4c2e0dcf196e2ff73f6468f`) against `CultureBotAI/CultureMech`;
+CultureMech itself carries no ref because it *is* the hub. CultureMech's
+`vendored-fleet-audit` has run green nightly through 2026-07-30.
 
 ## Adopt DisMech knowledge-gaps + datasets + QC dashboard (claw#7) — LANDED
 

--- a/conf/id_label_targets.yaml
+++ b/conf/id_label_targets.yaml
@@ -54,10 +54,12 @@ ignored_prefixes:
 
 synonym_scope: exact_related
 
-# Severity of IMPLAUSIBLE_LABEL (from `label_waiver_mode: plausible`). Ships as
-# `warn`: findings land in the report, build stays green. Flip to `error` once
-# the backlog clears -- the same report-then-enforce rollout the base gate used.
-plausibility_severity: warn
+# Severity of IMPLAUSIBLE_LABEL (from `label_waiver_mode: plausible`). Shipped as
+# `warn` for the report-then-enforce rollout the base gate used; flipped to
+# `error` on 2026-07-30 once that backlog reached zero (OK_CANONICAL 5034 /
+# OK_ID_ONLY 1667 / OK_EXCEPTION 16 / IMPLAUSIBLE_LABEL 0). An implausible
+# id<->label pair now fails `just validate-products` instead of only reporting.
+plausibility_severity: error
 
 # Numeric accession ceiling per ontology. An id that does NOT resolve AND sits
 # above the ceiling is a foreign identifier wearing an OBO prefix (a PubChem CID

--- a/scripts/export_individual_records.py
+++ b/scripts/export_individual_records.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import re
 import sys
-from collections import Counter
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -116,6 +115,73 @@ def collect_preserved_fields(ingredients_root: Path) -> PreservedFields:
     return result
 
 
+@dataclass
+class FilenameIndex:
+    """Existing per-record filename stems, so an export never renames a record.
+
+    The filename is otherwise re-derived from `preferred_term` on every run, which
+    makes the naming rule retroactive: any change to `sanitize_filename` silently
+    renames the whole corpus, and every `MIM:<stem>` SSSOM subject derived from a
+    filename goes with it. The committed corpus was in fact written by more than
+    one historical rule, so no single rule reproduces it — reusing the name a
+    record already has is the only stable answer.
+
+    Indexed by both keys for the same reason as `PreservedFields`: `identifier`
+    survives a display-name change, `preferred_term` survives an identifier change
+    (promotion UNMAPPED_NNNN->CHEBI:x, demotion, remap).
+    """
+
+    by_identifier: dict[str, str] = field(default_factory=dict)
+    by_preferred_term: dict[str, str] = field(default_factory=dict)
+
+    def for_record(self, record: dict) -> str | None:
+        """The stem this record already uses, or None if it is new."""
+        ident = record.get("identifier")
+        if ident and ident in self.by_identifier:
+            return self.by_identifier[ident]
+        term = record.get("preferred_term")
+        if term and term in self.by_preferred_term:
+            return self.by_preferred_term[term]
+        return None
+
+
+def collect_existing_filenames(ingredients_root: Path) -> FilenameIndex:
+    """Index current filename stems before files are cleared.
+
+    Scans the whole tree (mapped/ and unmapped/) so a record that moves between
+    them keeps its name — a promotion should not also re-slug the file.
+    """
+    result = FilenameIndex()
+    if not ingredients_root.exists():
+        return result
+    term_collisions: set[str] = set()
+    for path in ingredients_root.rglob("*.yaml"):
+        try:
+            record = load_yaml(path)
+        except Exception:
+            continue
+        if not isinstance(record, dict):
+            continue
+        stem = path.stem
+        ident = record.get("identifier")
+        if ident:
+            # A duplicate identifier cannot pick a single name; leave those
+            # records to the term index or to sanitize_filename.
+            if ident in result.by_identifier:
+                result.by_identifier.pop(ident, None)
+                term_collisions.add(f"\0ident\0{ident}")
+            elif f"\0ident\0{ident}" not in term_collisions:
+                result.by_identifier[ident] = stem
+        term = record.get("preferred_term")
+        if term:
+            if term in result.by_preferred_term or term in term_collisions:
+                result.by_preferred_term.pop(term, None)
+                term_collisions.add(term)
+            else:
+                result.by_preferred_term[term] = stem
+    return result
+
+
 def sanitize_filename(preferred_term: str) -> str:
     """Convert preferred term to a safe filename.
 
@@ -150,9 +216,11 @@ def sanitize_filename(preferred_term: str) -> str:
     # "(-)-"/"(R)-" stereodescriptor) so filenames don't start with a dash
     name = name.strip('_-')
 
-    # Title case the first letter of each word
-    parts = name.split('_')
-    name = '_'.join(part.capitalize() if part else '' for part in parts)
+    # Uppercase the leading character only. str.capitalize() would lowercase
+    # everything after it, which destroys chemical casing that carries meaning
+    # here (NaCl, KI, TAPSO, MnCl2 -> Nacl, Ki, Tapso, Mncl2).
+    if name:
+        name = name[0].upper() + name[1:]
 
     # Ensure we have a valid name
     if not name:
@@ -166,6 +234,7 @@ def export_collection_to_individual_files(
     output_dir: Path,
     dry_run: bool = False,
     preserved: PreservedFields | None = None,
+    existing_names: FilenameIndex | None = None,
 ) -> dict[str, int]:
     """Export a collection YAML file to individual ingredient files.
 
@@ -176,12 +245,16 @@ def export_collection_to_individual_files(
         preserved: Per-record-authored fields (from ``collect_preserved_fields``),
             merged into records whose collection copy lacks them. Pass None to
             skip preservation.
+        existing_names: Filename stems already in use (from
+            ``collect_existing_filenames``), so records keep the names they have.
+            Pass None to name every record from scratch.
 
     Returns:
-        Dictionary with statistics: 'total', 'created', 'collisions'.
+        Dictionary with statistics: 'total', 'created', 'collisions', 'renamed'.
     """
     preserved = preserved or PreservedFields()
-    stats = {'total': 0, 'created': 0, 'collisions': 0}
+    existing_names = existing_names or FilenameIndex()
+    stats = {'total': 0, 'created': 0, 'collisions': 0, 'renamed': 0}
 
     # Load collection
     try:
@@ -207,26 +280,40 @@ def export_collection_to_individual_files(
         for stale in output_dir.glob("*.yaml"):
             stale.unlink()
 
-    # Track filename collisions
-    filename_counter = Counter()
+    # Names already claimed in this directory, so a reused name and a freshly
+    # derived one cannot land on the same file.
+    taken: set[str] = set()
 
     for ingredient in ingredients:
         preferred_term = ingredient.get('preferred_term', 'Unknown')
-        identifier = ingredient.get('identifier', 'UNKNOWN')
 
-        # Generate base filename
-        base_filename = sanitize_filename(preferred_term)
-        filename = base_filename
+        # Keep the name this record already has. Re-deriving it from
+        # preferred_term on every run is what makes the naming rule retroactive
+        # and renames the corpus behind git's back on a case-insensitive
+        # filesystem. Only genuinely new records get a name from scratch.
+        stable = existing_names.for_record(ingredient)
+        if stable is not None and stable not in taken:
+            filename = stable
+        else:
+            base_filename = sanitize_filename(preferred_term)
+            filename = base_filename
+            suffix = 1
+            while filename in taken:
+                suffix += 1
+                filename = f"{base_filename}_{suffix}"
+            if suffix > 1:
+                stats['collisions'] += 1
+                console.print(
+                    f"[yellow]Collision detected: {preferred_term} -> {filename}.yaml[/yellow]"
+                )
+            if stable is not None and stable != filename:
+                stats['renamed'] += 1
+                console.print(
+                    f"[yellow]Renamed: {stable}.yaml -> {filename}.yaml "
+                    f"({preferred_term})[/yellow]"
+                )
 
-        # Handle duplicates
-        filename_counter[base_filename] += 1
-        if filename_counter[base_filename] > 1:
-            filename = f"{base_filename}_{filename_counter[base_filename]}"
-            stats['collisions'] += 1
-            console.print(
-                f"[yellow]Collision detected: {preferred_term} -> {filename}.yaml[/yellow]"
-            )
-
+        taken.add(filename)
         output_path = output_dir / f"{filename}.yaml"
 
         # Re-attach per-record-authored fields (e.g. discussions) that the
@@ -313,8 +400,12 @@ def main(input_dir: str | None, output_dir: str | None, dry_run: bool):
             f"({', '.join(PER_RECORD_AUTHORED_FIELDS)}) for {n_preserved} record(s)[/dim]"
         )
 
+    # Index current filenames BEFORE the clear loop, for the same reason and
+    # over the same whole tree.
+    existing_names = collect_existing_filenames(output_dir_path)
+
     # Process each collection
-    total_stats = {'total': 0, 'created': 0, 'collisions': 0}
+    total_stats = {'total': 0, 'created': 0, 'collisions': 0, 'renamed': 0}
 
     with Progress(
         SpinnerColumn(),
@@ -330,11 +421,13 @@ def main(input_dir: str | None, output_dir: str | None, dry_run: bool):
                 output_subdir,
                 dry_run=dry_run,
                 preserved=preserved,
+                existing_names=existing_names,
             )
 
             total_stats['total'] += stats['total']
             total_stats['created'] += stats['created']
             total_stats['collisions'] += stats['collisions']
+            total_stats['renamed'] += stats['renamed']
 
             progress.update(
                 task,
@@ -351,6 +444,9 @@ def main(input_dir: str | None, output_dir: str | None, dry_run: bool):
 
     if total_stats['collisions'] > 0:
         console.print(f"  [yellow]Filename collisions: {total_stats['collisions']}[/yellow]")
+
+    if total_stats['renamed'] > 0:
+        console.print(f"  [yellow]Renamed: {total_stats['renamed']}[/yellow]")
 
     if not dry_run:
         console.print(f"\n[green]Individual files written to: {output_dir_path}[/green]")

--- a/tests/test_export_filename_stability.py
+++ b/tests/test_export_filename_stability.py
@@ -1,0 +1,203 @@
+"""Regression guard: exporting collections must not rename existing records.
+
+The exporter clears the per-record tree and rewrites it from the collection, so
+before this guard the filename was re-derived from `preferred_term` on every run.
+That made the naming rule retroactive: a change to `sanitize_filename` renamed
+the whole corpus, and every `MIM:<stem>` SSSOM subject derived from a filename
+went with it. On a case-insensitive filesystem git reported no change at all, so
+389 of 2,252 records were being silently re-cased on each `just export-individual`
+(issue #147).
+
+The committed corpus was written by more than one historical naming rule, so no
+single rule reproduces it — reusing the name a record already has is the fix.
+These tests pin that, plus the chemical-casing behaviour for genuinely new
+records.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+
+def _load_exporter():
+    spec = importlib.util.spec_from_file_location(
+        "export_individual_records", ROOT / "scripts" / "export_individual_records.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    # Register before exec: a @dataclass under `from __future__ import annotations`
+    # resolves its module via sys.modules during class creation.
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _write_collection(path: Path, records: list[dict]) -> None:
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "generation_date": "2026-07-30T00:00:00+00:00",
+                "total_count": len(records),
+                "ingredients": records,
+            },
+            sort_keys=False,
+        )
+    )
+
+
+def _record(identifier: str, term: str, **extra) -> dict:
+    return {"identifier": identifier, "preferred_term": term, **extra}
+
+
+# --- the naming rule itself -------------------------------------------------
+
+
+def test_sanitize_filename_preserves_chemical_casing():
+    """str.capitalize() turned NaCl into Nacl; formulas carry meaning here."""
+    exp = _load_exporter()
+    assert exp.sanitize_filename("NaCl (99%)") == "NaCl_99"
+    assert exp.sanitize_filename("TAPSO") == "TAPSO"
+    assert exp.sanitize_filename("KI") == "KI"
+    assert exp.sanitize_filename("MnCl2 x 4 H2O") == "MnCl2_x_4_H2O"
+
+
+def test_sanitize_filename_matches_documented_examples():
+    exp = _load_exporter()
+    assert exp.sanitize_filename("sodium chloride") == "Sodium_chloride"
+    assert exp.sanitize_filename("D-glucose") == "D-glucose"
+    assert exp.sanitize_filename("(-)-Epinephrine") == "Epinephrine"
+    assert exp.sanitize_filename("(R)-3-hydroxybutyrate") == "R-3-hydroxybutyrate"
+
+
+def test_sanitize_filename_uppercases_leading_character():
+    exp = _load_exporter()
+    assert exp.sanitize_filename("peptone") == "Peptone"
+
+
+# --- the stability index ----------------------------------------------------
+
+
+def test_index_finds_existing_stem_by_identifier(tmp_path):
+    exp = _load_exporter()
+    root = tmp_path / "ingredients"
+    (root / "mapped").mkdir(parents=True)
+    (root / "mapped" / "Weird_Legacy_Name.yaml").write_text(
+        yaml.safe_dump(_record("CHEBI:1", "Glucose"))
+    )
+
+    index = exp.collect_existing_filenames(root)
+    assert index.for_record(_record("CHEBI:1", "Renamed Display Term")) == "Weird_Legacy_Name"
+
+
+def test_index_finds_existing_stem_by_preferred_term_when_identifier_changed(tmp_path):
+    """Promotion UNMAPPED_NNNN -> CHEBI:x changes the primary key itself."""
+    exp = _load_exporter()
+    root = tmp_path / "ingredients"
+    (root / "unmapped").mkdir(parents=True)
+    (root / "unmapped" / "Some_Compound.yaml").write_text(
+        yaml.safe_dump(_record("UNMAPPED_0001", "Some compound"))
+    )
+
+    index = exp.collect_existing_filenames(root)
+    assert index.for_record(_record("CHEBI:99", "Some compound")) == "Some_Compound"
+
+
+def test_index_drops_ambiguous_keys(tmp_path):
+    """Duplicate identifiers/terms cannot pick one name; fall through instead."""
+    exp = _load_exporter()
+    root = tmp_path / "ingredients"
+    (root / "mapped").mkdir(parents=True)
+    (root / "mapped" / "First.yaml").write_text(yaml.safe_dump(_record("CHEBI:7", "Shared term")))
+    (root / "mapped" / "Second.yaml").write_text(yaml.safe_dump(_record("CHEBI:7", "Shared term")))
+
+    index = exp.collect_existing_filenames(root)
+    assert index.for_record(_record("CHEBI:7", "Shared term")) is None
+
+
+def test_index_is_empty_for_missing_root(tmp_path):
+    exp = _load_exporter()
+    index = exp.collect_existing_filenames(tmp_path / "nope")
+    assert index.for_record(_record("CHEBI:1", "Anything")) is None
+
+
+# --- end-to-end: an export must not rename ----------------------------------
+
+
+def test_export_keeps_existing_filename_even_when_rule_would_differ(tmp_path):
+    """The core #147 guard: a legacy name survives a re-export untouched."""
+    exp = _load_exporter()
+    root = tmp_path / "ingredients"
+    out = root / "mapped"
+    out.mkdir(parents=True)
+    # A name today's rule would never generate from this preferred_term.
+    (out / "14-B-D-Galactobiose.yaml").write_text(
+        yaml.safe_dump(_record("CHEBI:5", "1,4-B-D-Galactobiose"))
+    )
+
+    collection = tmp_path / "mapped_ingredients.yaml"
+    _write_collection(collection, [_record("CHEBI:5", "1,4-B-D-Galactobiose")])
+
+    index = exp.collect_existing_filenames(root)
+    stats = exp.export_collection_to_individual_files(collection, out, existing_names=index)
+
+    assert [p.name for p in sorted(out.glob("*.yaml"))] == ["14-B-D-Galactobiose.yaml"]
+    assert stats["renamed"] == 0
+
+
+def test_export_names_new_records_from_the_rule(tmp_path):
+    exp = _load_exporter()
+    out = tmp_path / "ingredients" / "mapped"
+    out.mkdir(parents=True)
+
+    collection = tmp_path / "mapped_ingredients.yaml"
+    _write_collection(collection, [_record("CHEBI:6", "brand new compound")])
+
+    index = exp.collect_existing_filenames(tmp_path / "ingredients")
+    exp.export_collection_to_individual_files(collection, out, existing_names=index)
+
+    assert (out / "Brand_new_compound.yaml").exists()
+
+
+def test_export_is_idempotent_across_repeated_runs(tmp_path):
+    """Two exports in a row must produce byte-identical filenames."""
+    exp = _load_exporter()
+    root = tmp_path / "ingredients"
+    out = root / "mapped"
+    out.mkdir(parents=True)
+
+    collection = tmp_path / "mapped_ingredients.yaml"
+    _write_collection(
+        collection,
+        [_record("CHEBI:8", "NaCl"), _record("CHEBI:9", "1,4-Butanediol")],
+    )
+
+    for _ in range(3):
+        index = exp.collect_existing_filenames(root)
+        exp.export_collection_to_individual_files(collection, out, existing_names=index)
+        assert sorted(p.name for p in out.glob("*.yaml")) == [
+            "14-Butanediol.yaml",
+            "NaCl.yaml",
+        ]
+
+
+def test_export_still_suffixes_genuine_collisions(tmp_path):
+    exp = _load_exporter()
+    root = tmp_path / "ingredients"
+    out = root / "mapped"
+    out.mkdir(parents=True)
+
+    collection = tmp_path / "mapped_ingredients.yaml"
+    _write_collection(
+        collection,
+        [_record("CHEBI:10", "Same name"), _record("CHEBI:11", "Same name")],
+    )
+
+    index = exp.collect_existing_filenames(root)
+    stats = exp.export_collection_to_individual_files(collection, out, existing_names=index)
+
+    assert sorted(p.name for p in out.glob("*.yaml")) == ["Same_name.yaml", "Same_name_2.yaml"]
+    assert stats["collisions"] == 1


### PR DESCRIPTION
Two backlog items, plus a significant finding the first one exposed.

## 1. `sanitize_filename` casing corruption — closes #147, closes #149

`export_collection_to_individual_files` clears the per-record tree and rewrites it from the collection, so a filename was **re-derived from `preferred_term` on every run**. That made the naming rule retroactive: any change to `sanitize_filename` renamed the whole corpus, and every `MIM:<stem>` SSSOM subject derived from a filename went with it. On macOS's case-insensitive filesystem git reported nothing, so **389 of 2,252 records were being silently re-cased** on each `just export-individual` — and `promote_resolved_unmapped.py` calls that command, so an ordinary promotion triggered it.

### The fix the issue proposes does not work

It assumes the corpus follows one case-preserving rule. It does not. Simulating four candidate rules against the filenames **git tracks** (not the drifted on-disk names):

| rule | exact | + `_N` suffix | mismatch |
|---|---|---|---|
| current — `part.capitalize()` | 1859 | 6 | **387** |
| uppercase first char of each part | 1854 | 3 | **395** |
| uppercase first char only | 1124 | 3 | 1125 |
| no case transformation | 1079 | 0 | 1173 |

The corpus is a **historical mix of two rules** and the leading two fail on *disjoint* sets — today's rule mismatches files preserving inner capitals (`1-Kestose`), the case-preserving rule mismatches files it created with lowercased tails (`112-trichloroethane`). Switching would rename **more** files (395) than leaving the bug alone (387).

### So stop deriving the name at all

`FilenameIndex` + `collect_existing_filenames` mirror the `PreservedFields` pattern this same file already uses for `discussions` — indexed by identifier **and** preferred_term, because neither key survives every move (identifier survives a display-name change; preferred_term survives the promotion/remap that changes the identifier itself). Ambiguous keys are dropped rather than guessed. Only genuinely new records get a name from the rule.

`sanitize_filename` is also corrected for new records: `str.capitalize()` lowercases everything after the first character, destroying chemical casing that carries meaning here (`TAPSO`→`Tapso`, `KI`→`Ki`, `MnCl2`→`Mncl2`; the corpus has the scars — `Feso43_X_N_H2o`, `K2hpo4`). Its docstring already promised the first-character-only behaviour this restores.

Also restores the two working-tree filenames that had already drifted, which is what made `tests/test_curie_normalizer.py` fail locally while passing in CI.

**Verified:** `just export-individual` rewrites all 2,260 records with **zero renames**; 490 tests pass; `just curie-validate` green. 9 new tests pin the behaviour including idempotency across repeated runs.

## 2. Enable the id↔label plausibility gate

`plausibility_severity: warn` → `error`. The report-then-enforce backlog it was waiting on is empty, so this costs nothing — `just validate-products` still exits 0 (OK_CANONICAL 5034 / OK_ID_ONLY 1667 / OK_EXCEPTION 16, no implausible pairs). Only the per-repo config changed; `validate_id_label_correspondence.py` is vendored and drift-checked, so its `severity != "error"` branch was left alone.

## 3. ⚠ What this exposed — #148 item 1 is a data-destroying landmine

With a full export finally safe to run, I measured it. `just export-individual` on `main` **reverts 67 files** (197 insertions, 472 deletions):

| curation action silently reverted | count |
|---|---|
| `RECLASSIFY_INGREDIENT_TYPE` (`UNDEFINED_MIXTURE` → `DEFINED_MEDIUM`) | 53 |
| `FLAGGED_NON_INGREDIENT` | 2 |

Those are exactly **PR #116's 53 media reclassifications**. They were written to the per-record files and never aggregated back into `data/curated/`, so the collection-as-source export undoes all 55 events and drops their history entries. Since `promote_resolved_unmapped.py` calls `export-individual`, any routine promotion would have reverted them silently.

#148 item 1 was logged as unverified; it is now confirmed, and it is not mere staleness. **No data changes are included in this PR** — the fix direction (`just aggregate-collections` before the next export) is recorded in `NEXT_TASKS.md` for #148 to pick up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)