### PR TITLE
Reconcile curated↔per-record and gate the round trip (#148)

### DIFF
--- a/.github/workflows/qc-roundtrip.yaml
+++ b/.github/workflows/qc-roundtrip.yaml
@@ -1,0 +1,78 @@
+name: QC — collection/per-record round-trip
+
+# Asserts that data/curated/ and data/ingredients/ still describe the same
+# records, so an edit made directly to a per-record file cannot be silently
+# reverted by the next `just export-individual` (which projects the collection
+# over the per-record tree, and which promote_resolved_unmapped.py calls).
+#
+# This is the guard that was missing: scripts/verify_roundtrip.py already
+# existed, but it compared against the committed data/collections/ artifact,
+# last regenerated in March 2026 — so it kept passing while 55 curation events
+# from PR #116 sat unreconciled in the per-record files. This job aggregates
+# into a temp directory instead, so it can never compare against a stale copy.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "data/curated/**"
+      - "data/ingredients/**"
+      - "scripts/aggregate_records.py"
+      - "scripts/verify_roundtrip.py"
+      - "scripts/export_individual_records.py"
+      - ".github/workflows/qc-roundtrip.yaml"
+  push:
+    branches: [main]
+    paths:
+      - "data/curated/**"
+      - "data/ingredients/**"
+      - "scripts/aggregate_records.py"
+      - "scripts/verify_roundtrip.py"
+      - "scripts/export_individual_records.py"
+      - ".github/workflows/qc-roundtrip.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  roundtrip:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout MIM
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install deps
+        run: python3 -m pip install pyyaml click rich
+
+      - name: Aggregate per-record files to a temp collection
+        run: |
+          python3 scripts/aggregate_records.py \
+            --ingredients-dir data/ingredients \
+            --output-dir "${RUNNER_TEMP}/agg"
+
+      - name: Verify curated <-> per-record round trip
+        run: |
+          python3 scripts/verify_roundtrip.py \
+            --original-dir data/curated \
+            --aggregated-dir "${RUNNER_TEMP}/agg"
+
+      - name: Assert export is a no-op (per-record tree matches the collection)
+        run: |
+          python3 scripts/export_individual_records.py \
+            --input-dir data/curated --output-dir data/ingredients
+          if ! git diff --quiet -- data/ingredients; then
+            echo "::error::export-individual changed data/ingredients — the per-record tree is not a clean projection of data/curated/."
+            git diff --stat -- data/ingredients
+            exit 1
+          fi
+          if [ -n "$(git status --porcelain -- data/ingredients)" ]; then
+            echo "::error::export-individual added or removed per-record files."
+            git status --porcelain -- data/ingredients
+            exit 1
+          fi
+          echo "export-individual is a no-op — round trip is closed."

--- a/.github/workflows/qc-roundtrip.yaml
+++ b/.github/workflows/qc-roundtrip.yaml
@@ -20,6 +20,11 @@ on:
       - "scripts/aggregate_records.py"
       - "scripts/verify_roundtrip.py"
       - "scripts/export_individual_records.py"
+      # The no-op assertion below compares emitted bytes, and save_yaml decides
+      # those bytes. A PR changing only its dump kwargs would otherwise skip
+      # this gate and land, after which every export diffs the whole corpus.
+      - "src/mediaingredientmech/utils/yaml_handler.py"
+      - "uv.lock"
       - ".github/workflows/qc-roundtrip.yaml"
   push:
     branches: [main]
@@ -29,6 +34,11 @@ on:
       - "scripts/aggregate_records.py"
       - "scripts/verify_roundtrip.py"
       - "scripts/export_individual_records.py"
+      # The no-op assertion below compares emitted bytes, and save_yaml decides
+      # those bytes. A PR changing only its dump kwargs would otherwise skip
+      # this gate and land, after which every export diffs the whole corpus.
+      - "src/mediaingredientmech/utils/yaml_handler.py"
+      - "uv.lock"
       - ".github/workflows/qc-roundtrip.yaml"
   workflow_dispatch:
 
@@ -42,37 +52,40 @@ jobs:
       - name: Checkout MIM
         uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v3
         with:
-          python-version: "3.13"
+          enable-cache: true
 
-      - name: Install deps
-        run: python3 -m pip install pyyaml click rich
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        # `uv sync --frozen`, not `pip install pyyaml`, because the final step
+        # asserts BYTE-EXACT YAML emission across 2,257 files. An unpinned
+        # PyYAML that changes Emitter line-wrapping would turn the whole corpus
+        # red with zero data change. uv.lock pins the emitter.
+        run: uv sync --frozen
 
       - name: Aggregate per-record files to a temp collection
         run: |
-          python3 scripts/aggregate_records.py \
+          uv run python scripts/aggregate_records.py \
             --ingredients-dir data/ingredients \
             --output-dir "${RUNNER_TEMP}/agg"
 
       - name: Verify curated <-> per-record round trip
         run: |
-          python3 scripts/verify_roundtrip.py \
+          uv run python scripts/verify_roundtrip.py \
             --original-dir data/curated \
             --aggregated-dir "${RUNNER_TEMP}/agg"
 
       - name: Assert export is a no-op (per-record tree matches the collection)
         run: |
-          python3 scripts/export_individual_records.py \
+          uv run python scripts/export_individual_records.py \
             --input-dir data/curated --output-dir data/ingredients
-          if ! git diff --quiet -- data/ingredients; then
-            echo "::error::export-individual changed data/ingredients — the per-record tree is not a clean projection of data/curated/."
-            git diff --stat -- data/ingredients
-            exit 1
-          fi
           if [ -n "$(git status --porcelain -- data/ingredients)" ]; then
-            echo "::error::export-individual added or removed per-record files."
+            echo "::error::export-individual changed data/ingredients — the per-record tree is not a clean projection of data/curated/. If a script edited data/ingredients/ directly (apply-role-research-results does), run 'just sync-curated' to write those edits back into data/curated/ and commit the result. Do NOT run 'just aggregate-collections' (writes data/collections/, which nothing reads) or 'just sync-individual' (exports first, destroying the per-record edits)."
             git status --porcelain -- data/ingredients
+            git diff --stat -- data/ingredients
             exit 1
           fi
           echo "export-individual is a no-op — round trip is closed."

--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -147,7 +147,7 @@ The collisions split into two dispositions, and telling them apart is the work:
 primary; these 61 predate that guard. Consider adding the same check as a
 repo-wide test so the count can only go down.
 
-## 3. Collection ↔ per-record drift (#148) — blocked by #1
+## 3. Collection ↔ per-record drift (#148) — DONE (2026-08-02, PR #162)
 
 Counts on 2026-07-30: mapped 1,879 per-record files vs 1,879 collection entries;
 unmapped **378 per-record files vs 381 collection entries**.
@@ -175,17 +175,22 @@ Also in scope, found during this reconcile:
   `data/curated/unmapped_ingredients.yaml` and `data/ingredients/unmapped/Tapso.yaml`.
   Every other unmapped record uses an `UNMAPPED_NNNN` placeholder. Mint one
   (`manage-identifiers`) — TAPSO is a real buffer and a mapping candidate.
-- **Self-inconsistent collection headers:** `data/curated/mapped_ingredients.yaml`
-  declares `total_count: 1879` but `mapped_count: 1877` against 1,879 records;
-  `data/curated/unmapped_ingredients.yaml` declares 381 against 378 files.
+- ~~**Self-inconsistent collection headers**~~ — **DONE (PR #162)**, recomputed
+  during the reconcile. Mapped now reports 1877 MAPPED + 2 non-MAPPED against
+  total 1879. Those 2 are `Bacto_Soytone.yaml` and `Sodium_L-lactate.yaml`, which
+  sit in `data/ingredients/mapped/` without `mapping_status: MAPPED` — filed
+  separately, since the honest header now surfaces them.
 - **Stale derived indexes:** `data/curated/mapped_ingredients_index.csv` (line 410)
   and `…_index.json` still carry `CHEBI:48601` for Carnitine Hydrochloride, whose
   identifier was corrected to `kgmicrobe.compound:carnitine_hydrochloride` (the
   collection YAML is right; only the indexes lag). Regenerate them.
 - **`data/collections/` is a dead March-2026 pair** (995 mapped / 136 unmapped,
-  generated 2026-03-06) alongside the live `data/curated/` pair (1879 / 381).
-  Only `data/curated/` is gated by `conf/id_label_targets.yaml`. Decide: delete,
-  or move to `ATTIC/`.
+  generated 2026-03-06) alongside the live `data/curated/` pair. Nothing reads it
+  and the new gate deliberately does not, but it is an active trap: it is the
+  aggregator's *default* output, so a bare `just aggregate-collections` still
+  writes there and looks like it did something. Retire it — delete or move to
+  `ATTIC/`, and repoint `aggregate_records.py`'s default. Left out of PR #162 to
+  keep that diff to the fix.
 
 **The issue's item 1 is now CONFIRMED and is worse than "stale files" — it is a
 data-destroying landmine. Measured 2026-07-30, once PR #159 made a full export
@@ -204,14 +209,48 @@ collection as the source — undoes all 55 curation events and drops their histo
 entries. `promote_resolved_unmapped.py` calls `just export-individual`, so **any
 routine promotion would have silently reverted them.**
 
-Fix direction: aggregate per-record → collection (`just aggregate-collections`)
-*before* the next export, and verify the resulting collection diff contains only
-those 55 events and the 3 orphan deletions above. Until that lands, treat
-`just export-individual` as unsafe on this corpus and check `git diff --stat`
-after every run. Re-running the export also recreates
-`unmapped/{Phytone,Soya_Pepton,Tryptone_Peptone}.yaml` from the stale entries,
-putting those three records in two states at once — delete those artifacts or fix
-the collection.
+**Root cause (found 2026-08-02): the reverse half of the round trip never fed
+back.** `aggregate_records.py` defaults `--output-dir` to `data/collections/`,
+but *every* consumer in the repo reads `data/curated/` — the only references to
+`data/collections/` anywhere are the aggregator's own default and
+`verify_roundtrip.py`'s. So a per-record edit had no path back into the export
+source, and `verify_roundtrip.py` — which would have caught this and already
+exits 1 on mismatch — was comparing against an artifact last regenerated in
+March 2026. It was never wired into CI. `just aggregate-collections` was
+therefore *not* the fix: on its own it writes to the dead end.
+
+**FIXED 2026-08-02 (PR #162).** Two halves:
+
+1. **Data reconciled.** Applied surgically (record and key order preserved, only
+   drifted fields touched) so the diff stayed reviewable: 55 unmapped records
+   gained `ingredient_type`/`curation_history`/`notes`; the 3 orphans were
+   dropped; headers recomputed (mapped now honestly reports 1877 MAPPED + 2
+   non-MAPPED against total 1879). `discussions` deliberately stays out of the
+   collection. 12 per-record files were also normalised — line wrapping and
+   scalar quoting only, verified semantically identical by parsing both sides and
+   stable across three consecutive exports. **`just export-individual` is now a
+   true no-op.**
+2. **Guard added so it cannot recur.** `just qc-roundtrip` (now part of `just
+   qc`) and `.github/workflows/qc-roundtrip.yaml` aggregate into a *temp* dir —
+   never a committed artifact — and verify against `data/curated`; CI also
+   asserts that `export-individual` produces no diff. `verify_roundtrip.py`
+   gained `--ignore-fields` (default `discussions`) and no longer stops after the
+   first mismatch per file. Verified the gate **fails** as well as passes:
+   reverting `data/curated` exits 1, and a single-field change with counts left
+   unchanged is caught and pinpointed.
+
+**The 53 reclassifications were validated before being made canonical.** All are
+named standard culture media — `Marine broth 2216` and `Oatmeal agar` appear
+verbatim in the schema's own `DEFINED_MEDIUM` examples. MediaDive REST confirms
+the 8 contested "Base" products carry no formula/CAS/ChEBI (formulations, not
+chemicals). Three independent Edison/PaperQA3 runs on the hardest cases — Blood
+Agar Base (incomplete base), Soil+Seawater Medium (natural-substrate, genuinely
+variable components), Leptospira Medium Base EMJH (supplement-dependent base) —
+**each independently confirmed `DEFINED_MEDIUM`**. Reports under
+`research/ingredients/` (gitignored).
+
+⚠ **All three runs independently flagged the same schema hazard** — see the new
+item 10 below.
 
 ## 4. Flip `plausibility_severity: warn` → `error` — DONE (2026-07-30, PR #159)
 
@@ -358,6 +397,35 @@ Nine items shipped in #108/#109/#111; three remain, all confirmed present:
    `:root[data-theme="dark"]`, ~55 lines each, e.g. `browser.html:294-348`).
    **Cross-Mech** — `theme-toggle.js` is vendored byte-identical across all Mech
    sites, so unifying tokens unilaterally would desync MIM. Coordinate in claw.
+
+## 10. `DEFINED_MEDIUM` reads as "chemically defined" — schema hazard (NEW)
+
+Surfaced independently by **all three** Edison/PaperQA3 runs during the #148
+validation (2026-08-02), each unprompted and each phrasing it as a warning:
+
+- Blood Agar Base — "`DEFINED_MEDIUM` should be understood as the project's
+  named-medium record type, **not a claim that every molecular constituent and
+  concentration is chemically specified**."
+- Soil+Seawater Medium — "may be retained if it means 'complete named medium,'
+  but **it must not be interpreted as 'chemically defined medium'**."
+- Leptospira Medium Base EMJH — "'defined' **should not be interpreted as
+  chemically defined**."
+
+In microbiology "defined medium" is a term of art meaning *chemically* defined
+(every constituent known and quantified) — the opposite of the complex digests
+and extracts these records contain. MIM's enum means "complete named medium
+formulation", which the schema *description* supports ("Complete medium
+formulation or recipe with multiple ingredients … Should cross-reference to
+CultureMech for full recipe") but the enum *name* actively contradicts. 53
+records now carry this value, and kg-microbe consumes it.
+
+Low-risk fix: sharpen the `DEFINED_MEDIUM` description to say explicitly that it
+denotes record granularity (a complete named medium), not chemical definedness,
+and that complex undefined components are expected. A rename is the honest fix
+but is cross-repo (CultureMech imports MIM's enums) and would need coordination —
+weigh against the description-only change. Note `UNDEFINED_MIXTURE` sits in the
+same enum and *does* carry the compositional meaning, which is what makes the
+pair misleading.
 
 ## 9. Small cleanups
 

--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -211,9 +211,11 @@ routine promotion would have silently reverted them.**
 
 **Root cause (found 2026-08-02): the reverse half of the round trip never fed
 back.** `aggregate_records.py` defaults `--output-dir` to `data/collections/`,
-but *every* consumer in the repo reads `data/curated/` — the only references to
-`data/collections/` anywhere are the aggregator's own default and
-`verify_roundtrip.py`'s. So a per-record edit had no path back into the export
+but *every* one of the ~20 consumers in the repo reads `data/curated/`. Nothing
+reads `data/collections/`: the only references are the aggregator's own default,
+`verify_roundtrip.py`'s, and two `notes/` docs that documented the stale
+comparison as the way to do it (fixed in PR #167).
+So a per-record edit had no path back into the export
 source, and `verify_roundtrip.py` — which would have caught this and already
 exits 1 on mismatch — was comparing against an artifact last regenerated in
 March 2026. It was never wired into CI. `just aggregate-collections` was
@@ -240,8 +242,10 @@ therefore *not* the fix: on its own it writes to the dead end.
    unchanged is caught and pinpointed.
 
 **The 53 reclassifications were validated before being made canonical.** All are
-named standard culture media — `Marine broth 2216` and `Oatmeal agar` appear
-verbatim in the schema's own `DEFINED_MEDIUM` examples. MediaDive REST confirms
+named standard culture media. `Oatmeal agar` appears **verbatim** in the schema's
+own `DEFINED_MEDIUM` examples, and `Marine broth 2216` is the broth counterpart
+of its `Marine agar 2216` example (same DSMZ 2216 formulation, solidified or
+not) — a near-match, not a verbatim one. MediaDive REST confirms
 the 8 contested "Base" products carry no formula/CAS/ChEBI (formulations, not
 chemicals). Three independent Edison/PaperQA3 runs on the hardest cases — Blood
 Agar Base (incomplete base), Soil+Seawater Medium (natural-substrate, genuinely
@@ -398,6 +402,33 @@ Nine items shipped in #108/#109/#111; three remain, all confirmed present:
    **Cross-Mech** — `theme-toggle.js` is vendored byte-identical across all Mech
    sites, so unifying tokens unilaterally would desync MIM. Coordinate in claw.
 
+## 9. Small cleanups
+
+- **`enrich_edison_response.py` non-recursive glob** (deferred in #146): the
+  default `DEFAULT_RESEARCH_DIR` pattern `*-edison-*-meta.yaml` is non-recursive,
+  so it will not see `research/ingredients/roles/` unless `--research-dir` is
+  passed. Fix before the role lane runs (item 5).
+- **`.claude/skills/ingredient-roles/SKILL.md` is pre-facet** — it documents the
+  retired flat lowercase role names (`carbon_source`, `buffer`) with no mention of
+  the three facets or the Step 7b lane. The facet-aware skill exists only in
+  CultureMech (`.claude/skills/research-ingredient-roles/SKILL.md`). Modernize or
+  point at it.
+- **`docs/ROLE_CURATION_WORKFLOW.md`** carries a 2026-03-15 stats snapshot
+  (446 ingredients / 996 mapped). It is honestly labelled "before the #128 facet
+  migration" and points at `scripts/validate_roles.py` for current numbers, so
+  this is cosmetic; the "Future Enhancements (Phase 5)" section (lines 399-420)
+  describes a manual DOI-review workflow that Step 7b supersedes.
+- **`chemical_properties` residual is the ceiling, not a task.** The enricher was
+  repaired in 2026-06 (OLS4 renamed its annotation keys: `formula` →
+  `generalized_empirical_formula`, SMILES/InChI → `*_string`). The remaining ~83
+  missing-formula records are abstract CHEBI classes, polymers, proteins,
+  complexes and minerals that legitimately have no single empirical formula.
+  Re-run any time with `python scripts/enrich_chemical_properties.py`
+  (idempotent), then `just export-individual`. Gotcha still live: OLS4 needs
+  **double** URL-encoding of ChEBI IRIs.
+- **`dashboard/` was last generated 2026-07-19**, before the role-facet work
+  landed. Re-run `just gen-qc-dashboard` after item 5.
+
 ## 10. `DEFINED_MEDIUM` reads as "chemically defined" — schema hazard (NEW)
 
 Surfaced independently by **all three** Edison/PaperQA3 runs during the #148
@@ -426,33 +457,6 @@ but is cross-repo (CultureMech imports MIM's enums) and would need coordination 
 weigh against the description-only change. Note `UNDEFINED_MIXTURE` sits in the
 same enum and *does* carry the compositional meaning, which is what makes the
 pair misleading.
-
-## 9. Small cleanups
-
-- **`enrich_edison_response.py` non-recursive glob** (deferred in #146): the
-  default `DEFAULT_RESEARCH_DIR` pattern `*-edison-*-meta.yaml` is non-recursive,
-  so it will not see `research/ingredients/roles/` unless `--research-dir` is
-  passed. Fix before the role lane runs (item 5).
-- **`.claude/skills/ingredient-roles/SKILL.md` is pre-facet** — it documents the
-  retired flat lowercase role names (`carbon_source`, `buffer`) with no mention of
-  the three facets or the Step 7b lane. The facet-aware skill exists only in
-  CultureMech (`.claude/skills/research-ingredient-roles/SKILL.md`). Modernize or
-  point at it.
-- **`docs/ROLE_CURATION_WORKFLOW.md`** carries a 2026-03-15 stats snapshot
-  (446 ingredients / 996 mapped). It is honestly labelled "before the #128 facet
-  migration" and points at `scripts/validate_roles.py` for current numbers, so
-  this is cosmetic; the "Future Enhancements (Phase 5)" section (lines 399-420)
-  describes a manual DOI-review workflow that Step 7b supersedes.
-- **`chemical_properties` residual is the ceiling, not a task.** The enricher was
-  repaired in 2026-06 (OLS4 renamed its annotation keys: `formula` →
-  `generalized_empirical_formula`, SMILES/InChI → `*_string`). The remaining ~83
-  missing-formula records are abstract CHEBI classes, polymers, proteins,
-  complexes and minerals that legitimately have no single empirical formula.
-  Re-run any time with `python scripts/enrich_chemical_properties.py`
-  (idempotent), then `just export-individual`. Gotcha still live: OLS4 needs
-  **double** URL-encoding of ChEBI IRIs.
-- **`dashboard/` was last generated 2026-07-19**, before the role-facet work
-  landed. Re-run `just gen-qc-dashboard` after item 5.
 
 ---
 

--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -6,7 +6,7 @@ deferrals here. Keep the cross-Mech items in sync with the sibling repos'
 `NEXT_TASKS.md` (CultureMech / CommunityMech / TraitMech). The hub,
 culturebotai-claw, now keeps one too, for items no single Mech owns.
 
-Last reconciled: 2026-07-31. **#160** was filed on 2026-07-30 for the
+Last reconciled: 2026-08-02. **#160** was filed on 2026-07-30 for the
 `trigger_paths` gap described in the vendored-sync section below.
 
 > **Reconcile note (2026-07-30).** The previous reconcile was 2026-06-15 and the
@@ -147,7 +147,7 @@ The collisions split into two dispositions, and telling them apart is the work:
 primary; these 61 predate that guard. Consider adding the same check as a
 repo-wide test so the count can only go down.
 
-## 3. Collection ↔ per-record drift (#148) — DONE (2026-08-02, PR #162)
+## 3. Collection ↔ per-record drift (#148) — DONE (2026-08-02, PR #167)
 
 Counts on 2026-07-30: mapped 1,879 per-record files vs 1,879 collection entries;
 unmapped **378 per-record files vs 381 collection entries**.
@@ -175,7 +175,7 @@ Also in scope, found during this reconcile:
   `data/curated/unmapped_ingredients.yaml` and `data/ingredients/unmapped/Tapso.yaml`.
   Every other unmapped record uses an `UNMAPPED_NNNN` placeholder. Mint one
   (`manage-identifiers`) — TAPSO is a real buffer and a mapping candidate.
-- ~~**Self-inconsistent collection headers**~~ — **DONE (PR #162)**, recomputed
+- ~~**Self-inconsistent collection headers**~~ — **DONE (PR #167)**, recomputed
   during the reconcile. Mapped now reports 1877 MAPPED + 2 non-MAPPED against
   total 1879. Those 2 are `Bacto_Soytone.yaml` and `Sodium_L-lactate.yaml`, which
   sit in `data/ingredients/mapped/` without `mapping_status: MAPPED` — filed
@@ -189,7 +189,7 @@ Also in scope, found during this reconcile:
   and the new gate deliberately does not, but it is an active trap: it is the
   aggregator's *default* output, so a bare `just aggregate-collections` still
   writes there and looks like it did something. Retire it — delete or move to
-  `ATTIC/`, and repoint `aggregate_records.py`'s default. Left out of PR #162 to
+  `ATTIC/`, and repoint `aggregate_records.py`'s default. Left out of PR #167 to
   keep that diff to the fix.
 
 **The issue's item 1 is now CONFIRMED and is worse than "stale files" — it is a
@@ -219,7 +219,7 @@ exits 1 on mismatch — was comparing against an artifact last regenerated in
 March 2026. It was never wired into CI. `just aggregate-collections` was
 therefore *not* the fix: on its own it writes to the dead end.
 
-**FIXED 2026-08-02 (PR #162).** Two halves:
+**FIXED 2026-08-02 (PR #167).** Two halves:
 
 1. **Data reconciled.** Applied surgically (record and key order preserved, only
    drifted fields touched) so the diff stayed reviewable: 55 unmapped records

--- a/data/curated/mapped_ingredients.yaml
+++ b/data/curated/mapped_ingredients.yaml
@@ -1,7 +1,7 @@
-generation_date: '2026-05-24T08:02:35.311940+00:00'
+generation_date: '2026-08-02T07:30:38.760974+00:00'
 total_count: 1879
 mapped_count: 1877
-unmapped_count: 0
+unmapped_count: 2
 ingredients:
 - identifier: CHEBI:149425
   preferred_term: NH4MgPO

--- a/data/curated/unmapped_ingredients.yaml
+++ b/data/curated/unmapped_ingredients.yaml
@@ -1,7 +1,7 @@
-generation_date: '2026-05-24T08:02:38.378922+00:00'
-total_count: 381
+generation_date: '2026-08-02T07:30:44.296114+00:00'
+total_count: 378
 mapped_count: 0
-unmapped_count: 381
+unmapped_count: 378
 ingredients:
 - identifier: UNMAPPED_0196
   preferred_term: 2-Carene-3-One
@@ -909,9 +909,15 @@ ingredients:
     action: AUTO_CLASSIFY_INGREDIENT_TYPE
     changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Broth')
     llm_assisted: false
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Imported from mim-queue (source_id=mediadive.ingredient:1473); no CAS-RN
     or CHEBI/NCIT match. Curator review needed.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0239
   preferred_term: apo-yersiniabactin
   synonyms:
@@ -1139,9 +1145,15 @@ ingredients:
     previous_status: UNMAPPED
     new_status: UNMAPPED
     llm_assisted: true
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Extracted from over-conflated Agar.yaml synonyms; reviewed on 2026-05-11
     as a named agar medium/base preparation, not agar identity.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0169
   preferred_term: BC Lignin Sorghum
   synonyms:
@@ -1199,9 +1211,15 @@ ingredients:
     previous_status: UNMAPPED
     new_status: UNMAPPED
     llm_assisted: true
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Extracted from over-conflated Agar.yaml synonyms; reviewed on 2026-05-11
     as a named agar medium/base preparation, not agar identity.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0330
   preferred_term: Bacto Bitone
   synonyms:
@@ -1255,9 +1273,15 @@ ingredients:
     action: AUTO_CLASSIFY_INGREDIENT_TYPE
     changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Infusion')
     llm_assisted: false
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Imported from mim-queue (source_id=mediadive.ingredient:1460); no CAS-RN
     or CHEBI/NCIT match. Curator review needed.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0333
   preferred_term: Bacto m TGE broth
   synonyms:
@@ -1281,9 +1305,15 @@ ingredients:
     action: AUTO_CLASSIFY_INGREDIENT_TYPE
     changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'broth')
     llm_assisted: false
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Imported from mim-queue (source_id=mediadive.ingredient:1896); no CAS-RN
     or CHEBI/NCIT match. Curator review needed.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0115
   preferred_term: Bacto Middlebrook 7H10 agar
   synonyms:
@@ -1312,9 +1342,15 @@ ingredients:
     previous_status: UNMAPPED
     new_status: UNMAPPED
     llm_assisted: true
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Extracted from over-conflated Agar.yaml synonyms; reviewed on 2026-05-11
     as a commercial agar medium/base preparation, not agar identity.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0334
   preferred_term: Bacto Panton
   synonyms:
@@ -1612,10 +1648,16 @@ ingredients:
     previous_status: UNMAPPED
     new_status: UNMAPPED
     llm_assisted: true
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Imported from mim-queue (source_id=mediadive.ingredient:2130); no CAS-RN
     or CHEBI/NCIT match. Reviewed on 2026-05-11 as a blood agar base preparation pending
     product- or recipe-level curation.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0340
   preferred_term: Blood agar No 2
   synonyms:
@@ -1642,10 +1684,16 @@ ingredients:
     previous_status: UNMAPPED
     new_status: UNMAPPED
     llm_assisted: true
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Imported from mim-queue (source_id=mediadive.ingredient:2111); no CAS-RN
     or CHEBI/NCIT match. Reviewed on 2026-05-11 as a blood agar medium/base preparation
     pending product- or recipe-level curation.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0051
   preferred_term: Bold 1NV Medium
   synonyms:
@@ -1729,10 +1777,16 @@ ingredients:
     previous_status: UNMAPPED
     new_status: UNMAPPED
     llm_assisted: true
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Imported from mim-queue (source_id=mediadive.ingredient:2112); no CAS-RN
     or CHEBI/NCIT match. Reviewed on 2026-05-11 as an agar base preparation pending
     product- or recipe-level curation.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0075
   preferred_term: Boron Stock
   synonyms:
@@ -1859,9 +1913,15 @@ ingredients:
     previous_status: UNMAPPED
     new_status: UNMAPPED
     llm_assisted: true
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Extracted from over-conflated Agar.yaml synonyms; reviewed on 2026-05-11
     as a named agar medium/base preparation, not agar identity.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0023
   preferred_term: Bristol Medium
   synonyms:
@@ -1913,9 +1973,15 @@ ingredients:
     action: AUTO_CLASSIFY_INGREDIENT_TYPE
     changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Broth')
     llm_assisted: false
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Imported from mim-queue (source_id=mediadive.ingredient:1136); no CAS-RN
     or CHEBI/NCIT match. Curator review needed.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0359
   preferred_term: CMRL 1066
   synonyms:
@@ -2164,10 +2230,16 @@ ingredients:
     previous_status: UNMAPPED
     new_status: UNMAPPED
     llm_assisted: true
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Imported from mim-queue (source_id=mediadive.ingredient:2099); no CAS-RN
     or CHEBI/NCIT match. Reviewed on 2026-05-11 as an agar base preparation pending
     product- or recipe-level curation.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0102
   preferred_term: CaSO4•2H2Osaturated solution
   synonyms:
@@ -2767,9 +2839,15 @@ ingredients:
     previous_status: UNMAPPED
     new_status: UNMAPPED
     llm_assisted: true
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Extracted from over-conflated Agar.yaml synonyms; reviewed on 2026-05-11
     as a blood agar base preparation, not agar identity.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0363
   preferred_term: Complan
   synonyms:
@@ -2858,9 +2936,15 @@ ingredients:
     previous_status: UNMAPPED
     new_status: UNMAPPED
     llm_assisted: true
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Extracted from over-conflated Agar.yaml synonyms; reviewed on 2026-05-11
     as a corn meal agar medium preparation, not agar identity.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0366
   preferred_term: Corn steep powder
   synonyms:
@@ -3189,10 +3273,16 @@ ingredients:
     previous_status: UNMAPPED
     new_status: UNMAPPED
     llm_assisted: true
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Imported from mim-queue (source_id=mediadive.ingredient:2126); no CAS-RN
     or CHEBI/NCIT match. Reviewed on 2026-05-11 as a dehydrated medium preparation
     pending product- or recipe-level curation.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0373
   preferred_term: dehydrated Wilkins-Chalgren medium
   synonyms:
@@ -3219,10 +3309,16 @@ ingredients:
     previous_status: UNMAPPED
     new_status: UNMAPPED
     llm_assisted: true
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Imported from mim-queue (source_id=mediadive.ingredient:2095); no CAS-RN
     or CHEBI/NCIT match. Reviewed on 2026-05-11 as a dehydrated medium preparation
     pending product- or recipe-level curation.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0200
   preferred_term: Deoxysappanone B 7,3'-Dimethyl Ether
   synonyms:
@@ -3407,10 +3503,16 @@ ingredients:
     previous_status: UNMAPPED
     new_status: UNMAPPED
     llm_assisted: true
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Imported from mim-queue (source_id=mediadive.ingredient:2177); no CAS-RN
     or CHEBI/NCIT match. Reviewed on 2026-05-11 as an agar base preparation pending
     product- or recipe-level curation.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0377
   preferred_term: Difco 0001
   synonyms:
@@ -3464,9 +3566,15 @@ ingredients:
     action: AUTO_CLASSIFY_INGREDIENT_TYPE
     changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'broth')
     llm_assisted: false
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Imported from mim-queue (source_id=mediadive.ingredient:530); no CAS-RN or
     CHEBI/NCIT match. Curator review needed.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0192
   preferred_term: Dihydrodehydroerosone
   synonyms:
@@ -3699,8 +3807,14 @@ ingredients:
     action: AUTO_CLASSIFY_INGREDIENT_TYPE
     changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Seawater')
     llm_assisted: false
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: 'CultureMech placeholder_id: 1'
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0031
   preferred_term: Enrichment Solution for Seawater Medium
   synonyms:
@@ -3907,8 +4021,14 @@ ingredients:
     previous_status: UNMAPPED
     new_status: UNMAPPED
     llm_assisted: true
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Extracted from over-conflated Agar.yaml synonyms
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0381
   preferred_term: Fastidious Anaerobe Basal Broth
   synonyms:
@@ -3932,9 +4052,15 @@ ingredients:
     action: AUTO_CLASSIFY_INGREDIENT_TYPE
     changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Broth')
     llm_assisted: false
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Imported from mim-queue (source_id=mediadive.ingredient:1079); no CAS-RN
     or CHEBI/NCIT match. Curator review needed.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0385
   preferred_term: FeSO43 x n H2O
   synonyms:
@@ -4175,9 +4301,19 @@ ingredients:
     previous_status: UNMAPPED
     new_status: UNMAPPED
     llm_assisted: true
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_followups_114
+    action: FLAGGED_NON_INGREDIENT
+    changes: Flagged as NON_INGREDIENT / source-composition placeholder (not a chemical
+      or mixture identity). Retained UNMAPPED; no ontology mapping invented and record
+      not deleted.
+    previous_status: UNMAPPED
+    new_status: UNMAPPED
+    llm_assisted: true
   notes: 'CultureMech placeholder_id: See source for composition; reviewed on 2026-05-11
     and retained unmapped because this is a source-composition placeholder rather
-    than a standalone ingredient identity.'
+    than a standalone ingredient identity. NON_INGREDIENT: placeholder term, not a
+    mappable ingredient (flagged 2026-07-05).'
 - identifier: UNMAPPED_0108
   preferred_term: G9 Trace Metals for J medium
   synonyms:
@@ -4234,9 +4370,15 @@ ingredients:
     previous_status: UNMAPPED
     new_status: UNMAPPED
     llm_assisted: true
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Extracted from over-conflated Agar.yaml synonyms; reviewed on 2026-05-11
     as a GAM agar medium/base preparation, not agar identity.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0388
   preferred_term: GAM broth
   synonyms:
@@ -4260,9 +4402,15 @@ ingredients:
     action: AUTO_CLASSIFY_INGREDIENT_TYPE
     changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'broth')
     llm_assisted: false
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Imported from mim-queue (source_id=mediadive.ingredient:1620); no CAS-RN
     or CHEBI/NCIT match. Curator review needed.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0389
   preferred_term: GAM Broth mod. powder
   synonyms:
@@ -4286,9 +4434,15 @@ ingredients:
     action: AUTO_CLASSIFY_INGREDIENT_TYPE
     changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Broth')
     llm_assisted: false
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Imported from mim-queue (source_id=mediadive.ingredient:1564); no CAS-RN
     or CHEBI/NCIT match. Curator review needed.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0390
   preferred_term: GAM Broth powder
   synonyms:
@@ -4312,9 +4466,15 @@ ingredients:
     action: AUTO_CLASSIFY_INGREDIENT_TYPE
     changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Broth')
     llm_assisted: false
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Imported from mim-queue (source_id=mediadive.ingredient:1563); no CAS-RN
     or CHEBI/NCIT match. Curator review needed.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0397
   preferred_term: GYP-sodium acetate-mineral salts broth
   synonyms:
@@ -4338,9 +4498,15 @@ ingredients:
     action: AUTO_CLASSIFY_INGREDIENT_TYPE
     changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'broth')
     llm_assisted: false
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Imported from mim-queue (source_id=mediadive.ingredient:1618); no CAS-RN
     or CHEBI/NCIT match. Curator review needed.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0238
   preferred_term: Galactan from Potato
   synonyms:
@@ -4666,9 +4832,15 @@ ingredients:
     action: AUTO_CLASSIFY_INGREDIENT_TYPE
     changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Infusion')
     llm_assisted: false
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Imported from mim-queue (source_id=mediadive.ingredient:1104); no CAS-RN
     or CHEBI/NCIT match. Curator review needed.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0401
   preferred_term: Homo-PIPES
   synonyms:
@@ -5017,9 +5189,15 @@ ingredients:
     action: AUTO_CLASSIFY_INGREDIENT_TYPE
     changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Infusion')
     llm_assisted: false
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Imported from mim-queue (source_id=mediadive.ingredient:930); no CAS-RN or
     CHEBI/NCIT match. Curator review needed.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0251
   preferred_term: Infusion from Potatoes
   synonyms:
@@ -5626,9 +5804,15 @@ ingredients:
     action: AUTO_CLASSIFY_INGREDIENT_TYPE
     changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'broth')
     llm_assisted: false
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Imported from mim-queue (source_id=mediadive.ingredient:1711); no CAS-RN
     or CHEBI/NCIT match. Curator review needed.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0422
   preferred_term: Lactobacillus MRS broth
   synonyms:
@@ -5652,9 +5836,15 @@ ingredients:
     action: AUTO_CLASSIFY_INGREDIENT_TYPE
     changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'broth')
     llm_assisted: false
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Imported from mim-queue (source_id=mediadive.ingredient:1776); no CAS-RN
     or CHEBI/NCIT match. Curator review needed.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0424
   preferred_term: Larchwood xylan
   synonyms:
@@ -5743,10 +5933,16 @@ ingredients:
     previous_status: UNMAPPED
     new_status: UNMAPPED
     llm_assisted: true
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Imported from mim-queue (source_id=mediadive.ingredient:990); no CAS-RN or
     CHEBI/NCIT match. Reviewed on 2026-05-11 as a medium base preparation pending
     product- or recipe-level curation.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0427
   preferred_term: Linsmaier & Skoog Medium including vitamins
   synonyms:
@@ -6044,9 +6240,15 @@ ingredients:
     action: AUTO_CLASSIFY_INGREDIENT_TYPE
     changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'broth')
     llm_assisted: false
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Imported from mim-queue (source_id=mediadive.ingredient:1899); no CAS-RN
     or CHEBI/NCIT match. Curator review needed.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0454
   preferred_term: MRS medium
   synonyms:
@@ -6158,9 +6360,15 @@ ingredients:
     action: AUTO_CLASSIFY_INGREDIENT_TYPE
     changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'broth')
     llm_assisted: false
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Imported from mim-queue (source_id=mediadive.ingredient:1112); no CAS-RN
     or CHEBI/NCIT match. Curator review needed.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0155
   preferred_term: Manganese-NTA
   synonyms:
@@ -6215,9 +6423,15 @@ ingredients:
     action: AUTO_CLASSIFY_INGREDIENT_TYPE
     changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Broth')
     llm_assisted: false
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Imported from mim-queue (source_id=mediadive.ingredient:545); no CAS-RN or
     CHEBI/NCIT match. Curator review needed.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0434
   preferred_term: Marine broth 2216
   synonyms:
@@ -6241,9 +6455,15 @@ ingredients:
     action: AUTO_CLASSIFY_INGREDIENT_TYPE
     changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'broth')
     llm_assisted: false
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Imported from mim-queue (source_id=mediadive.ingredient:1607); no CAS-RN
     or CHEBI/NCIT match. Curator review needed.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0269
   preferred_term: Mc_general_salts
   synonyms:
@@ -7126,9 +7346,15 @@ ingredients:
     previous_status: UNMAPPED
     new_status: UNMAPPED
     llm_assisted: true
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Extracted from over-conflated Agar.yaml synonyms; reviewed on 2026-05-11
     as a Mueller Hinton II agar medium/base preparation, not agar identity.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0610
   preferred_term: Murashige-Skoog basal salts
   synonyms:
@@ -7929,10 +8155,16 @@ ingredients:
     previous_status: UNMAPPED
     new_status: UNMAPPED
     llm_assisted: true
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Imported from mim-queue (source_id=mediadive.ingredient:2364); no CAS-RN
     or CHEBI/NCIT match. Reviewed on 2026-05-11 as a nutrient agar medium/base preparation
     pending recipe- or product-level curation.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0227
   preferred_term: O-methyl-D-glucuronoxylan
   synonyms:
@@ -8020,10 +8252,16 @@ ingredients:
     previous_status: UNMAPPED
     new_status: UNMAPPED
     llm_assisted: true
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Imported from mim-queue (source_id=mediadive.ingredient:2125); no CAS-RN
     or CHEBI/NCIT match. Reviewed on 2026-05-11 as an agar base preparation pending
     product- or recipe-level curation.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0129
   preferred_term: Oatmeal agar
   synonyms:
@@ -8051,9 +8289,15 @@ ingredients:
     previous_status: UNMAPPED
     new_status: UNMAPPED
     llm_assisted: true
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Extracted from over-conflated Agar.yaml synonyms; reviewed on 2026-05-11
     as an oatmeal agar medium/base preparation, not agar identity.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0099
   preferred_term: Organic Peat
   synonyms:
@@ -8292,9 +8536,15 @@ ingredients:
     action: AUTO_CLASSIFY_INGREDIENT_TYPE
     changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'broth')
     llm_assisted: false
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Imported from mim-queue (source_id=mediadive.ingredient:953); no CAS-RN or
     CHEBI/NCIT match. Curator review needed.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0231
   preferred_term: Pectic galactan from potato
   synonyms:
@@ -8326,36 +8576,6 @@ ingredients:
     CultureBot media; samples: Surya_sugar_mix. No CAS-RN or CHEBI mapping available;
     curator review needed. Reviewed on 2026-05-11 as a potato-derived pectic galactan
     substrate/fraction pending source and polymer-fraction curation.'
-  ingredient_type: UNDEFINED_MIXTURE
-- identifier: UNMAPPED_0488
-  preferred_term: Phytone
-  synonyms:
-  - synonym_text: Phytone
-    synonym_type: RAW_TEXT
-    source: mim-queue
-  mapping_status: UNMAPPED
-  occurrence_statistics:
-    total_occurrences: 0
-    media_count: 0
-  curation_history:
-  - timestamp: '2026-04-30T18:43:03.698454+00:00'
-    curator: audit_import_ingredients[mim-queue]
-    action: CREATED_AS_UNMAPPED
-    changes: Imported from mim-queue (source_id=mediadive.ingredient:362); no CAS-RN
-      or CHEBI/NCIT match. Curator review needed.
-    new_status: UNMAPPED
-    llm_assisted: false
-  - timestamp: '2026-05-11T19:35:00Z'
-    curator: mediaingredientmech-agentic-curation
-    action: CLASSIFIED_UNDEFINED_MIXTURE
-    changes: Classified as a plant-derived peptone/protein hydrolysate preparation
-      and left unmapped pending product-level curation.
-    previous_status: UNMAPPED
-    new_status: UNMAPPED
-    llm_assisted: true
-  notes: Imported from mim-queue (source_id=mediadive.ingredient:362); no CAS-RN or
-    CHEBI/NCIT match. Reviewed on 2026-05-11 as a plant-derived peptone/protein hydrolysate
-    preparation pending product-level curation.
   ingredient_type: UNDEFINED_MIXTURE
 - identifier: UNMAPPED_0490
   preferred_term: Plain flour
@@ -8874,9 +9094,15 @@ ingredients:
     previous_status: UNMAPPED
     new_status: UNMAPPED
     llm_assisted: true
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Extracted from over-conflated Agar.yaml synonyms; reviewed on 2026-05-11
     as an R agar medium/base preparation, not agar identity.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0166
   preferred_term: Red Arabinan from sugar-beet
   synonyms:
@@ -8935,10 +9161,16 @@ ingredients:
     previous_status: UNMAPPED
     new_status: UNMAPPED
     llm_assisted: true
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Imported from mim-queue (source_id=mediadive.ingredient:1769); no CAS-RN
     or CHEBI/NCIT match. Reviewed on 2026-05-11 as a medium preparation pending product-
     or recipe-level curation.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0240
   preferred_term: Rhamnogalacturonan-II from apple juice concentrate
   synonyms:
@@ -9365,9 +9597,19 @@ ingredients:
     previous_status: UNMAPPED
     new_status: UNMAPPED
     llm_assisted: true
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_followups_114
+    action: FLAGGED_NON_INGREDIENT
+    changes: Flagged as NON_INGREDIENT / source-composition placeholder (not a chemical
+      or mixture identity). Retained UNMAPPED; no ontology mapping invented and record
+      not deleted.
+    previous_status: UNMAPPED
+    new_status: UNMAPPED
+    llm_assisted: true
   notes: 'CultureMech placeholder_id: See source for composition; reviewed on 2026-05-11
     and retained unmapped because this is a source-composition placeholder rather
-    than a standalone ingredient identity.'
+    than a standalone ingredient identity. NON_INGREDIENT: placeholder term, not a
+    mappable ingredient (flagged 2026-07-05).'
 - identifier: UNMAPPED_0519
   preferred_term: Selenite-tungstate solution see Medium No. 431
   synonyms:
@@ -9588,8 +9830,14 @@ ingredients:
     action: AUTO_CLASSIFY_INGREDIENT_TYPE
     changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Soil')
     llm_assisted: false
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: 'CultureMech placeholder_id: 2'
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0078
   preferred_term: 'Soilwater: GR- Medium'
   synonyms:
@@ -9674,36 +9922,6 @@ ingredients:
   notes: 'CultureMech placeholder_id: 6; reviewed on 2026-05-11 as a named soilwater
     peat medium formulation pending recipe-level curation.'
   ingredient_type: DEFINED_MEDIUM
-- identifier: UNMAPPED_0531
-  preferred_term: Soya pepton
-  synonyms:
-  - synonym_text: Soya pepton
-    synonym_type: RAW_TEXT
-    source: mim-queue
-  mapping_status: UNMAPPED
-  occurrence_statistics:
-    total_occurrences: 0
-    media_count: 0
-  curation_history:
-  - timestamp: '2026-04-30T18:43:03.698454+00:00'
-    curator: audit_import_ingredients[mim-queue]
-    action: CREATED_AS_UNMAPPED
-    changes: Imported from mim-queue (source_id=mediadive.ingredient:1466); no CAS-RN
-      or CHEBI/NCIT match. Curator review needed.
-    new_status: UNMAPPED
-    llm_assisted: false
-  - timestamp: '2026-05-11T08:03:00Z'
-    curator: mediaingredientmech-agentic-curation
-    action: CLASSIFIED_UNDEFINED_MIXTURE
-    changes: Classified as a plant-derived peptone/nutrient digest and left unmapped
-      pending product composition and source-specific ontology curation.
-    previous_status: UNMAPPED
-    new_status: UNMAPPED
-    llm_assisted: true
-  notes: Imported from mim-queue (source_id=mediadive.ingredient:1466); no CAS-RN
-    or CHEBI/NCIT match. Reviewed on 2026-05-11 as a plant-derived peptone/nutrient
-    digest pending product composition curation.
-  ingredient_type: UNDEFINED_MIXTURE
 - identifier: UNMAPPED_0098
   preferred_term: Sphagnum extract
   synonyms:
@@ -9817,9 +10035,15 @@ ingredients:
     action: AUTO_CLASSIFY_INGREDIENT_TYPE
     changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Broth')
     llm_assisted: false
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Imported from mim-queue (source_id=mediadive.ingredient:630); no CAS-RN or
     CHEBI/NCIT match. Curator review needed.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0533
   preferred_term: Steric solution
   synonyms:
@@ -10409,9 +10633,15 @@ ingredients:
     action: AUTO_CLASSIFY_INGREDIENT_TYPE
     changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Broth')
     llm_assisted: false
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Imported from mim-queue (source_id=mediadive.ingredient:1705); no CAS-RN
     or CHEBI/NCIT match. Curator review needed.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0545
   preferred_term: Tomato extract
   synonyms:
@@ -10681,9 +10911,15 @@ ingredients:
     action: AUTO_CLASSIFY_INGREDIENT_TYPE
     changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'soy')
     llm_assisted: false
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Imported from mim-queue (source_id=mediadive.ingredient:1617); no CAS-RN
     or CHEBI/NCIT match. Curator review needed.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0252
   preferred_term: Trypticase soy broth
   synonyms:
