### PR TITLE
Run vendored-sync on every PR instead of almost never

### DIFF
--- a/.github/workflows/label-correspondence.yaml
+++ b/.github/workflows/label-correspondence.yaml
@@ -32,18 +32,16 @@ on:
 permissions:
   contents: read
 
-jobs:
-  vendored-sync:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      # Shared-reference drift check against the canonical hub (CultureMech) at
-      # the pinned commit in scripts/.vendored_canon_ref — the reference lives in
-      # another repo, so a local edit to a vendored copy fails CI. Fast and
-      # dependency-free (bash + curl), blocks before any uv/OAK setup.
-      - name: Verify vendored files match canonical hub
-        run: bash scripts/check_vendored_sync.sh
+# The vendored-sync job used to live here and inherited the `paths:` filter
+# above, which is scoped to this workflow's expensive OAK-backed gate. That
+# filter listed only 2 of the 6 files the drift checker compares, so the guard
+# almost never fired (CultureBotAI/TraitMech#198). It now has its own workflow —
+# .github/workflows/vendored-sync.yaml — with no paths filter, because it is
+# bash + curl and there is nothing to save by filtering it. The filter above is
+# correct for THIS job, which needs uv + a cached OAK ontology download.
 
+
+jobs:
   id-label-gate:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/vendored-sync.yaml
+++ b/.github/workflows/vendored-sync.yaml
@@ -1,0 +1,74 @@
+name: vendored-sync
+
+# Cross-repo durability guard. Several files here are vendored byte-identical
+# from the canonical hub (CultureBotAI/CultureMech) at the commit pinned in
+# scripts/.vendored_canon_ref; scripts/check_vendored_sync.sh fetches each one
+# and diffs it, so a one-copy edit fails CI.
+#
+# DELIBERATELY NO `paths:` FILTER. This job used to live in
+# label-correspondence.yaml and inherited that workflow's filter, which listed
+# only 2 of the 6 files the checker compares. Editing scripts/chem_formula.py or
+# any tests/test_id_label_*.py never fired the guard, and neither did editing
+# the checker itself or the pinned ref (CultureBotAI/TraitMech#198).
+#
+# A path list cannot be derived from the checker's own FILES array — GitHub
+# evaluates `paths:` from static YAML before checkout, so it cannot read the
+# repo. Any hand-maintained list therefore has to be kept in sync with the
+# checker by hand, which is precisely the drift this guard exists to prevent.
+# Running unconditionally removes the failure class instead of re-syncing two
+# lists. The job is bash + curl with no uv/OAK, so there is nothing to save by
+# filtering it; the expensive id-label gate keeps its filter.
+#
+# Reference implementation: CultureBotAI/TraitMech#196.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: vendored-sync-${{ github.ref }}
+  # PRs only: on main, cancelling would leave the earlier commit unverified.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  vendored-sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      # Retried here rather than inside check_vendored_sync.sh: that script is
+      # vendored byte-identical across the spokes and has no canonical copy in
+      # the hub to diff against (CommunityMech#278), so editing it locally would
+      # create cross-repo drift that nothing currently detects.
+      - name: Verify vendored files match canonical hub
+        run: |
+          set -uo pipefail
+          for attempt in 1 2 3; do
+            # Capture the status explicitly. `if cmd; then ...; fi` is NOT usable
+            # here: an if-statement whose condition fails and which has no else
+            # branch returns 0 itself, so a following `status=$?` reads 0 rather
+            # than the command's exit code.
+            status=0
+            bash scripts/check_vendored_sync.sh || status=$?
+            if [ "$status" -eq 0 ]; then
+              exit 0
+            fi
+            # Exit 2 is a local precondition failure (missing or empty pinned
+            # ref), not a transient fetch problem — retrying cannot help.
+            if [ "$status" -eq 2 ]; then
+              echo "::error::scripts/.vendored_canon_ref is missing or empty" >&2
+              exit 2
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              echo "::warning::vendored-sync attempt $attempt failed (exit $status); retrying in 5s" >&2
+              sleep 5
+            fi
+          done
+          echo "::error::vendored files differ from the canonical hub, or the hub could not be reached after 3 attempts" >&2
+          exit 1


### PR DESCRIPTION
Part of the cross-Mech sweep tracked in CultureBotAI/TraitMech#198. Reference implementation: CultureBotAI/TraitMech#196.

## The problem

`scripts/check_vendored_sync.sh` compares **six** files against the canonical hub. Only **two** were reachable through the `paths:` filter of the workflow the job lived in:

| file compared by the checker | reachable via `trigger_paths`? |
|---|---|
| `scripts/validate_id_label_correspondence.py` | yes, listed directly |
| `src/mediaingredientmech/schema/mech_shared.yaml` | yes, via `src/mediaingredientmech/schema/**` |
| `scripts/chem_formula.py` | **no** |
| `tests/test_id_label_empty_adapter.py` | **no** |
| `tests/test_id_label_unknown_prefix.py` | **no** |
| `tests/test_id_label_plausibility.py` | **no** |

`scripts/check_vendored_sync.sh` and `scripts/.vendored_canon_ref` were not listed either, so editing the checker or silently reverting the pin did not fire the checker.

## Why "delete the filter" rather than "extend it"

The two jobs sharing that filter are not comparable in cost: `vendored-sync` is bash + curl, while the id-label gate needs `uv` and a cached OAK ontology download. The filter is correct for the expensive one and was inherited by the cheap one.

Extending the list by hand recreates the bug — two lists that must agree, with nothing enforcing it. And deriving the filter from the checker's `FILES` array **is not implementable**: GitHub evaluates `paths:` from static YAML *before* checkout, so it cannot read the repo.

So the job moves to its own workflow with no filter. There is no longer a list that can drift.

## Retry

Running unconditionally means 6 unauthenticated `raw.githubusercontent` fetches per PR, so a hub blip would fail unrelated work. Three attempts, 5s apart. Exit 2 (missing/empty pinned ref) short-circuits, since retrying cannot fix a local precondition.

The retry is in the **workflow**, not in `check_vendored_sync.sh`. That script is vendored byte-identical across the spokes and has no canonical copy in the hub to diff against (CommunityMech#278), so editing it here would create cross-repo drift that nothing currently detects.

## Verified

- both workflows parse; `vendored-sync` resolves to no `paths:` filter and `label-correspondence` retains its filter and its `id-label-gate` job
- the real checker passes **6/6** against `CultureBotAI/CultureMech@6be694f3`
- retry exercised against stubs: exit 0 immediate, exit 2 short-circuits with no retry, exit 1 after 2 retries (~10s)

## Note on the sweep

Checking this repo corrected two things in TraitMech#198:

- **"MIM" is `CultureBotAI/MediaIngredientMech`.** The issue recorded MIM as unverified because `gh api CultureBotAI/MIM` 404s — that is an abbreviation, not a repo name.
- **CultureMech is out of scope.** As the hub it has no `check_vendored_sync.sh` and no `vendored-sync` job, so it has nothing to fix. The sweep is the two spokes, not three repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)