### PR TITLE
Port the append-only curation-history layer from TraitMech

### DIFF
--- a/.github/workflows/curation-history.yaml
+++ b/.github/workflows/curation-history.yaml
@@ -1,0 +1,105 @@
+name: Curation history
+
+# Two-part check, deliberately asymmetric (see history/README.md):
+#
+#   * VALIDITY is blocking. A malformed history record fails like any other
+#     validation error.
+#   * PRESENCE is advisory. If an ingredient record changes without a matching
+#     history record, this warns in the job summary and passes. A hard gate on
+#     provenance blocks legitimate work at inconvenient moments and trains people
+#     to route around it — and MIM's bulk imports touch hundreds of records in a
+#     single commit.
+#
+# Validation uses the VENDORED schema at
+# src/mediaingredientmech/schema/history.yaml, so this job has no dependency on
+# the private culturebotai-claw repo. Only the `just new-history` scaffolder
+# needs claw, and that is a dev-time tool.
+
+on:
+  pull_request:
+    paths: &trigger_paths
+      - "data/ingredients/**"
+      - "data/curated/**"
+      - "data/custom/**"
+      - "mappings/**"
+      - "history/**"
+      - "src/mediaingredientmech/schema/history.yaml"
+      - ".github/workflows/curation-history.yaml"
+  push:
+    branches: [main]
+    paths: *trigger_paths
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: curation-history-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  history:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # need the merge base to diff against
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Validate history records (blocking)
+        run: |
+          set -euo pipefail
+          if [ ! -d history ] || [ -z "$(find history -name '*.yaml' -print -quit)" ]; then
+            echo "No history records to validate."
+            exit 0
+          fi
+          find history -name '*.yaml' -print0 \
+            | xargs -0 uv run linkml-validate \
+                --schema src/mediaingredientmech/schema/history.yaml \
+                --target-class HistoryRecord
+
+      - name: Check for missing history records (advisory)
+        if: github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin "${{ github.base_ref }}"
+          base="origin/${{ github.base_ref }}"
+
+          # Counts mapping artifacts too, not just ingredient YAMLs: a large share
+          # of MIM curation lands in mappings/ rather than in any single record.
+          changed_targets=$(git diff --name-only "$base"...HEAD \
+            -- 'data/ingredients/**/*.yaml' 'data/curated/**/*.yaml' \
+               'data/custom/**/*.yaml' 'mappings/**' | wc -l | tr -d ' ')
+          new_history=$(git diff --name-only --diff-filter=A "$base"...HEAD -- 'history/**/*.yaml' | wc -l | tr -d ' ')
+
+          {
+            echo "## Curation history"
+            echo
+            echo "- curation targets changed: **$changed_targets**"
+            echo "- history records added: **$new_history**"
+            echo
+            if [ "$changed_targets" -gt 0 ] && [ "$new_history" -eq 0 ]; then
+              echo "> [!WARNING]"
+              echo "> This PR changes ingredient records or mappings but adds no"
+              echo "> history record."
+              echo "> Scaffold one with \`just new-history\` — see \`history/README.md\`."
+              echo ">"
+              echo "> Advisory only; this does not block the build."
+            elif [ "$changed_targets" -gt 0 ]; then
+              echo "Provenance recorded for this change."
+            else
+              echo "No curation targets changed; nothing to record."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/curation-history.yaml
+++ b/.github/workflows/curation-history.yaml
@@ -52,8 +52,6 @@ jobs:
         with:
           enable-cache: true
 
-      - name: Set up Python
-        run: uv python install 3.12
 
       - name: Install dependencies
         run: uv sync --frozen

--- a/.github/workflows/curation-history.yaml
+++ b/.github/workflows/curation-history.yaml
@@ -80,8 +80,8 @@ jobs:
           # Counts mapping artifacts too, not just ingredient YAMLs: a large share
           # of MIM curation lands in mappings/ rather than in any single record.
           changed_targets=$(git diff --name-only "$base"...HEAD \
-            -- 'data/ingredients/**/*.yaml' 'data/curated/**/*.yaml' \
-               'data/custom/**/*.yaml' 'mappings/**' | wc -l | tr -d ' ')
+            -- 'data/ingredients/**/*.yaml' 'data/curated/*.yaml' \
+               'data/custom/*.yaml' 'mappings/**' | wc -l | tr -d ' ')
           new_history=$(git diff --name-only --diff-filter=A "$base"...HEAD -- 'history/**/*.yaml' | wc -l | tr -d ' ')
 
           {

--- a/history/README.md
+++ b/history/README.md
@@ -1,0 +1,140 @@
+# Curation history
+
+Append-only provenance for curation sessions. One record per session per target,
+written once and **never edited afterwards**. Corrections go in a new record that
+references the old one in its `details`.
+
+```
+history/<kind-dir>/<slug>/<TIMESTAMP>-<actor>-<shortid>.yaml
+```
+
+## Why this exists
+
+Nothing else in the repo records *which model, using which tool, changed what,
+why, and under which issue*. Git tells you a commit happened; it does not tell
+you that an ontology mapping was checked against OLS4 rather than guessed, that a
+snippet was verified verbatim against a cached abstract, or that a review
+deliberately changed nothing.
+
+MIM has a per-record `curation_history` field, but that is a different thing: it
+lives inside the ingredient YAML, describes the record's own edit trail, and says
+nothing about the session — no model, no harness, no issue link, and no way to
+record work that touched a mapping file, a report, or the schema rather than a
+single ingredient.
+
+That gap matters more as autonomous agents start doing the changing. See
+`culturebotai-claw/docs/AUTONOMOUS_LOOPS.md`.
+
+## Why the layout looks like that
+
+The directory-per-slug plus unguessable `shortid` is the whole design. Two agents
+curating the same ingredient concurrently cannot write the same file, so this
+layer has **no merge-conflict surface**. A single shared changelog would conflict
+on every parallel PR; this never does.
+
+## Writing a record
+
+Do not hand-write the filename or the timestamp — scaffold it:
+
+```bash
+just new-history --kind record --slug Tryptone \
+  --target-root data/ingredients/mapped \
+  --event EDIT --outcome changed \
+  --sections ontology_mapping,evidence \
+  --summary "Re-ground Tryptone to FOODON after CHEBI specificity loss" \
+  --model claude-opus-5 --agent-tool claude-code \
+  --issue https://github.com/CultureBotAI/MediaIngredientMech/issues/119 \
+  --details "What was done, what evidence was used, how it was validated."
+```
+
+`--slug` is the ingredient record's filename stem, so `--kind record` plus
+`--target-root data/ingredients/mapped` resolves to
+`data/ingredients/mapped/Tryptone.yaml`. Unmapped records live under
+`data/ingredients/unmapped`; curated collections under `data/curated`, but those
+are container documents rather than single ingredients, so prefer `--kind mapping`
+or `--kind report` with an explicit `--path` for them.
+
+Omit `--details` and you get a TODO placeholder to edit before committing —
+`just validate-history` **fails** while it is still there, so an unfilled record
+cannot slip through. The command prints the record path as its final stdout line,
+so scripts can capture it.
+
+`--kind record` and `--kind schema` can derive the target path from `--slug` plus
+`--target-root`. Every other kind needs an explicit `--path`, because only those
+two are reliably `.yaml`.
+
+Then validate and stage:
+
+```bash
+just validate-history history/records/Tryptone/<file>.yaml
+git add history/
+```
+
+## The vocabulary
+
+`event`: `CREATE` · `EDIT` · `REVIEW` · `AUDIT` · `GENERAL`
+
+`outcome`: `changed` · `no_change` · `needs_followup` · `blocked`
+
+Outcome is **orthogonal** to event on purpose. A `REVIEW` that found nothing is
+`no_change` — a real result worth recording, because it says something was
+checked. An `EDIT` that hit a wall is `blocked`, and `details` must say what the
+wall was so the next session does not rediscover it.
+
+`kind`: `record` · `schema` · `mapping` · `report` · `infrastructure` · `other`
+(`other` requires an explicit `--path`).
+
+`mapping` is the one that earns its keep here: a large share of MIM's curation
+lands in `mappings/ingredient_mappings.sssom.tsv` rather than in any single
+ingredient file, and that work has no other provenance surface.
+
+## How strictly this is enforced
+
+Deliberately split:
+
+- **Presence is advisory.** CI warns when an ingredient record changes without a
+  matching history record. It does not block. A hard gate on provenance blocks
+  legitimate work at inconvenient moments and trains people to route around it.
+  MIM's bulk-import and re-grounding scripts touch hundreds of records in one
+  commit, and a blocking gate there would be pure friction.
+- **Validity is not.** If you write a record it must be schema-valid, and
+  `just validate-history` fails like any other validation error.
+
+## Where the schema lives
+
+Two copies, on purpose:
+
+- **Canonical**: `culturebotai-claw/shared/history/history.yaml`, with the
+  scaffolder at `culturebotai-claw/src/kg_microbe_history/`.
+- **Vendored here**: `src/mediaingredientmech/schema/history.yaml`, byte-identical.
+
+Check that identity rather than trusting this file — with a claw checkout:
+
+```bash
+diff "${CLAW_SRC:-../culturebotai-claw/src}/../shared/history/history.yaml" \
+     src/mediaingredientmech/schema/history.yaml && echo "in sync"
+```
+
+Do not write the md5 into this README. An earlier draft of the TraitMech copy did
+exactly that, and it went stale one commit later when the schema gained a field
+and the hash was not updated — which is the argument against putting a hash in
+prose at all: nothing recomputes it, so it decays into a confident false negative.
+A runnable command cannot go stale.
+
+The vendored copy exists so validation has **no dependency on claw**, which is
+private — a public repo's CI cannot check it out without a token. `just
+validate-history` and the `curation-history` workflow both use the local copy and
+work with no claw checkout at all.
+
+Only `just new-history` needs claw, via `CLAW_SRC` (default:
+`../culturebotai-claw/src`). That is a dev-time scaffolder, and anyone writing
+curation records has claw checked out.
+
+Changing the schema means changing the canonical copy and re-vendoring here — the
+same hub-and-spoke rule as `mech_shared.yaml`. This copy is **not** on the
+automated drift check and nothing enforces that rule yet. It cannot simply be
+appended to `scripts/check_vendored_sync.sh`: that script diffs against
+`CultureBotAI/CultureMech@<scripts/.vendored_canon_ref>` over tokenless
+`raw.githubusercontent`, and this file's canonical copy lives in claw, which is
+private. Closing that gap needs either a second hub for claw-canonical files or a
+mirror of `history.yaml` into the CultureMech hub.

--- a/history/infrastructure/curation-history/2026-08-01T041536Z-claude-code-1d1c58.yaml
+++ b/history/infrastructure/curation-history/2026-08-01T041536Z-claude-code-1d1c58.yaml
@@ -1,0 +1,44 @@
+history_version: 1
+target:
+  kind: infrastructure
+  path: history/README.md
+  slug: curation-history
+session:
+  id: 2026-08-01T041536Z-claude-code-1d1c58
+  timestamp: '2026-08-01T04:15:36Z'
+  actors:
+  - type: ai_agent
+    name: claude-code
+    model: claude-opus-5
+    agent_tool: claude-code
+events:
+- type: CREATE
+  outcome: changed
+  sections:
+  - justfile
+  - schema
+  - ci
+  - docs
+  summary: Port the append-only curation-history layer from TraitMech into MIM
+  details: 'Ported TraitMech''s history surface into MIM as four artifacts: (1) the history
+    LinkML schema vendored byte-identical from culturebotai-claw/shared/history/history.yaml
+    to src/mediaingredientmech/schema/history.yaml (md5 3742bc2068b637868c48aba406f6569d,
+    verified equal to both the claw canonical copy and TraitMech''s vendored copy); (2) justfile
+    recipes new-history (scaffolder, resolved through CLAW_SRC, exits 1 with a pointer when
+    kg_microbe_history is absent) and validate-history (vendored schema, no claw dependency,
+    exits 2 on empty or nonexistent target); (3) this history/README.md; (4) .github/workflows/curation-history.yaml,
+    where record validity is blocking and record presence is advisory. Also enabled ''set
+    positional-arguments := true'' in the justfile, which new-history needs so multi-word
+    --summary/--details prose survives interpolation as "$@" — verified beforehand that no
+    existing MIM recipe references $1 or $@, so no other recipe changes behaviour. Verified:
+    ''just --list'' parses and goes from 52 to 54 recipes (exactly the two additions, no other
+    diff); scaffolding without --details produces the TODO placeholder and ''just validate-history''
+    fails on it with the schema''s ''^(?!TODO: replace this placeholder)'' pattern; this record
+    validates clean; CLAW_SRC=/nonexistent fails loudly. Not carried over from TraitMech:
+    its README cites issue #191 for the vendored-drift gap, which does not apply here — MIM''s
+    scripts/check_vendored_sync.sh diffs against CultureBotAI/CultureMech@scripts/.vendored_canon_ref
+    over tokenless raw.githubusercontent, and history.yaml''s canonical copy is in claw (private),
+    so the README states that constraint instead of citing a MIM issue number. The advisory
+    presence check also counts mappings/** as a curation target, which TraitMech has no analogue
+    for: much of MIM''s curation lands in mappings/ingredient_mappings.sssom.tsv rather than
+    in a single ingredient YAML.'

--- a/justfile
+++ b/justfile
@@ -3,6 +3,12 @@
 
 set dotenv-load := true
 
+# Pass recipe arguments to bash as "$@", so quoted arguments keep their quoting.
+# Needed by `new-history`, whose --summary/--details are prose; plain `{{args}}`
+# interpolation splits them on whitespace. No existing recipe uses $1/$@, so
+# enabling this changes nothing else.
+set positional-arguments := true
+
 research_dir := "research"
 templates_dir := "templates"
 
@@ -373,3 +379,58 @@ curie-verify-micro:
 [group('QC')]
 curie-validate:
     uv run python -m pytest tests/test_curie_normalizer.py -q --no-cov
+
+# =============================================================================
+# Curation history (append-only provenance)
+# =============================================================================
+# Records which model, using which tool, changed what, why, and under which
+# issue. One file per session per target under history/; never edited after
+# write. See history/README.md. The schema is vendored at
+# src/mediaingredientmech/schema/history.yaml; the scaffolder lives in claw.
+
+# Scaffold a history record. Prints the path as its last stdout line.
+#   just new-history --kind record --slug Tryptone \
+#     --target-root data/ingredients/mapped --event EDIT --outcome changed \
+#     --summary "..." --details "..." --model <model-id>
+new-history *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    claw_src="${CLAW_SRC:-../culturebotai-claw/src}"
+    if [ ! -d "$claw_src/kg_microbe_history" ]; then
+      echo "new-history: kg_microbe_history not found under '$claw_src'." >&2
+      echo "Set CLAW_SRC to the src/ directory of a culturebotai-claw checkout." >&2
+      exit 1
+    fi
+    # "$@" not {{args}} — see `set positional-arguments` at the top of this file.
+    # `uv run python`, not `python3`: bare python3 is whatever the machine puts
+    # first on PATH, which need not be the project venv.
+    PYTHONPATH="$claw_src" uv run python -m kg_microbe_history new "$@"
+
+# Validate one history record, or a directory of them. Uses the VENDORED schema,
+# so this works with no claw checkout — same as CI.
+validate-history target="history":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    target="{{target}}"
+    if [ -z "$target" ]; then
+      echo "validate-history: empty target. Pass a record path or a directory." >&2
+      exit 2
+    fi
+    if [ ! -e "$target" ]; then
+      echo "validate-history: '$target' does not exist." >&2
+      exit 2
+    fi
+    if [ -d "$target" ]; then
+      if [ -z "$(find "$target" -name '*.yaml' -print -quit)" ]; then
+        echo "No history records under '$target'."
+        exit 0
+      fi
+      find "$target" -name '*.yaml' -print0 \
+        | xargs -0 uv run linkml-validate \
+            --schema src/mediaingredientmech/schema/history.yaml \
+            --target-class HistoryRecord
+    else
+      uv run linkml-validate \
+        --schema src/mediaingredientmech/schema/history.yaml \
+        --target-class HistoryRecord "$target"
+    fi

--- a/src/mediaingredientmech/schema/history.yaml
+++ b/src/mediaingredientmech/schema/history.yaml
@@ -1,0 +1,265 @@
+id: https://w3id.org/kg-microbe/history
+name: mech_history
+title: Mech curation-history module — append-only provenance records
+description: >-
+  Append-only provenance for curation sessions across the Mech knowledge bases
+  (CultureMech / MIM / CommunityMech / TraitMech). Ported from
+  monarch-initiative/dismech's `history/` layer.
+
+  One record per session per target, written once and never edited. Records live
+  at `history/<kind-dir>/<slug>/<TIMESTAMP>-<actor>-<shortid>.yaml`. The
+  directory-per-slug layout with an unguessable `shortid` is the whole point:
+  concurrent agents curating the same record never write the same file, so the
+  layer has ZERO merge-conflict surface. Compare a single shared CHANGELOG,
+  which conflicts on every parallel PR.
+
+  This answers a question nothing else in the fleet can: which model, using which
+  tool, changed what, why, and under which issue. That matters more as autonomous
+  agents start doing the changing — see culturebotai-claw docs/AUTONOMOUS_LOOPS.md.
+
+  ENFORCEMENT IS DELIBERATELY SPLIT. Presence of a record is *advisory* — CI
+  warns, it does not block, because a hard gate on provenance blocks legitimate
+  work at inconvenient moments and trains people to route around it. But if a
+  record IS written it must be schema-valid, and that check is hard.
+
+  Do not hand-write records or filenames. Scaffold with `just new-history`, which
+  guarantees a schema-valid skeleton and a collision-free name, then edit the
+  `details` field.
+
+license: BSD-3-Clause
+default_range: string
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+  mech_history: https://w3id.org/kg-microbe/history/
+
+default_prefix: mech_history
+
+imports:
+  - linkml:types
+
+# ============================== Enums ==============================
+
+enums:
+
+  HistoryTargetKindEnum:
+    description: >-
+      What kind of thing the session acted on. Repo-agnostic: each Mech maps its
+      own record type onto one of these, and `other` exists so a repo never has
+      to invent an enum value to record real work.
+    permissible_values:
+      record:
+        description: >-
+          A knowledge-base record — a CultureMech media recipe, a MIM ingredient,
+          a CommunityMech community, a TraitMech trait.
+      schema:
+        description: A LinkML schema or schema module.
+      mapping:
+        description: A mapping artifact such as an SSSOM file or a grounding table.
+      report:
+        description: A generated report, audit, dashboard, or ranking artifact.
+      infrastructure:
+        description: >-
+          Tooling, CI, justfile recipes, skills — changes to how the repo works
+          rather than to what it knows.
+      other:
+        description: >-
+          Anything not covered above. Requires an explicit path when scaffolding,
+          since the target cannot be derived from a slug.
+
+  HistoryActorTypeEnum:
+    description: Who or what performed the session.
+    permissible_values:
+      human:
+        description: A person working directly.
+      ai_agent:
+        description: >-
+          An LLM-driven agent, whether human-supervised or autonomous. Record the
+          model and the harness in `model` / `agent_tool`.
+      automation:
+        description: >-
+          A deterministic script or scheduled job with no model in the loop —
+          a cron scan, a regeneration step.
+      other:
+        description: Anything else.
+
+  HistoryEventTypeEnum:
+    description: >-
+      What the session did. Kept deliberately small; reach for `outcome` rather
+      than inventing a new type for "tried and failed".
+    permissible_values:
+      GENERAL:
+        description: Unclassified or legacy. Prefer a specific type.
+      CREATE:
+        description: Created a target that did not previously exist.
+      EDIT:
+        description: Modified an existing target.
+      REVIEW:
+        description: >-
+          Reviewed a target. May or may not have produced edits — say which via
+          `outcome`.
+      AUDIT:
+        description: >-
+          Structured inspection, compliance check, or triage across one or many
+          targets.
+
+  HistoryOutcomeEnum:
+    description: >-
+      What actually happened. Orthogonal to event type on purpose: it lets you
+      record a REVIEW that changed nothing (`no_change`) or an EDIT that got
+      stuck (`blocked`) without multiplying event types.
+    permissible_values:
+      changed:
+        description: The target was modified.
+      no_change:
+        description: >-
+          The session ran to completion and deliberately changed nothing. This is
+          a real result, not a non-event — it records that something was checked.
+      needs_followup:
+        description: Partial progress; specific remaining work is named in `details`.
+      blocked:
+        description: >-
+          Could not proceed. `details` must say what blocked it, so the next
+          session does not rediscover the same wall.
+
+# ============================== Classes ==============================
+
+classes:
+
+  HistoryRecord:
+    tree_root: true
+    description: >-
+      One curation session against one target. Append-only: write it once, never
+      edit it. Corrections go in a new record that references the old one in its
+      `details`.
+    attributes:
+      history_version:
+        description: Schema version of this record. Currently always 1.
+        range: integer
+        required: true
+        ifabsent: int(1)
+      target:
+        range: HistoryTarget
+        required: true
+      session:
+        range: HistorySession
+        required: true
+      links:
+        range: HistoryLinks
+        required: false
+      events:
+        description: >-
+          What happened, in order. At least one — a record with no events carries
+          no information.
+        range: HistoryEvent
+        required: true
+        multivalued: true
+        minimum_cardinality: 1
+        inlined_as_list: true
+
+  HistoryTarget:
+    description: What the session acted on.
+    attributes:
+      kind:
+        range: HistoryTargetKindEnum
+        required: true
+      slug:
+        description: >-
+          Stable identifier for the target within its kind — usually the record
+          filename stem. Also the directory name under `history/<kind-dir>/`.
+        required: false
+      path:
+        description: Repo-relative path to the target.
+        required: true
+
+  HistorySession:
+    description: When the session ran and who ran it.
+    attributes:
+      id:
+        description: >-
+          Stable session identifier. Always equals the record's filename stem, so
+          a record can be located from its id alone.
+        required: true
+      timestamp:
+        description: ISO-8601 UTC start time.
+        required: true
+        pattern: '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+\-]\d{2}:\d{2})$'
+      actors:
+        description: >-
+          Everyone involved. A list even when there is one actor, because
+          human-plus-agent sessions are the common case and retrofitting a list
+          later would break every existing record.
+        range: HistoryActor
+        required: true
+        multivalued: true
+        minimum_cardinality: 1
+        inlined_as_list: true
+
+  HistoryActor:
+    description: A participant in the session.
+    attributes:
+      type:
+        range: HistoryActorTypeEnum
+        required: true
+      name:
+        description: >-
+          Identifier for the actor — a GitHub login for a human, a harness name
+          such as `claude-code` or `codex` for an agent.
+        required: true
+      model:
+        description: >-
+          Model identifier when the actor is an AI agent, e.g. `claude-opus-5`.
+          This is the field that makes the layer worth having; fill it in.
+        required: false
+      agent_tool:
+        description: Harness that ran the model, e.g. `claude-code`, `codex`.
+        required: false
+      agent_version:
+        description: Version of the harness, when known.
+        required: false
+
+  HistoryLinks:
+    description: Pointers to related discussion. All optional.
+    attributes:
+      issues:
+        range: uri
+        multivalued: true
+      prs:
+        range: uri
+        multivalued: true
+      urls:
+        range: uri
+        multivalued: true
+
+  HistoryEvent:
+    description: One thing the session did.
+    attributes:
+      type:
+        range: HistoryEventTypeEnum
+        required: true
+      outcome:
+        range: HistoryOutcomeEnum
+        required: true
+      sections:
+        description: >-
+          Which parts of the target were touched, in the target's own vocabulary
+          (e.g. `composition`, `causal_graphs`, `ontology_mapping`).
+        multivalued: true
+        required: false
+      summary:
+        description: One short line. Shows up in listings; keep it scannable.
+        required: true
+      details:
+        description: >-
+          The substance, and the reason this layer exists. Required, because a
+          record without it is just a timestamp. Write what a colleague picking
+          this up cold would need: what was done, what evidence or provider was
+          used, how it was validated, and anything deliberately left undone.
+
+          The pattern rejects the scaffolder's TODO placeholder. That check lives
+          in the schema rather than only in the CLI so that a repo validating with
+          plain `linkml-validate` against its vendored copy — which is how the
+          spokes do it, to avoid depending on this private repo — catches an
+          unfilled record too.
+        required: true
+        pattern: '^(?!TODO: replace this placeholder)'


### PR DESCRIPTION
Ports TraitMech's curation-history surface into MIM. Four artifacts, no behaviour change to anything that existed.

## What lands

- **`src/mediaingredientmech/schema/history.yaml`** — the history LinkML schema, vendored **byte-identical** from `culturebotai-claw/shared/history/history.yaml`. Verified: all three copies (claw canonical, TraitMech vendored, this one) are md5 `3742bc2068b637868c48aba406f6569d`. Vendored on purpose — claw is private, so a public repo's CI cannot check it out without a token. `just validate-history` and the new workflow use only the local copy.
- **`just new-history`** — scaffolds a record. Resolves the scaffolder through `CLAW_SRC` (default `../culturebotai-claw/src`) and **fails loudly** when it is missing; no skip path.
- **`just validate-history [target]`** — validates one record or a directory against the vendored schema. Exits 2 on an empty or nonexistent target.
- **`history/README.md`**
- **`.github/workflows/curation-history.yaml`** — deliberately asymmetric: record **validity is blocking**, record **presence is advisory** (warns in the job summary, does not fail the build).

## `set positional-arguments := true`

`new-history` needs it so multi-word `--summary` / `--details` prose survives as `"$@"` instead of being split on whitespace by `{{args}}` interpolation. Checked first: **no existing MIM recipe references `$1` or `$@`**, so enabling it changes nothing else. Smoke-tested an existing `*args` recipe (`just fetch-pubmed --help`) — the argument still interpolates correctly.

## Adaptations from TraitMech

- Paths point at MIM's real data directories (`data/ingredients/{mapped,unmapped}`, `data/curated`, `data/custom`) rather than `data/traits/**`.
- The advisory presence check also counts **`mappings/**`** as a curation target. TraitMech has no analogue; a large share of MIM curation lands in `mappings/ingredient_mappings.sssom.tsv` rather than in any single ingredient YAML.
- TraitMech's README cites its issue #191 for the vendored-drift gap. That number is not meaningful here, so the README states the underlying constraint instead: `scripts/check_vendored_sync.sh` diffs against `CultureBotAI/CultureMech@<scripts/.vendored_canon_ref>` over tokenless `raw.githubusercontent`, and this file's canonical copy lives in claw (private) — so closing the gap needs either a second hub for claw-canonical files or a mirror of `history.yaml` into the CultureMech hub.
- The README also notes how this differs from MIM's existing in-record `curation_history` field, which has no model / harness / issue / session dimension and cannot describe work that touched a mapping, report, or schema.

## Verified locally

| check | result |
|---|---|
| `just --list` parses; recipe count | 52 → 54, diff is exactly the two new recipes |
| scaffold + `just validate-history <record>` | `No issues found`, exit 0 |
| scaffold **without** `--details`, then validate | fails on `'^(?!TODO: replace this placeholder)'`, exit 1 |
| `CLAW_SRC=/nonexistent just new-history …` | exit 1 with a pointer to set `CLAW_SRC` |
| `just validate-history ""` | exit 2 |
| `just validate-history history/nope.yaml` | exit 2 |
| workflow YAML parses, `&trigger_paths` anchor resolves | yes |

The one committed history record describes this port and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)