@@ -10707,35 +10943,15 @@ ingredients:
     action: AUTO_CLASSIFY_INGREDIENT_TYPE
     changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'soy')
     llm_assisted: false
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Imported from CultureBotHT (compounds_to_cas.csv (no CAS-RN)). No CAS-RN
     or CHEBI mapping available; curator review needed.
-  ingredient_type: UNDEFINED_MIXTURE
-- identifier: UNMAPPED_0558
-  preferred_term: Tryptone peptone
-  synonyms:
-  - synonym_text: Tryptone peptone
-    synonym_type: RAW_TEXT
-    source: mim-queue
-  mapping_status: UNMAPPED
-  occurrence_statistics:
-    total_occurrences: 0
-    media_count: 0
-  curation_history:
-  - timestamp: '2026-04-30T18:43:03.698454+00:00'
-    curator: audit_import_ingredients[mim-queue]
-    action: CREATED_AS_UNMAPPED
-    changes: Imported from mim-queue (source_id=mediadive.ingredient:164); no CAS-RN
-      or CHEBI/NCIT match. Curator review needed.
-    new_status: UNMAPPED
-    llm_assisted: false
-  - timestamp: '2026-05-02T03:12:19.985362+00:00'
-    curator: auto_classify_ingredient_type
-    action: AUTO_CLASSIFY_INGREDIENT_TYPE
-    changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Tryptone')
-    llm_assisted: false
-  notes: Imported from mim-queue (source_id=mediadive.ingredient:164); no CAS-RN or
-    CHEBI/NCIT match. Curator review needed.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0138
   preferred_term: Tryptone soya broth (Oxoid)
   synonyms:
@@ -10760,8 +10976,14 @@ ingredients:
     action: AUTO_CLASSIFY_INGREDIENT_TYPE
     changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Tryptone')
     llm_assisted: false
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Extracted from over-conflated Trypticase_Peptone.yaml synonyms
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0560
   preferred_term: Tryptose-phosphate
   synonyms:
@@ -10815,9 +11037,15 @@ ingredients:
     action: AUTO_CLASSIFY_INGREDIENT_TYPE
     changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'broth')
     llm_assisted: false
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Imported from mim-queue (source_id=mediadive.ingredient:2163); no CAS-RN
     or CHEBI/NCIT match. Curator review needed.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0255
   preferred_term: UW concentrated base
   synonyms:
@@ -10970,9 +11198,15 @@ ingredients:
     action: AUTO_CLASSIFY_INGREDIENT_TYPE
     changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'infusion')
     llm_assisted: false
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Imported from mim-queue (source_id=mediadive.ingredient:579); no CAS-RN or
     CHEBI/NCIT match. Curator review needed.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0204
   preferred_term: Vitafiber
   synonyms:
@@ -11419,9 +11653,15 @@ ingredients:
     action: AUTO_CLASSIFY_INGREDIENT_TYPE
     changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Broth')
     llm_assisted: false
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Imported from mim-queue (source_id=mediadive.ingredient:2093); no CAS-RN
     or CHEBI/NCIT match. Curator review needed.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0578
   preferred_term: Wilkins Chalgrene Anaerobe Broth
   synonyms:
@@ -11445,9 +11685,15 @@ ingredients:
     action: AUTO_CLASSIFY_INGREDIENT_TYPE
     changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'Broth')
     llm_assisted: false
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Imported from mim-queue (source_id=mediadive.ingredient:2140); no CAS-RN
     or CHEBI/NCIT match. Curator review needed.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0315
   preferred_term: Wolfe's mineral mix
   synonyms:
@@ -11656,9 +11902,15 @@ ingredients:
     action: AUTO_CLASSIFY_INGREDIENT_TYPE
     changes: set ingredient_type=UNDEFINED_MIXTURE (name matches complex pattern 'broth')
     llm_assisted: false
+  - timestamp: '2026-07-05T00:00:00+00:00'
+    curator: cbclaw_media_modeling_114
+    action: RECLASSIFY_INGREDIENT_TYPE
+    changes: 'ingredient_type UNDEFINED_MIXTURE -> DEFINED_MEDIUM: this is a complete
+      culture-medium/agar/broth formulation (a medium), not an ingredient-level mixture.'
+    llm_assisted: true
   notes: Imported from mim-queue (source_id=mediadive.ingredient:1683); no CAS-RN
     or CHEBI/NCIT match. Curator review needed.
-  ingredient_type: UNDEFINED_MIXTURE
+  ingredient_type: DEFINED_MEDIUM
 - identifier: UNMAPPED_0208
   preferred_term: Yacontrol (Yacon root syrup)
   synonyms:

--- a/data/ingredients/mapped/1-Kestose.yaml
+++ b/data/ingredients/mapped/1-Kestose.yaml
@@ -57,6 +57,15 @@ chemical_properties:
   inchi: InChI=1S/C18H32O16/c19-1-6-9(23)12(26)13(27)16(31-6)34-18(15(29)11(25)8(3-21)33-18)5-30-17(4-22)14(28)10(24)7(2-20)32-17/h6-16,19-29H,1-5H2/t6-,7-,8-,9-,10-,11-,12+,13-,14+,15+,16-,17-,18+/m1/s1
   smiles: OC[C@H]1O[C@@](CO)(OC[C@@]2(O[C@H]3O[C@H](CO)[C@@H](O)[C@H](O)[C@H]3O)O[C@H](CO)[C@@H](O)[C@@H]2O)[C@@H](O)[C@@H]1O
 ingredient_type: SINGLE_INGREDIENT
+nutritional_roles:
+- role: CARBON_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: 'Inferred from CHEBI ancestry: subclass/has_role of CHEBI:16646
+      (carbohydrate)'
+    curator_note: Provisional role inferred from CHEBI is_a/has_role closure; review
+      recommended.
 discussions:
 - discussion_id: kgscan-f77a72b7ddb7
   prompt: 'Knowledge gap for 1-Kestose: Background Lignocellulose represents a primary
@@ -98,12 +107,3 @@ discussions:
       remain unclear.
     explanation: Gap-signal sentence (unclear_unknown) from the cited abstract.
   posed_by: kg-microbe-kgscan
-nutritional_roles:
-- role: CARBON_SOURCE
-  confidence: 0.7
-  evidence:
-  - reference_type: COMPUTATIONAL_PREDICTION
-    reference_text: 'Inferred from CHEBI ancestry: subclass/has_role of CHEBI:16646
-      (carbohydrate)'
-    curator_note: Provisional role inferred from CHEBI is_a/has_role closure; review
-      recommended.

--- a/data/ingredients/mapped/1-Pentanol.yaml
+++ b/data/ingredients/mapped/1-Pentanol.yaml
@@ -50,30 +50,40 @@ chemical_properties:
 ingredient_type: SINGLE_INGREDIENT
 discussions:
 - discussion_id: kgscan-fedfdc7a75ff
-  prompt: 'Knowledge gap for 1-Pentanol: Current studies on the biodistribution, intracellular behavior, biodegradation, and clearance of diatom-based nanocarriers are inadequate and often lack systematic evaluation, leaving critical knowledge gaps.'
+  prompt: 'Knowledge gap for 1-Pentanol: Current studies on the biodistribution, intracellular
+    behavior, biodegradation, and clearance of diatom-based nanocarriers are inadequate
+    and often lack systematic evaluation, leaving critical knowledge gaps.'
   kind: KNOWLEDGE_GAP
   status: OPEN
-  rationale: 'Surfaced by the Europe PMC literature gap-signal scan (categories: explicit_gap, future_work, limitations_barriers, unclear_unknown). Curator review required: set attaches_to, refine the prompt, and weigh the cited evidence.'
+  rationale: 'Surfaced by the Europe PMC literature gap-signal scan (categories: explicit_gap,
+    future_work, limitations_barriers, unclear_unknown). Curator review required:
+    set attaches_to, refine the prompt, and weigh the cited evidence.'
   attaches_to: []
   evidence:
   - reference: PMID:42278216
     supports: NO_EVIDENCE
     evidence_source: abstract
-    snippet: Current studies on the biodistribution, intracellular behavior, biodegradation, and clearance of diatom-based nanocarriers are inadequate and often lack systematic evaluation, leaving critical knowledge gaps.
+    snippet: Current studies on the biodistribution, intracellular behavior, biodegradation,
+      and clearance of diatom-based nanocarriers are inadequate and often lack systematic
+      evaluation, leaving critical knowledge gaps.
     explanation: Gap-signal sentence (explicit_gap) from the cited abstract.
   - reference: PMID:42073201
     supports: NO_EVIDENCE
     evidence_source: abstract
-    snippet: However, the mechanisms of flavor formation remain unclear, which limits the process optimization of this technology.
+    snippet: However, the mechanisms of flavor formation remain unclear, which limits
+      the process optimization of this technology.
     explanation: Gap-signal sentence (unclear_unknown) from the cited abstract.
   - reference: PMID:42193735
     supports: NO_EVIDENCE
     evidence_source: abstract
-    snippet: Volatile organic compounds (VOCs) emitted by mushrooms may influence interactions with animal consumers, yet the roles of individual compounds and their mixtures remain poorly understood.
+    snippet: Volatile organic compounds (VOCs) emitted by mushrooms may influence
+      interactions with animal consumers, yet the roles of individual compounds and
+      their mixtures remain poorly understood.
     explanation: Gap-signal sentence (unclear_unknown) from the cited abstract.
   - reference: PMID:40946651
     supports: NO_EVIDENCE
     evidence_source: abstract
-    snippet: However, the changes and underlying mechanisms governing flavor compound deposition during this period remains unclear.
+    snippet: However, the changes and underlying mechanisms governing flavor compound
+      deposition during this period remains unclear.
     explanation: Gap-signal sentence (unclear_unknown) from the cited abstract.
   posed_by: kg-microbe-kgscan

--- a/data/ingredients/mapped/1-aminocyclopropane-1-carboxylate.yaml
+++ b/data/ingredients/mapped/1-aminocyclopropane-1-carboxylate.yaml
@@ -60,6 +60,15 @@ chemical_properties:
   inchi: InChI=1S/C4H7NO2/c5-4(1-2-4)3(6)7/h1-2,5H2,(H,6,7)
   smiles: NC1(C(=O)O)CC1
 ingredient_type: SINGLE_INGREDIENT
+nutritional_roles:
+- role: AMINO_ACID_SOURCE
+  confidence: 0.7
+  evidence:
+  - reference_type: COMPUTATIONAL_PREDICTION
+    reference_text: 'Inferred from CHEBI ancestry: subclass/has_role of CHEBI:33709
+      (amino acid)'
+    curator_note: Provisional role inferred from CHEBI is_a/has_role closure; review
+      recommended.
 discussions:
 - discussion_id: kgscan-afcc7416ff5f
   prompt: 'Knowledge gap for 1-aminocyclopropane-1-carboxylate: This systematic review
@@ -102,12 +111,3 @@ discussions:
       demanding more efficient strategies to secure food production.
     explanation: Gap-signal sentence (limitations_barriers) from the cited abstract.
   posed_by: kg-microbe-kgscan
-nutritional_roles:
-- role: AMINO_ACID_SOURCE
-  confidence: 0.7
-  evidence:
-  - reference_type: COMPUTATIONAL_PREDICTION
-    reference_text: 'Inferred from CHEBI ancestry: subclass/has_role of CHEBI:33709
-      (amino acid)'
-    curator_note: Provisional role inferred from CHEBI is_a/has_role closure; review
-      recommended.

--- a/data/ingredients/mapped/1-ethyl-3-methylimidazolium_Acetate.yaml
+++ b/data/ingredients/mapped/1-ethyl-3-methylimidazolium_Acetate.yaml
@@ -62,30 +62,41 @@ chemical_properties:
 ingredient_type: SINGLE_INGREDIENT
 discussions:
 - discussion_id: kgscan-7872af433046
-  prompt: 'Knowledge gap for 1-ethyl-3-methylimidazolium acetate: Ionic liquids (ILs) have been used to replace organic solvents, thereby causing challenges for wastewater treatment.'
+  prompt: 'Knowledge gap for 1-ethyl-3-methylimidazolium acetate: Ionic liquids (ILs)
+    have been used to replace organic solvents, thereby causing challenges for wastewater
+    treatment.'
   kind: KNOWLEDGE_GAP
   status: OPEN
-  rationale: 'Surfaced by the Europe PMC literature gap-signal scan (categories: future_work, limitations_barriers, unclear_unknown). Curator review required: set attaches_to, refine the prompt, and weigh the cited evidence.'
+  rationale: 'Surfaced by the Europe PMC literature gap-signal scan (categories: future_work,
+    limitations_barriers, unclear_unknown). Curator review required: set attaches_to,
+    refine the prompt, and weigh the cited evidence.'
   attaches_to: []
   evidence:
   - reference: PMID:41015306
     supports: NO_EVIDENCE
     evidence_source: abstract
-    snippet: Ionic liquids (ILs) have been used to replace organic solvents, thereby causing challenges for wastewater treatment.
+    snippet: Ionic liquids (ILs) have been used to replace organic solvents, thereby
+      causing challenges for wastewater treatment.
     explanation: Gap-signal sentence (limitations_barriers) from the cited abstract.
   - reference: PMID:40666722
     supports: NO_EVIDENCE
     evidence_source: abstract
-    snippet: By focusing on the deconstruction and reassembly of nonedible agro-wastes, these methods address critical challenges such as resource competition, plastic pollution, and greenhouse gas emissions.
+    snippet: By focusing on the deconstruction and reassembly of nonedible agro-wastes,
+      these methods address critical challenges such as resource competition, plastic
+      pollution, and greenhouse gas emissions.
     explanation: Gap-signal sentence (limitations_barriers) from the cited abstract.
   - reference: PMID:42195639
     supports: NO_EVIDENCE
     evidence_source: abstract
-    snippet: These inherent structural complexities present significant challenges for its efficient isolation and precise transformation.
+    snippet: These inherent structural complexities present significant challenges
+      for its efficient isolation and precise transformation.
     explanation: Gap-signal sentence (limitations_barriers) from the cited abstract.
   - reference: PMID:40649189
     supports: NO_EVIDENCE
     evidence_source: abstract
-    snippet: However, challenges related to large-scale production, functionalization, regulatory frameworks, and safety concerns persist, necessitating further research and innovation.
-    explanation: Gap-signal sentence (future_work, limitations_barriers) from the cited abstract.
+    snippet: However, challenges related to large-scale production, functionalization,
+      regulatory frameworks, and safety concerns persist, necessitating further research
+      and innovation.
+    explanation: Gap-signal sentence (future_work, limitations_barriers) from the
+      cited abstract.
   posed_by: kg-microbe-kgscan

--- a/data/ingredients/mapped/1-naphtylacetic_Acid.yaml
+++ b/data/ingredients/mapped/1-naphtylacetic_Acid.yaml
@@ -62,30 +62,38 @@ notes: Imported from mim-queue (source_id=mediadive.ingredient:2436). Identity r
 ingredient_type: SINGLE_INGREDIENT
 discussions:
 - discussion_id: kgscan-546f113a807c
-  prompt: 'Knowledge gap for 1-Naphtylacetic Acid: Despite their commercial popularity, numerous research gaps have limited the expansion of fundamental research and dogwood breeding programs.'
+  prompt: 'Knowledge gap for 1-Naphtylacetic Acid: Despite their commercial popularity,
+    numerous research gaps have limited the expansion of fundamental research and
+    dogwood breeding programs.'
   kind: KNOWLEDGE_GAP
   status: OPEN
-  rationale: 'Surfaced by the Europe PMC literature gap-signal scan (categories: explicit_gap, future_work, limitations_barriers, unclear_unknown). Curator review required: set attaches_to, refine the prompt, and weigh the cited evidence.'
+  rationale: 'Surfaced by the Europe PMC literature gap-signal scan (categories: explicit_gap,
+    future_work, limitations_barriers, unclear_unknown). Curator review required:
+    set attaches_to, refine the prompt, and weigh the cited evidence.'
   attaches_to: []
   evidence:
   - reference: PMID:41695534
     supports: NO_EVIDENCE
     evidence_source: abstract
-    snippet: Despite their commercial popularity, numerous research gaps have limited the expansion of fundamental research and dogwood breeding programs.
+    snippet: Despite their commercial popularity, numerous research gaps have limited
+      the expansion of fundamental research and dogwood breeding programs.
     explanation: Gap-signal sentence (explicit_gap) from the cited abstract.
   - reference: PMID:40634860
     supports: NO_EVIDENCE
     evidence_source: abstract
-    snippet: Due to their heterogeneity and polygenic nature, the metabolic pathways and biological mechanisms underlying these conditions remain elusive.
+    snippet: Due to their heterogeneity and polygenic nature, the metabolic pathways
+      and biological mechanisms underlying these conditions remain elusive.
     explanation: Gap-signal sentence (unclear_unknown) from the cited abstract.
   - reference: PMID:40587842
     supports: NO_EVIDENCE
     evidence_source: abstract
-    snippet: However, the specific mechanisms by which gut bacteria and their metabolites exert therapeutic effects in melanoma remain poorly understood.
+    snippet: However, the specific mechanisms by which gut bacteria and their metabolites
+      exert therapeutic effects in melanoma remain poorly understood.
     explanation: Gap-signal sentence (unclear_unknown) from the cited abstract.
   - reference: PMID:40110012
     supports: NO_EVIDENCE
     evidence_source: abstract
-    snippet: Despite extensive research, the exact causes and optimal treatment approaches for depression remain unclear.
+    snippet: Despite extensive research, the exact causes and optimal treatment approaches
+      for depression remain unclear.
     explanation: Gap-signal sentence (unclear_unknown) from the cited abstract.
   posed_by: kg-microbe-kgscan

--- a/data/ingredients/mapped/1-octen-3-ol.yaml
+++ b/data/ingredients/mapped/1-octen-3-ol.yaml
@@ -50,30 +50,40 @@ chemical_properties:
 ingredient_type: SINGLE_INGREDIENT
 discussions:
 - discussion_id: kgscan-ca9d598a165f
-  prompt: 'Knowledge gap for 1-octen-3-ol: The use of plant-based proteins is a promising route, but it also comes with challenges: Plant-based proteins often contain antinutritional factors and off-flavors, which can negatively impact consumer acceptance.'
+  prompt: 'Knowledge gap for 1-octen-3-ol: The use of plant-based proteins is a promising
+    route, but it also comes with challenges: Plant-based proteins often contain antinutritional
+    factors and off-flavors, which can negatively impact consumer acceptance.'
   kind: KNOWLEDGE_GAP
   status: OPEN
-  rationale: 'Surfaced by the Europe PMC literature gap-signal scan (categories: explicit_gap, future_work, limitations_barriers, unclear_unknown). Curator review required: set attaches_to, refine the prompt, and weigh the cited evidence.'
+  rationale: 'Surfaced by the Europe PMC literature gap-signal scan (categories: explicit_gap,
+    future_work, limitations_barriers, unclear_unknown). Curator review required:
+    set attaches_to, refine the prompt, and weigh the cited evidence.'
   attaches_to: []
   evidence:
   - reference: PMID:41918190
     supports: NO_EVIDENCE
     evidence_source: abstract
-    snippet: 'The use of plant-based proteins is a promising route, but it also comes with challenges: Plant-based proteins often contain antinutritional factors and off-flavors, which can negatively impact consumer acceptance.'
+    snippet: 'The use of plant-based proteins is a promising route, but it also comes
+      with challenges: Plant-based proteins often contain antinutritional factors
+      and off-flavors, which can negatively impact consumer acceptance.'
     explanation: Gap-signal sentence (limitations_barriers) from the cited abstract.
   - reference: PMID:41098762
     supports: NO_EVIDENCE
     evidence_source: abstract
-    snippet: The correlation between flavor profiles and microbial communities in Jiang-shui, a traditional fermented vegetable product from Northwest China, remains incompletely understood.
+    snippet: The correlation between flavor profiles and microbial communities in
+      Jiang-shui, a traditional fermented vegetable product from Northwest China,
+      remains incompletely understood.
     explanation: Gap-signal sentence (unclear_unknown) from the cited abstract.
   - reference: PMID:41745288
     supports: NO_EVIDENCE
     evidence_source: abstract
-    snippet: It also identifies existing research gaps and prospects for future research directions.
+    snippet: It also identifies existing research gaps and prospects for future research
+      directions.
     explanation: Gap-signal sentence (explicit_gap, future_work) from the cited abstract.
   - reference: PMID:41815431
     supports: NO_EVIDENCE
     evidence_source: abstract
-    snippet: However, the information regarding the molecular mechanisms involved in mycorrhizal VOCs signaling and their effect on plants remains still elusive.
+    snippet: However, the information regarding the molecular mechanisms involved
+      in mycorrhizal VOCs signaling and their effect on plants remains still elusive.
     explanation: Gap-signal sentence (unclear_unknown) from the cited abstract.
   posed_by: kg-microbe-kgscan

--- a/data/ingredients/mapped/112-trichloroethane.yaml
+++ b/data/ingredients/mapped/112-trichloroethane.yaml
@@ -79,30 +79,40 @@ chemical_properties:
 ingredient_type: SINGLE_INGREDIENT
 discussions:
 - discussion_id: kgscan-47348d9115e1
-  prompt: 'Knowledge gap for 1,1,2-Trichloroethane: Organohalide-respiring bacteria (OHRB) are globally distributed, yet their ecological roles in marine environments remain poorly understood, with few isolates characterized from these systems.'
+  prompt: 'Knowledge gap for 1,1,2-Trichloroethane: Organohalide-respiring bacteria
+    (OHRB) are globally distributed, yet their ecological roles in marine environments
+    remain poorly understood, with few isolates characterized from these systems.'
   kind: KNOWLEDGE_GAP
   status: OPEN
-  rationale: 'Surfaced by the Europe PMC literature gap-signal scan (categories: limitations_barriers, unclear_unknown). Curator review required: set attaches_to, refine the prompt, and weigh the cited evidence.'
+  rationale: 'Surfaced by the Europe PMC literature gap-signal scan (categories: limitations_barriers,
+    unclear_unknown). Curator review required: set attaches_to, refine the prompt,
+    and weigh the cited evidence.'
   attaches_to: []
   evidence:
   - reference: PMID:42227946
     supports: NO_EVIDENCE
     evidence_source: abstract
-    snippet: Organohalide-respiring bacteria (OHRB) are globally distributed, yet their ecological roles in marine environments remain poorly understood, with few isolates characterized from these systems.
+    snippet: Organohalide-respiring bacteria (OHRB) are globally distributed, yet
+      their ecological roles in marine environments remain poorly understood, with
+      few isolates characterized from these systems.
     explanation: Gap-signal sentence (unclear_unknown) from the cited abstract.
   - reference: PMID:40209987
     supports: NO_EVIDENCE
     evidence_source: abstract
-    snippet: However, the heterogeneity of the aquifer environment may affect the dechlorination efficiency of the coupled systems, and the underlying mechanisms remain unclear.
+    snippet: However, the heterogeneity of the aquifer environment may affect the
+      dechlorination efficiency of the coupled systems, and the underlying mechanisms
+      remain unclear.
     explanation: Gap-signal sentence (unclear_unknown) from the cited abstract.
   - reference: DOI:10.1101/2024.07.29.605694
     supports: NO_EVIDENCE
     evidence_source: abstract
-    snippet: How these specific sequence variations influence activity is largely unknown.
+    snippet: How these specific sequence variations influence activity is largely
+      unknown.
     explanation: Gap-signal sentence (unclear_unknown) from the cited abstract.
   - reference: PMID:41454413
     supports: NO_EVIDENCE
     evidence_source: abstract
-    snippet: This review evaluates the prospects and limitations of using neuropeptides and their synthetic analogues as bioinsecticides.
+    snippet: This review evaluates the prospects and limitations of using neuropeptides
+      and their synthetic analogues as bioinsecticides.
     explanation: Gap-signal sentence (limitations_barriers) from the cited abstract.
   posed_by: kg-microbe-kgscan

--- a/data/ingredients/mapped/12-Propanediol.yaml
+++ b/data/ingredients/mapped/12-Propanediol.yaml
@@ -50,30 +50,45 @@ chemical_properties:
 ingredient_type: SINGLE_INGREDIENT
 discussions:
 - discussion_id: kgscan-2db2ffbbe7ca
-  prompt: 'Knowledge gap for 1,2-Propanediol: By integrating data from experimental models, clinical studies, and translational research, the review identifies areas of consensus, ongoing controversy, and major knowledge gaps in IBD pathophysiology and clinical practice.'
+  prompt: 'Knowledge gap for 1,2-Propanediol: By integrating data from experimental
+    models, clinical studies, and translational research, the review identifies areas
+    of consensus, ongoing controversy, and major knowledge gaps in IBD pathophysiology
+    and clinical practice.'
   kind: KNOWLEDGE_GAP
   status: OPEN
-  rationale: 'Surfaced by the Europe PMC literature gap-signal scan (categories: controversy_conflict, explicit_gap, future_work, limitations_barriers, unclear_unknown). Curator review required: set attaches_to, refine the prompt, and weigh the cited evidence.'
+  rationale: 'Surfaced by the Europe PMC literature gap-signal scan (categories: controversy_conflict,
+    explicit_gap, future_work, limitations_barriers, unclear_unknown). Curator review
+    required: set attaches_to, refine the prompt, and weigh the cited evidence.'
   attaches_to: []
   evidence:
   - reference: PMID:42198674
     supports: NO_EVIDENCE
     evidence_source: abstract
-    snippet: By integrating data from experimental models, clinical studies, and translational research, the review identifies areas of consensus, ongoing controversy, and major knowledge gaps in IBD pathophysiology and clinical practice.
-    explanation: Gap-signal sentence (explicit_gap, controversy_conflict) from the cited abstract.
+    snippet: By integrating data from experimental models, clinical studies, and translational
+      research, the review identifies areas of consensus, ongoing controversy, and
+      major knowledge gaps in IBD pathophysiology and clinical practice.
+    explanation: Gap-signal sentence (explicit_gap, controversy_conflict) from the
+      cited abstract.
   - reference: PMID:41191190
     supports: NO_EVIDENCE
     evidence_source: abstract
-    snippet: Despite the remarkable progress in biopropanol production technology, it still faces numerous challenges, including the low production efficiency of natural microorganisms, the strong inhibitory effect of the product, and poor substrate conversion rates.
+    snippet: Despite the remarkable progress in biopropanol production technology,
+      it still faces numerous challenges, including the low production efficiency
+      of natural microorganisms, the strong inhibitory effect of the product, and
+      poor substrate conversion rates.
     explanation: Gap-signal sentence (limitations_barriers) from the cited abstract.
   - reference: PMID:41715897
     supports: NO_EVIDENCE
     evidence_source: abstract
-    snippet: Despite their recognized importance, the molecular strategies through which HMOs govern microbial competition and niche establishment remain poorly understood.
+    snippet: Despite their recognized importance, the molecular strategies through
+      which HMOs govern microbial competition and niche establishment remain poorly
+      understood.
     explanation: Gap-signal sentence (unclear_unknown) from the cited abstract.
   - reference: PMID:42149637
     supports: NO_EVIDENCE
     evidence_source: abstract
-    snippet: However, the fitness costs imposed by multidrug-resistant (MDR) IncHI2 plasmids across different serovars and the underlying mechanisms remain poorly understood.
+    snippet: However, the fitness costs imposed by multidrug-resistant (MDR) IncHI2
+      plasmids across different serovars and the underlying mechanisms remain poorly
+      understood.
     explanation: Gap-signal sentence (unclear_unknown) from the cited abstract.
   posed_by: kg-microbe-kgscan

--- a/data/ingredients/mapped/Carnitine_Hydrochloride.yaml
+++ b/data/ingredients/mapped/Carnitine_Hydrochloride.yaml
@@ -8,12 +8,11 @@ ontology_mapping:
   evidence:
   - evidence_type: CURATOR_JUDGMENT
     source: cbclaw_followups_114
-    notes: 'Corrected mis-mapping: auto-created from CultureBotHT CAS-RN 461-05-2, which
-      in ChEBI genuinely resolves to CHEBI:48601 (carnitinamide chloride — the amide,
-      C7H17N2O2·Cl), not carnitine. Remapped to the carnitine parent CHEBI:17126 as a
-      NARROW_MATCH (salt/hydrochloride -> parent), mirroring sibling
-      Carnitine_Dl_Hydrochloride. Erroneous cas_rn 461-05-2 and amide chemistry backfill
-      removed.'
+    notes: 'Corrected mis-mapping: auto-created from CultureBotHT CAS-RN 461-05-2,
+      which in ChEBI genuinely resolves to CHEBI:48601 (carnitinamide chloride — the
+      amide, C7H17N2O2·Cl), not carnitine. Remapped to the carnitine parent CHEBI:17126
+      as a NARROW_MATCH (salt/hydrochloride -> parent), mirroring sibling Carnitine_Dl_Hydrochloride.
+      Erroneous cas_rn 461-05-2 and amide chemistry backfill removed.'
 synonyms:
 - synonym_text: 4-amino-2-hydroxy-N,N,N-trimethyl-4-oxobutan-1-aminium chloride
   synonym_type: EXACT_SYNONYM
@@ -50,17 +49,17 @@ curation_history:
 - timestamp: '2026-07-05T00:00:00+00:00'
   curator: cbclaw_followups_114
   action: CORRECTED
-  changes: 'ontology_id CHEBI:48601 (carnitinamide chloride, the amide) -> CHEBI:17126
+  changes: ontology_id CHEBI:48601 (carnitinamide chloride, the amide) -> CHEBI:17126
     (carnitine), NARROW_MATCH (salt -> parent), mirroring Carnitine_Dl_Hydrochloride;
-    identifier CHEBI:48601 -> kgmicrobe.compound:carnitine_hydrochloride; removed erroneous
-    cas_rn 461-05-2 and amide chemistry backfill (molecular_formula/inchi/smiles).'
+    identifier CHEBI:48601 -> kgmicrobe.compound:carnitine_hydrochloride; removed
+    erroneous cas_rn 461-05-2 and amide chemistry backfill (molecular_formula/inchi/smiles).
   llm_assisted: true
 - timestamp: '2026-07-05T00:00:00+00:00'
   curator: cbclaw_dedup_review_114
   action: DEDUP_REVIEWED
-  changes: 'Reviewed for duplication vs Carnitine (Dl) Hydrochloride (cas:461-06-3). Decision:
-    NOT merged - distinct name surface-forms (stereo-unspecified "Carnitine Hydrochloride"
-    from CultureBotHT vs racemic "DL"); both correctly map to the stereo-unspecified parent
-    CHEBI:17126 (carnitine). MIM keeps one record per surface-form.'
+  changes: 'Reviewed for duplication vs Carnitine (Dl) Hydrochloride (cas:461-06-3).
+    Decision: NOT merged - distinct name surface-forms (stereo-unspecified "Carnitine
+    Hydrochloride" from CultureBotHT vs racemic "DL"); both correctly map to the stereo-unspecified
+    parent CHEBI:17126 (carnitine). MIM keeps one record per surface-form.'
   llm_assisted: true
 ingredient_type: SINGLE_INGREDIENT

--- a/data/ingredients/mapped/Gepotidacin.yaml
+++ b/data/ingredients/mapped/Gepotidacin.yaml
@@ -13,8 +13,7 @@ ontology_mapping:
       cas:1075236-89-3); CHEBI label 'gepotidacin' is label-exact with the ingredient.
   - evidence_type: DATABASE_MATCH
     source: NCIT via OLS (label-exact)
-    notes: Prior narrow parent NCIT:C170025 (superseded by exact CHEBI primary);
-      matched_via='Gepotidacin'
+    notes: Prior narrow parent NCIT:C170025 (superseded by exact CHEBI primary); matched_via='Gepotidacin'
 synonyms: []
 mapping_status: MAPPED
 occurrence_statistics:
@@ -52,8 +51,8 @@ curation_history:
 - timestamp: '2026-07-05T10:06:57.852475+00:00'
   curator: cbclaw_chebi_grounding_tier2
   action: AUTO_GROUND_TO_CHEBI
-  changes: 'primary cas:1075236-89-3 → CHEBI:747127 (gepotidacin) via unique CAS-RN→CHEBI
-    dbxref match (skos:exactMatch); prior NCIT:C170025 narrow parent superseded.'
+  changes: primary cas:1075236-89-3 → CHEBI:747127 (gepotidacin) via unique CAS-RN→CHEBI
+    dbxref match (skos:exactMatch); prior NCIT:C170025 narrow parent superseded.
   new_status: MAPPED
   llm_assisted: false
 chemical_properties:

--- a/data/ingredients/mapped/Tryptone_Peptone.yaml
+++ b/data/ingredients/mapped/Tryptone_Peptone.yaml
@@ -8,8 +8,8 @@ ontology_mapping:
   evidence:
   - evidence_type: CURATOR_JUDGMENT
     source: cbclaw_followups_114
-    notes: Tryptone peptone is a pancreatic (tryptic) digest of casein; mapped to the
-      precise MICRO term MICRO:0000182 (tryptone), mirroring sibling records Tryptone
+    notes: Tryptone peptone is a pancreatic (tryptic) digest of casein; mapped to
+      the precise MICRO term MICRO:0000182 (tryptone), mirroring sibling records Tryptone
       and Bacto-tryptone.
 synonyms:
 - synonym_text: Tryptone peptone

--- a/data/ingredients/mapped/cholesterol.yaml
+++ b/data/ingredients/mapped/cholesterol.yaml
@@ -10,8 +10,8 @@ ontology_mapping:
     source: PubChem
     cas_rn: 57-88-5
     notes: 'Corrected mis-mapping: CAS-RN 57-88-5 (cholesterol) had resolved to the
-      deuterated isotopologue CHEBI:140435 (cholesterol-2,2,3,4,4,6-d6); remapped to
-      CHEBI:16113 (cholesterol). EXACT_MATCH.'
+      deuterated isotopologue CHEBI:140435 (cholesterol-2,2,3,4,4,6-d6); remapped
+      to CHEBI:16113 (cholesterol). EXACT_MATCH.'
 synonyms:
 - synonym_text: (3beta,14beta,17alpha)-cholest-5-en-3-ol
   synonym_type: EXACT_SYNONYM
@@ -61,9 +61,10 @@ curation_history:
 - timestamp: '2026-07-05T00:00:00+00:00'
   curator: cbclaw_followups_114
   action: CORRECTED
-  changes: 'ontology_id CHEBI:140435 (cholesterol-2,2,3,4,4,6-d6, deuterated isotopologue)
+  changes: ontology_id CHEBI:140435 (cholesterol-2,2,3,4,4,6-d6, deuterated isotopologue)
     -> CHEBI:16113 (cholesterol); mapping_quality CAS_RN_LOOKUP -> EXACT_MATCH; molecular_formula
-    C33H58O -> C27H46O; cleared deuterated inchi/smiles for backfill. CAS 57-88-5 retained.'
+    C33H58O -> C27H46O; cleared deuterated inchi/smiles for backfill. CAS 57-88-5
+    retained.
   llm_assisted: true
 notes: Created from FEBA ontology enrichment workflow. Used in 1 FEBA media formulations.
 chemical_properties:

--- a/history/infrastructure/roundtrip-gate/2026-08-02T073659Z-claude-code-eb4051.yaml
+++ b/history/infrastructure/roundtrip-gate/2026-08-02T073659Z-claude-code-eb4051.yaml
@@ -1,0 +1,41 @@
+history_version: 1
+target:
+  kind: infrastructure
+  path: .github/workflows/qc-roundtrip.yaml
+  slug: roundtrip-gate
+session:
+  id: 2026-08-02T073659Z-claude-code-eb4051
+  timestamp: '2026-08-02T07:36:59Z'
+  actors:
+  - type: ai_agent
+    name: claude-code
+    model: claude-fable-5
+    agent_tool: claude-code
+links:
+  issues:
+  - https://github.com/CultureBotAI/MediaIngredientMech/issues/148
+events:
+- type: CREATE
+  outcome: changed
+  sections:
+  - justfile
+  - ci
+  - scripts
+  summary: Add a blocking curated<->per-record round-trip gate so the drift cannot recur
+  details: 'scripts/verify_roundtrip.py already existed and already exited 1 on mismatch;
+    it was never wired into CI, and its default --aggregated-dir points at the committed data/collections/
+    artifact, last regenerated 2026-03-06. So the check kept passing while 55 curation events
+    sat unreconciled. Comparing against a committed copy is the trap. Added: ''just qc-roundtrip''
+    (now part of the qc composite) and .github/workflows/qc-roundtrip.yaml, both of which
+    aggregate into a mktemp/RUNNER_TEMP directory so there is nothing stale to compare against;
+    the workflow additionally asserts that export-individual produces no diff, which catches
+    added or removed files as well as content drift. verify_roundtrip.py gained --ignore-fields
+    defaulting to ''discussions'' (authored per-record by claw kgscan and deliberately absent
+    from the collection, so comparing it would report a permanent expected difference and
+    make the gate useless), and its comparison loop no longer breaks after the first mismatch
+    per file, collecting up to 25 - as a gate, a one-at-a-time drip turns one fix into many
+    CI rounds. VERIFIED THE GATE FAILS, not just passes: stashing data/curated back to its
+    pre-fix state exits 1; and injecting a single-field change with record counts left unchanged
+    (BCYE agar -> UNDEFINED_MIXTURE) is caught and pinpointed to UNMAPPED_0113, confirming
+    the subtle field-level path works and not only the count check. Full ''just qc'' passes
+    on the reconciled tree.'

--- a/history/other/curated-collection-reconciliation/2026-08-02T073645Z-claude-code-81e34c.yaml
+++ b/history/other/curated-collection-reconciliation/2026-08-02T073645Z-claude-code-81e34c.yaml
@@ -1,0 +1,52 @@
+history_version: 1
+target:
+  kind: other
+  path: data/curated/unmapped_ingredients.yaml
+  slug: curated-collection-reconciliation
+session:
+  id: 2026-08-02T073645Z-claude-code-81e34c
+  timestamp: '2026-08-02T07:36:45Z'
+  actors:
+  - type: ai_agent
+    name: claude-code
+    model: claude-fable-5
+    agent_tool: claude-code
+links:
+  issues:
+  - https://github.com/CultureBotAI/MediaIngredientMech/issues/148
+events:
+- type: EDIT
+  outcome: changed
+  sections:
+  - ingredient_type
+  - curation_history
+  - notes
+  - headers
+  summary: Reconcile data/curated with the per-record corpus; validate the 53 media reclassifications
+  details: 'PR #116''s media reclassification was written directly into per-record files and
+    never reached data/curated/. Because export_individual_records.py projects the collection
+    over the per-record tree, every ''just export-individual'' reverted it: 53 RECLASSIFY_INGREDIENT_TYPE
+    (UNDEFINED_MIXTURE -> DEFINED_MEDIUM) and 2 FLAGGED_NON_INGREDIENT events plus their curation_history
+    entries. promote_resolved_unmapped.py calls export-individual, so any promotion reverted
+    all 55 silently. Root cause: aggregate_records.py defaults --output-dir to data/collections/,
+    which no consumer reads (grep shows the only references anywhere are the aggregator''s
+    own default and verify_roundtrip.py''s), so per-record edits had no path back to the export
+    source. Applied surgically, preserving record and key order and touching only drifted
+    fields, rather than by wholesale re-aggregation: 55 unmapped records gained ingredient_type/curation_history/notes;
+    3 orphan entries dropped (UNMAPPED_0488 Phytone, UNMAPPED_0531 Soya pepton, UNMAPPED_0558
+    Tryptone peptone, all already promoted into data/ingredients/mapped as FOODON:03315720
+    / FOODON:03315720 / MICRO:0000182); headers recomputed, mapped now honestly reporting
+    1877 MAPPED + 2 non-MAPPED against total 1879. discussions deliberately NOT copied into
+    the collection (per-record-authored by claw kgscan). Also normalised 12 per-record files
+    that re-export rewrites (line wrapping and scalar quoting only) - verified semantically
+    identical by parsing both sides and stable across three consecutive exports, making the
+    corpus a fixed point; export-individual is now a true no-op. VALIDATION of the 53 reclassifications
+    before making them canonical: all are named standard culture media, and Marine broth 2216
+    and Oatmeal agar appear verbatim in the schema''s own DEFINED_MEDIUM examples. MediaDive
+    REST (/rest/ingredient/{id}) confirms the 8 contested ''Base'' products carry no formula,
+    CAS-RN or ChEBI, i.e. formulations not chemicals. Three independent Edison/PaperQA3 literature
+    runs on the hardest cases - Blood Agar Base (incomplete base), Soil+Seawater Medium (natural-substrate,
+    genuinely variable components), Leptospira Medium Base EMJH (supplement-dependent base)
+    - each independently confirmed retaining DEFINED_MEDIUM. All three also independently
+    warned that DEFINED_MEDIUM reads as ''chemically defined'', a term of art meaning the
+    opposite of these complex-digest media; filed as a separate schema-clarity finding.'

--- a/history/other/curated-collection-reconciliation/2026-08-02T075816Z-claude-code-d01a8a.yaml
+++ b/history/other/curated-collection-reconciliation/2026-08-02T075816Z-claude-code-d01a8a.yaml
@@ -1,0 +1,35 @@
+history_version: 1
+target:
+  kind: other
+  path: data/curated/unmapped_ingredients.yaml
+  slug: curated-collection-reconciliation
+session:
+  id: 2026-08-02T075816Z-claude-code-d01a8a
+  timestamp: '2026-08-02T07:58:16Z'
+  actors:
+  - type: ai_agent
+    name: claude-code
+    model: claude-fable-5
+    agent_tool: claude-code
+links:
+  issues:
+  - https://github.com/CultureBotAI/MediaIngredientMech/issues/148
+events:
+- type: REVIEW
+  outcome: changed
+  sections:
+  - evidence
+  summary: 'Correction to record 2026-08-02T073645Z-claude-code-81e34c: Marine broth 2216
+    is not a verbatim schema example'
+  details: 'Corrects an overstatement in history/other/curated-collection-reconciliation/2026-08-02T073645Z-claude-code-81e34c.yaml,
+    which is append-only and therefore left unedited. That record stated that ''Marine broth
+    2216 and Oatmeal agar appear verbatim in the schema''s own DEFINED_MEDIUM examples''.
+    Only ''Oatmeal agar'' is verbatim. The schema (src/mediaingredientmech/schema/mediaingredientmech.yaml,
+    IngredientTypeEnum.DEFINED_MEDIUM) reads ''(e.g., R2A agar, LB broth, Marine agar 2216,
+    Oatmeal agar)'' — Marine *agar* 2216. The MIM record is UNMAPPED_0434 ''Marine broth 2216'',
+    the broth counterpart of the same DSMZ 2216 formulation (solidified or not), so it is
+    a near-match supporting the same conclusion, but it is not a verbatim example and should
+    not have been offered as one. Caught by an adversarial review of PR #167. The conclusion
+    it supported is unaffected: the 53 reclassifications remain validated by the schema description,
+    by MediaDive REST for the 8 contested Base products, and by three independent Edison/PaperQA3
+    runs. Corrected in NEXT_TASKS.md and the PR body in the same session.'

--- a/justfile
+++ b/justfile
@@ -179,7 +179,23 @@ report-label-drift:
 # `just validate-products` locally to reproduce the gate; `just report-label-drift`
 # writes the full drift TSV. Engine A (`just validate-terms-all`) is a local-only
 # LinkML cross-check (one validator process per record → too slow for CI).
-qc: validate-all validate-strict qc-evidence qc-sssom
+qc: validate-all validate-strict qc-evidence qc-sssom qc-roundtrip
+
+# Assert data/curated/ and data/ingredients/ still agree, so a per-record edit
+# cannot be silently reverted by the next `just export-individual` (which
+# projects the collection over the per-record tree). Aggregates into a temp dir
+# rather than data/collections/ -- comparing against that committed artifact is
+# what let this drift for months: it was last regenerated in March 2026, so the
+# check passed while 55 curation events sat unreconciled. (CI blocking.)
+qc-roundtrip:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    tmp="$(mktemp -d)"
+    trap 'rm -rf "$tmp"' EXIT
+    uv run python scripts/aggregate_records.py \
+        --ingredients-dir data/ingredients --output-dir "$tmp" >/dev/null
+    uv run python scripts/verify_roundtrip.py \
+        --original-dir data/curated --aggregated-dir "$tmp"
 
 # Render per-ingredient HTML detail pages from data/ingredients/*.yaml
 # into pages/ingredient/. Idempotent (skips fresh outputs); --force

--- a/justfile
+++ b/justfile
@@ -192,10 +192,42 @@ qc-roundtrip:
     set -euo pipefail
     tmp="$(mktemp -d)"
     trap 'rm -rf "$tmp"' EXIT
+    # Aggregate diagnostics are NOT discarded: aggregate_records.py skips a
+    # per-record file it cannot load and still exits 0, so silencing it turns a
+    # corrupt YAML into a bare "ingredient count mismatch" with no cause.
     uv run python scripts/aggregate_records.py \
-        --ingredients-dir data/ingredients --output-dir "$tmp" >/dev/null
+        --ingredients-dir data/ingredients --output-dir "$tmp"
     uv run python scripts/verify_roundtrip.py \
         --original-dir data/curated --aggregated-dir "$tmp"
+    # Same byte-level assertion CI makes, so `just qc` green means CI green.
+    # Without this the recipe misses serialization drift (key order, quoting,
+    # line wrapping) that fails the workflow.
+    uv run python scripts/export_individual_records.py \
+        --input-dir data/curated --output-dir data/ingredients
+    if [ -n "$(git status --porcelain -- data/ingredients)" ]; then
+      echo "error: export-individual changed data/ingredients — the per-record tree" >&2
+      echo "is not a clean projection of data/curated/. Run 'just sync-curated' if the" >&2
+      echo "per-record files are the ones you meant to keep." >&2
+      git status --porcelain -- data/ingredients >&2
+      exit 1
+    fi
+
+# Write the per-record tree BACK into data/curated/ — the missing half of the
+# round trip, and the remediation when `qc-roundtrip` goes red because a script
+# edited data/ingredients/ directly (apply-role-research-results does exactly
+# this). Note `aggregate-collections` is NOT this: it writes data/collections/,
+# which nothing reads, and `sync-individual` runs export FIRST, destroying the
+# per-record edits before aggregating.
+#
+# Expect a LARGE diff even when content is unchanged: the aggregator emits
+# records in filename order, which is not the collection's historical order.
+# Nothing depends on that order (the verifier sorts, the exporter iterates), but
+# review `git diff data/curated` semantically rather than by line count.
+# `discussions` is dropped on the way in -- see PER_RECORD_ONLY_FIELDS in
+# scripts/aggregate_records.py.
+sync-curated:
+    uv run python scripts/aggregate_records.py \
+        --ingredients-dir data/ingredients --output-dir data/curated
 
 # Render per-ingredient HTML detail pages from data/ingredients/*.yaml
 # into pages/ingredient/. Idempotent (skips fresh outputs); --force

--- a/notes/INDIVIDUAL_RECORDS.md
+++ b/notes/INDIVIDUAL_RECORDS.md
@@ -48,13 +48,19 @@ python scripts/export_individual_records.py --input-dir data/curated --output-di
 - Reverse operation of export script
 - Adds metadata: generation_date, total_count, mapped_count, unmapped_count
 - Optional validation during aggregation
-- Output: `data/collections/mapped_ingredients.yaml` and `unmapped_ingredients.yaml`
+- Output: whatever `--output-dir` names. **The default, `data/collections/`, is a
+  dead end** — nothing in the repo reads it (see issue #169). Writing there was
+  the root cause of #148: per-record edits had no path back into `data/curated/`,
+  which is what `export_individual_records.py` actually reads.
 
 **Usage:**
 ```bash
-python scripts/aggregate_records.py
+# Write the per-record tree back into the live collection. This is the one you
+# almost always want, and what `just sync-curated` runs.
+python scripts/aggregate_records.py --ingredients-dir data/ingredients --output-dir data/curated
+
+# Bare invocation writes data/collections/, which nothing consumes.
 python scripts/aggregate_records.py --validate
-python scripts/aggregate_records.py --ingredients-dir data/ingredients --output-dir data/collections
 ```
 
 ### 4. Updated Validation Script
@@ -84,11 +90,17 @@ python scripts/validate_all.py --mode collection    # Only collection files
 - Handles duplicate identifiers correctly (sorts by identifier + preferred_term)
 - Reports differences and metadata changes
 
-**Usage:**
+**Usage:** prefer `just qc-roundtrip`, which aggregates into a temp directory and
+then makes the same byte-level assertion CI does.
+
 ```bash
-python scripts/verify_roundtrip.py
-python scripts/verify_roundtrip.py --original-dir data/curated --aggregated-dir data/collections
+just qc-roundtrip
 ```
+
+> **Do not compare against `data/collections/`.** That committed artifact was
+> last regenerated 2026-03-06, so the comparison passed for months while 55
+> curation events sat unreconciled (#148). Comparing against *any* committed copy
+> is the trap; aggregate into a temp directory instead.
 
 ### 6. Updated Justfile Commands
 

--- a/scripts/aggregate_records.py
+++ b/scripts/aggregate_records.py
@@ -32,10 +32,32 @@ from mediaingredientmech.utils.yaml_handler import load_yaml, save_yaml
 console = Console()
 
 
+def _exporter_authored_fields() -> tuple[str, ...]:
+    """Fields authored only on per-record files, which the collection never carries.
+
+    Imported from the exporter rather than re-declared: if the two lists drift,
+    aggregating would inject a field the collection format does not have, and the
+    next export would either wipe it or fight over it.
+    """
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "_mim_export_individual_records", Path(__file__).with_name("export_individual_records.py")
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return tuple(mod.PER_RECORD_AUTHORED_FIELDS)
+
+
+PER_RECORD_ONLY_FIELDS: tuple[str, ...] = _exporter_authored_fields()
+
+
 def aggregate_individual_files(
     ingredients_dir: Path,
     category: str,
-    validate: bool = False
+    validate: bool = False,
+    exclude_fields: tuple[str, ...] = PER_RECORD_ONLY_FIELDS,
 ) -> dict | None:
     """Aggregate individual YAML files into a collection.
 
@@ -43,6 +65,11 @@ def aggregate_individual_files(
         ingredients_dir: Directory containing individual ingredient files.
         category: Category name ('mapped' or 'unmapped').
         validate: If True, validate each record before aggregating.
+        exclude_fields: Per-record-authored fields to drop, so the output is in
+            the collection's shape. Defaults to the exporter's
+            PER_RECORD_AUTHORED_FIELDS -- without this, aggregating back into
+            data/curated/ injects `discussions` into a document that by design
+            does not carry it.
 
     Returns:
         Collection dictionary with metadata and ingredients list, or None if error.
@@ -79,6 +106,9 @@ def aggregate_individual_files(
                 if 'mapping_status' not in ingredient:
                     errors.append(f"{yaml_file.name}: Missing 'mapping_status' field")
                     continue
+
+            for field_name in exclude_fields:
+                ingredient.pop(field_name, None)
 
             ingredients.append(ingredient)
 

--- a/scripts/verify_roundtrip.py
+++ b/scripts/verify_roundtrip.py
@@ -27,6 +27,12 @@ from mediaingredientmech.utils.yaml_handler import load_yaml
 
 console = Console()
 
+# Fields authored directly on the per-record files and deliberately absent from
+# the curated collection (culturebotai-claw's kgscan writes `discussions`; the
+# exporter re-attaches them). Kept in sync with PER_RECORD_AUTHORED_FIELDS in
+# scripts/export_individual_records.py.
+PER_RECORD_ONLY_FIELDS: tuple[str, ...] = ("discussions",)
+
 
 def compare_ingredient_records(orig: dict, agg: dict, ignore_fields: set[str] = None) -> list[str]:
     """Compare two ingredient records and return differences.
@@ -63,16 +69,27 @@ def compare_ingredient_records(orig: dict, agg: dict, ignore_fields: set[str] = 
     return diffs
 
 
-def verify_round_trip(original_dir: Path, aggregated_dir: Path) -> dict:
+def verify_round_trip(
+    original_dir: Path,
+    aggregated_dir: Path,
+    ignore_fields: set[str] | None = None,
+) -> dict:
     """Verify round-trip integrity between original and aggregated collections.
 
     Args:
         original_dir: Directory with original collection files.
         aggregated_dir: Directory with aggregated collection files.
+        ignore_fields: Record fields excluded from the comparison. Defaults to
+            the per-record-authored fields that the collection deliberately does
+            not carry (see PER_RECORD_AUTHORED_FIELDS in
+            scripts/export_individual_records.py) — comparing them would report
+            a permanent, expected difference and make the gate useless.
 
     Returns:
         Dictionary with verification results.
     """
+    if ignore_fields is None:
+        ignore_fields = set(PER_RECORD_ONLY_FIELDS)
     results = {
         'files_compared': 0,
         'identical': 0,
@@ -134,14 +151,17 @@ def verify_round_trip(original_dir: Path, aggregated_dir: Path) -> dict:
 
         data_identical = True
         for i, (orig_ing, agg_ing) in enumerate(zip(orig_sorted, agg_sorted)):
-            diffs = compare_ingredient_records(orig_ing, agg_ing)
+            diffs = compare_ingredient_records(orig_ing, agg_ing, ignore_fields)
             if diffs:
                 data_identical = False
                 results['errors'].append(
                     f"{category_file}, ingredient {i} ({orig_ing.get('identifier')}): "
                     f"{', '.join(diffs[:3])}"  # Show first 3 diffs
                 )
-                break  # Only report first mismatch per file
+                # Report several per file, not just the first: as a gate, a
+                # one-at-a-time drip turns a single fix into many CI rounds.
+                if len(results['errors']) >= 25:
+                    break
 
         if data_identical and metadata_diff:
             results['metadata_only_diff'] += 1
@@ -166,7 +186,15 @@ def verify_round_trip(original_dir: Path, aggregated_dir: Path) -> dict:
     default=None,
     help="Directory with aggregated collection files (default: data/collections/)",
 )
-def main(original_dir: str | None, aggregated_dir: str | None):
+@click.option(
+    "--ignore-fields",
+    default=",".join(PER_RECORD_ONLY_FIELDS),
+    help=(
+        "Comma-separated record fields to exclude from comparison "
+        f"(default: {','.join(PER_RECORD_ONLY_FIELDS)}). Pass an empty string to compare everything."
+    ),
+)
+def main(original_dir: str | None, aggregated_dir: str | None, ignore_fields: str):
     """Verify round-trip integrity between original and aggregated collections."""
     # Set default paths
     if original_dir is None:
@@ -183,7 +211,11 @@ def main(original_dir: str | None, aggregated_dir: str | None):
     console.print(f"Original:   {original_dir_path}")
     console.print(f"Aggregated: {aggregated_dir_path}\n")
 
-    results = verify_round_trip(original_dir_path, aggregated_dir_path)
+    ignored = {f.strip() for f in ignore_fields.split(",") if f.strip()}
+    if ignored:
+        console.print(f"[dim]Ignoring per-record-only field(s): {', '.join(sorted(ignored))}[/dim]")
+
+    results = verify_round_trip(original_dir_path, aggregated_dir_path, ignored)
 
     # Summary table
     table = Table(title="Verification Results")

--- a/scripts/verify_roundtrip.py
+++ b/scripts/verify_roundtrip.py
@@ -29,9 +29,25 @@ console = Console()
 
 # Fields authored directly on the per-record files and deliberately absent from
 # the curated collection (culturebotai-claw's kgscan writes `discussions`; the
-# exporter re-attaches them). Kept in sync with PER_RECORD_AUTHORED_FIELDS in
-# scripts/export_individual_records.py.
-PER_RECORD_ONLY_FIELDS: tuple[str, ...] = ("discussions",)
+# exporter re-attaches them).
+#
+# IMPORTED, not re-declared. Drift between the two lists is silent in the unsafe
+# direction: a field added here but not to the exporter's list would be wiped on
+# every export while this gate stayed green — precisely the data loss the gate
+# exists to catch.
+def _load_exporter_authored_fields() -> tuple[str, ...]:
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "_mim_export_individual_records", Path(__file__).with_name("export_individual_records.py")
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return tuple(mod.PER_RECORD_AUTHORED_FIELDS)
+
+
+PER_RECORD_ONLY_FIELDS: tuple[str, ...] = _load_exporter_authored_fields()
 
 
 def compare_ingredient_records(orig: dict, agg: dict, ignore_fields: set[str] = None) -> list[str]:

--- a/tests/test_verify_roundtrip.py
+++ b/tests/test_verify_roundtrip.py
@@ -1,0 +1,151 @@
+"""Guards for the curated <-> per-record round-trip gate.
+
+The gate exists because `just export-individual` projects data/curated/ over the
+per-record tree, so anything written directly into data/ingredients/ is reverted
+on the next export. That silently destroyed 55 curation events from PR #116
+(issue #148). These tests pin the behaviour the gate depends on — above all that
+it *fails* when it should, since a gate that can only pass is worthless.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, ROOT / "scripts" / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _write_collection(path: Path, records: list[dict]) -> None:
+    mapped = sum(1 for r in records if r.get("mapping_status") == "MAPPED")
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "generation_date": "2026-08-02T00:00:00+00:00",
+                "total_count": len(records),
+                "mapped_count": mapped,
+                "unmapped_count": len(records) - mapped,
+                "ingredients": records,
+            },
+            sort_keys=False,
+        )
+    )
+
+
+def _record(identifier: str, term: str, **extra) -> dict:
+    return {
+        "identifier": identifier,
+        "preferred_term": term,
+        "mapping_status": "MAPPED",
+        **extra,
+    }
+
+
+def _pair(tmp_path: Path, original: list[dict], aggregated: list[dict]):
+    orig_dir, agg_dir = tmp_path / "curated", tmp_path / "agg"
+    orig_dir.mkdir()
+    agg_dir.mkdir()
+    for d, recs in ((orig_dir, original), (agg_dir, aggregated)):
+        _write_collection(d / "mapped_ingredients.yaml", recs)
+        _write_collection(d / "unmapped_ingredients.yaml", [])
+    return orig_dir, agg_dir
+
+
+# --- the constant must not drift from the exporter's -------------------------
+
+
+def test_per_record_only_fields_tracks_the_exporter():
+    """Drift here is silent in the unsafe direction: a field listed only in the
+    verifier is wiped on every export while the gate stays green."""
+    vr = _load("verify_roundtrip")
+    exp = _load("export_individual_records")
+    assert vr.PER_RECORD_ONLY_FIELDS == tuple(exp.PER_RECORD_AUTHORED_FIELDS)
+
+
+# --- the gate must pass when it should ---------------------------------------
+
+
+def test_identical_collections_pass(tmp_path):
+    vr = _load("verify_roundtrip")
+    recs = [_record("CHEBI:1", "Glucose"), _record("CHEBI:2", "NaCl")]
+    orig, agg = _pair(tmp_path, recs, [dict(r) for r in recs])
+
+    results = vr.verify_round_trip(orig, agg)
+    assert results["data_diffs"] == 0
+    assert results["errors"] == []
+
+
+def test_per_record_only_field_is_ignored(tmp_path):
+    """`discussions` lives only on per-record files by design; comparing it
+    would report a permanent expected difference and make the gate useless."""
+    vr = _load("verify_roundtrip")
+    orig = [_record("CHEBI:1", "Glucose")]
+    agg = [_record("CHEBI:1", "Glucose", discussions=[{"discussion_id": "kgscan-1"}])]
+    o, a = _pair(tmp_path, orig, agg)
+
+    assert vr.verify_round_trip(o, a)["errors"] == []
+
+
+# --- the gate must FAIL when it should ---------------------------------------
+
+
+def test_single_field_drift_is_caught_with_counts_unchanged(tmp_path):
+    """The subtle case: record counts match, one field differs. This is the
+    shape of the #148 drift (ingredient_type flipped on 53 records)."""
+    vr = _load("verify_roundtrip")
+    orig = [_record("UNMAPPED_0113", "BCYE agar", ingredient_type="UNDEFINED_MIXTURE")]
+    agg = [_record("UNMAPPED_0113", "BCYE agar", ingredient_type="DEFINED_MEDIUM")]
+    o, a = _pair(tmp_path, orig, agg)
+
+    results = vr.verify_round_trip(o, a)
+    assert results["data_diffs"] == 1
+    assert any("UNMAPPED_0113" in e for e in results["errors"])
+
+
+def test_record_count_mismatch_is_caught(tmp_path):
+    vr = _load("verify_roundtrip")
+    o, a = _pair(tmp_path, [_record("CHEBI:1", "A"), _record("CHEBI:2", "B")], [_record("CHEBI:1", "A")])
+
+    assert vr.verify_round_trip(o, a)["errors"]
+
+
+def test_a_field_present_only_in_the_collection_is_caught(tmp_path):
+    """Direction matters: the exporter would wipe this on the next run."""
+    vr = _load("verify_roundtrip")
+    orig = [_record("CHEBI:1", "Glucose", notes="curated note")]
+    agg = [_record("CHEBI:1", "Glucose")]
+    o, a = _pair(tmp_path, orig, agg)
+
+    assert vr.verify_round_trip(o, a)["data_diffs"] == 1
+
+
+def test_many_mismatches_still_fail_despite_the_error_cap(tmp_path):
+    """The cap bounds *reporting*, not the verdict — data_diffs is set before it."""
+    vr = _load("verify_roundtrip")
+    orig = [_record(f"CHEBI:{i}", f"T{i}", ingredient_type="UNDEFINED_MIXTURE") for i in range(60)]
+    agg = [_record(f"CHEBI:{i}", f"T{i}", ingredient_type="DEFINED_MEDIUM") for i in range(60)]
+    o, a = _pair(tmp_path, orig, agg)
+
+    results = vr.verify_round_trip(o, a)
+    assert results["data_diffs"] > 0
+    assert len(results["errors"]) <= 30  # capped, but non-empty
+    assert results["errors"]
+
+
+def test_more_than_one_mismatch_is_reported_per_file(tmp_path):
+    """It used to stop after the first, turning one fix into many CI rounds."""
+    vr = _load("verify_roundtrip")
+    orig = [_record(f"CHEBI:{i}", f"T{i}", notes="a") for i in range(5)]
+    agg = [_record(f"CHEBI:{i}", f"T{i}", notes="b") for i in range(5)]
+    o, a = _pair(tmp_path, orig, agg)
+
+    assert len(vr.verify_round_trip(o, a)["errors"]) > 1


### PR DESCRIPTION
Fixes the data-destroying landmine measured in #159: `just export-individual` reverted **55 curation events** from PR #116 — 53 `RECLASSIFY_INGREDIENT_TYPE` (`UNDEFINED_MIXTURE` → `DEFINED_MEDIUM`) and 2 `FLAGGED_NON_INGREDIENT` — along with their `curation_history` entries. Since `promote_resolved_unmapped.py` calls `export-individual`, any routine promotion reverted all 55 silently.

## Root cause: the reverse half of the round trip never fed back

`aggregate_records.py` defaults `--output-dir` to `data/collections/`. **Nothing reads that directory** — grep shows the only references anywhere are the aggregator's own default and `verify_roundtrip.py`'s; every one of the ~20 consumers reads `data/curated/`. So a per-record edit had no path back into the export source.

Worse, `verify_roundtrip.py` — which would have caught this, and already exits 1 on mismatch — was comparing `data/curated/` against that committed `data/collections/` artifact, **last regenerated 2026-03-06**. It kept passing while the 55 events sat unreconciled, and it was never wired into CI.

So the fix recorded in `NEXT_TASKS.md` (`just aggregate-collections` before the next export) would **not** have worked: on its own it writes to the dead end.

## 1. Data reconciled

Applied surgically — record order, key order, and untouched fields preserved — rather than by wholesale re-aggregation, so the diff stays reviewable:

| | |
|---|---|
| 55 unmapped records | gain `ingredient_type` / `curation_history` / `notes` |
| 3 orphan entries dropped | `UNMAPPED_0488` Phytone, `UNMAPPED_0531` Soya pepton, `UNMAPPED_0558` Tryptone peptone — all already promoted into `data/ingredients/mapped/` as `FOODON:03315720` / `FOODON:03315720` / `MICRO:0000182` |
| headers recomputed | mapped now honestly reports 1877 MAPPED + 2 non-MAPPED against total 1879 (was 1877/0 vs 1879, self-inconsistent) |

`discussions` is deliberately **not** copied into the collection — it is authored per-record by claw's kgscan and excluded by design (`PER_RECORD_AUTHORED_FIELDS`).

Also commits 12 per-record files that a re-export normalises (line wrapping and scalar quoting only). Verified semantically identical by parsing both sides, and stable across three consecutive exports — a one-time normalisation that makes the corpus a fixed point. **`just export-individual` is now a true no-op.**

## 2. The 53 reclassifications were validated before being made canonical

All 53 are named standard culture media. `Oatmeal agar` appears **verbatim** in the schema's own `DEFINED_MEDIUM` examples; `Marine broth 2216` is the broth counterpart of its `Marine agar 2216` example (same DSMZ 2216 formulation, solidified or not) — a near-match, not a verbatim one. The contested subset is the ~9 "Base" products.

- **MediaDive REST** (`/rest/ingredient/{id}`): all 8 with source ids return no `formula`, no `CAS-RN`, no `ChEBI` — formulations, not chemicals.
- **Three independent Edison/PaperQA3 runs** on the hardest cases, chosen to stress different failure modes: **Blood Agar Base** (incomplete base), **Soil+Seawater Medium** (natural-substrate, genuinely variable components), **Leptospira Medium Base EMJH** (supplement-dependent base). **Each independently confirmed retaining `DEFINED_MEDIUM`.**

Canary discipline followed: one real run first, artifacts verified on disk before the other two.

## 3. Gate so it cannot recur

- `just qc-roundtrip` (added to the `qc` composite) and new `.github/workflows/qc-roundtrip.yaml`, both aggregating into a **temp dir** — never a committed artifact, which is the trap that caused this. CI additionally asserts `export-individual` produces no diff, catching added/removed files as well as content drift.
- `verify_roundtrip.py` gains `--ignore-fields` (default `discussions`), and no longer stops after the first mismatch per file — as a gate, a one-at-a-time drip turns one fix into many CI rounds.

**Verified the gate fails, not just passes:** reverting `data/curated` to its pre-fix state exits 1; and injecting a single-field change with record counts left unchanged (`BCYE agar` → `UNDEFINED_MIXTURE`) is caught and pinpointed to `UNMAPPED_0113` — so the subtle field-level path works, not only the count check.

## Verification

`just qc` exits 0 (including the new gate), 490 tests pass, `export-individual` is a no-op. Two curation-history records added under the layer #163 ported; both validate clean.

## Not in this PR

`data/collections/` retirement — it is still the aggregator's *default* output, so a bare `just aggregate-collections` writes to the dead end and looks like it worked. Kept out to keep this diff to the fix; re-scoped in `NEXT_TASKS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)