### PR TITLE
Make a dropped record fatal in the aggregator; stop relabelling REJECTED (#172)

### DIFF
--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -230,8 +230,10 @@ therefore *not* the fix: on its own it writes to the dead end.
 1. **Data reconciled.** Applied surgically (record and key order preserved, only
    drifted fields touched) so the diff stayed reviewable: 55 unmapped records
    gained `ingredient_type`/`curation_history`/`notes`; the 3 orphans were
-   dropped; headers recomputed (mapped now honestly reports 1877 MAPPED + 2
-   non-MAPPED against total 1879). `discussions` deliberately stays out of the
+   dropped. Headers were also recomputed, and **that part was a mistake** — see
+   the header bullet above; `unmapped_count` was set to 2 when the 2 records are
+   `REJECTED`, not UNMAPPED. Reverted to 0 in the #172 fix, which counts each
+   status explicitly. `discussions` deliberately stays out of the
    collection. 12 per-record files were also normalised — line wrapping and
    scalar quoting only, verified semantically identical by parsing both sides and
    stable across three consecutive exports. **`just export-individual` is now a

--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -175,11 +175,15 @@ Also in scope, found during this reconcile:
   `data/curated/unmapped_ingredients.yaml` and `data/ingredients/unmapped/Tapso.yaml`.
   Every other unmapped record uses an `UNMAPPED_NNNN` placeholder. Mint one
   (`manage-identifiers`) — TAPSO is a real buffer and a mapping candidate.
-- ~~**Self-inconsistent collection headers**~~ — **DONE (PR #167)**, recomputed
-  during the reconcile. Mapped now reports 1877 MAPPED + 2 non-MAPPED against
-  total 1879. Those 2 are `Bacto_Soytone.yaml` and `Sodium_L-lactate.yaml`, which
-  sit in `data/ingredients/mapped/` without `mapping_status: MAPPED` — filed
-  separately, since the honest header now surfaces them.
+- ~~**"Self-inconsistent" collection headers**~~ — **the original header was
+  right; the reconcile briefly made it wrong.** `total_count: 1879` against
+  `mapped_count: 1877` + `unmapped_count: 0` does not sum, but that is accurate,
+  not inconsistent: 2 records are `mapping_status: REJECTED`, and
+  `IngredientCollection` is closed with no slot for other statuses. PR #167
+  recomputed `unmapped_count` as `total − mapped`, which relabelled those 2 as
+  UNMAPPED — asserting something false. Corrected in the #172 fix, which counts
+  each status explicitly and prints a note when they legitimately do not sum. The
+  2 records (`Bacto_Soytone.yaml`, `Sodium_L-lactate.yaml`) are filed as #170.
 - **Stale derived indexes:** `data/curated/mapped_ingredients_index.csv` (line 410)
   and `…_index.json` still carry `CHEBI:48601` for Carnitine Hydrochloride, whose
   identifier was corrected to `kgmicrobe.compound:carnitine_hydrochloride` (the

--- a/data/curated/mapped_ingredients.yaml
+++ b/data/curated/mapped_ingredients.yaml
@@ -1,7 +1,7 @@
 generation_date: '2026-08-02T07:30:38.760974+00:00'
 total_count: 1879
 mapped_count: 1877
-unmapped_count: 2
+unmapped_count: 0
 ingredients:
 - identifier: CHEBI:149425
   preferred_term: NH4MgPO

--- a/history/infrastructure/aggregate-records/2026-08-03T030057Z-claude-code-1ae0ca.yaml
+++ b/history/infrastructure/aggregate-records/2026-08-03T030057Z-claude-code-1ae0ca.yaml
@@ -1,0 +1,47 @@
+history_version: 1
+target:
+  kind: infrastructure
+  path: scripts/aggregate_records.py
+  slug: aggregate-records
+session:
+  id: 2026-08-03T030057Z-claude-code-1ae0ca
+  timestamp: '2026-08-03T03:00:57Z'
+  actors:
+  - type: ai_agent
+    name: claude-code
+    model: claude-fable-5
+    agent_tool: claude-code
+links:
+  issues:
+  - https://github.com/CultureBotAI/MediaIngredientMech/issues/172
+events:
+- type: EDIT
+  outcome: changed
+  sections:
+  - scripts
+  - tests
+  - data
+  summary: Make a dropped record fatal in the aggregator; count statuses explicitly
+  details: 'aggregate_individual_files caught a per-file load error, printed it, SKIPPED the
+    record, and main() exited 0 unconditionally; total_errors was declared and never incremented,
+    so the plumbing was intended and never wired up. Latent until PR #167 made aggregation
+    load-bearing in two new places: ''just sync-curated'' writes the aggregation over data/curated/,
+    so one unparseable per-record file meant the record was dropped from the collection, the
+    next ''just export-individual'' deleted its per-record file too (export clears the tree
+    and rewrites from the collection), and ''just qc-roundtrip'' then compared two sources
+    that agreed the record did not exist and PASSED - silent, unrecoverable loss of a curation
+    record. Reproduced before fixing with a corrupt file beside a good one: output read ''Total
+    ingredients aggregated: 1'' with a green checkmark and exit 0, the second record absent.
+    Now returns (collection, errors); main sums and exits 1 naming the missing records. Second
+    half: unmapped_count was computed as total-mapped, relabelling every other status as UNMAPPED
+    in a header consumers read; now each status is counted explicitly. This corrected my own
+    error in #167, where I called the original header (total 1879 / mapped 1877 / unmapped
+    0) ''self-inconsistent'' and recomputed unmapped_count to 2 - the original was right,
+    the counts do not sum because 2 records are REJECTED and IngredientCollection is closed
+    with no slot for other statuses, so #167 asserted something false. Restored to 0 and the
+    aggregator now prints a note naming the statuses when counts legitimately do not sum.
+    Verified: 506 tests pass including 8 new in tests/test_aggregate_records.py; ''just qc''
+    exits 0; export remains a no-op. NOTE on CI coverage: PR #173 is stacked on #167''s branch,
+    and the roundtrip/qc/pytest workflows trigger only on pull_request against main, so they
+    did not run for this PR - verified locally instead, and they will run once the base is
+    retargeted to main.'

--- a/justfile
+++ b/justfile
@@ -192,9 +192,10 @@ qc-roundtrip:
     set -euo pipefail
     tmp="$(mktemp -d)"
     trap 'rm -rf "$tmp"' EXIT
-    # Aggregate diagnostics are NOT discarded: aggregate_records.py skips a
-    # per-record file it cannot load and still exits 0, so silencing it turns a
-    # corrupt YAML into a bare "ingredient count mismatch" with no cause.
+    # Aggregate diagnostics are NOT discarded: a per-record file it cannot load
+    # names itself here. (It now also exits 1 and writes nothing rather than
+    # dropping the record silently -- see #172 -- but the diagnostic is still
+    # what tells you WHICH file.)
     uv run python scripts/aggregate_records.py \
         --ingredients-dir data/ingredients --output-dir "$tmp"
     uv run python scripts/verify_roundtrip.py \

--- a/scripts/aggregate_records.py
+++ b/scripts/aggregate_records.py
@@ -95,20 +95,32 @@ def aggregate_individual_files(
         try:
             ingredient = load_yaml(yaml_file)
 
+            # Structural checks that run ALWAYS, not just under --validate,
+            # because they are the ones that cause silent record loss. load_yaml
+            # returns {} for an empty or comment-only document, which would
+            # otherwise be appended as a `- {}` record: the file's real content is
+            # gone, the collection still "has" a record, and nothing errors.
+            if not isinstance(ingredient, dict):
+                errors.append(f"{yaml_file.name}: Invalid format (not a mapping)")
+                continue
+            if not ingredient:
+                errors.append(f"{yaml_file.name}: Empty document (truncated or comment-only?)")
+                continue
+            if 'mapping_status' not in ingredient:
+                # Required by the schema, and the aggregator counts on it; without
+                # it the header's status counts silently under-report.
+                errors.append(f"{yaml_file.name}: Missing 'mapping_status' field")
+                continue
+
             # Validate basic structure
             if validate:
-                if not isinstance(ingredient, dict):
-                    errors.append(f"{yaml_file.name}: Invalid format (not a dict)")
-                    continue
                 if 'identifier' not in ingredient:
                     errors.append(f"{yaml_file.name}: Missing 'identifier' field")
                     continue
                 if 'preferred_term' not in ingredient:
                     errors.append(f"{yaml_file.name}: Missing 'preferred_term' field")
                     continue
-                if 'mapping_status' not in ingredient:
-                    errors.append(f"{yaml_file.name}: Missing 'mapping_status' field")
-                    continue
+                # `mapping_status` is checked unconditionally above.
 
             for field_name in exclude_fields:
                 ingredient.pop(field_name, None)
@@ -217,6 +229,7 @@ def main(ingredients_dir: str | None, output_dir: str | None, validate: bool):
     categories = ['mapped', 'unmapped']
     total_ingredients = 0
     total_errors = 0
+    pending: list[tuple[str, dict]] = []
 
     with Progress(
         SpinnerColumn(),
@@ -240,17 +253,34 @@ def main(ingredients_dir: str | None, output_dir: str | None, validate: bool):
                 )
                 continue
 
-            # Write collection file
-            output_file = output_dir_path / f"{category}_ingredients.yaml"
-            save_yaml(collection, output_file, backup=True)
-
-            ingredient_count = collection['total_count']
-            total_ingredients += ingredient_count
+            # Buffer, do not write yet. `sync-curated` points --output-dir at
+            # data/curated/, so writing a category before knowing whether a later
+            # one failed would overwrite the live collection with a short one and
+            # then exit 1 — destroying the record in the working tree and leaving
+            # the caller to notice and `git checkout`. Nothing is written unless
+            # every record aggregated.
+            pending.append((category, collection))
+            total_ingredients += collection['total_count']
 
             progress.update(
                 task,
-                description=f"[green]{category}: {ingredient_count} ingredients → {output_file.name}[/green]"
+                description=f"[green]{category}: {collection['total_count']} ingredients[/green]"
             )
+
+    if total_errors:
+        # Fail BEFORE writing anything.
+        console.print(
+            f"\n[bold red]✗ {total_errors} record(s) could not be aggregated.[/bold red]"
+        )
+        console.print(
+            "[red]No collections were written — the existing files are untouched.[/red]"
+        )
+        console.print("[red]Fix the offending file(s) and re-run.[/red]")
+        sys.exit(1)
+
+    for category, collection in pending:
+        output_file = output_dir_path / f"{category}_ingredients.yaml"
+        save_yaml(collection, output_file, backup=True)
 
     # Summary
     console.print("\n[bold]Summary:[/bold]")
@@ -261,22 +291,6 @@ def main(ingredients_dir: str | None, output_dir: str | None, validate: bool):
         output_file = output_dir_path / f"{category}_ingredients.yaml"
         if output_file.exists():
             console.print(f"    [green]✓[/green] {output_file.name}")
-
-    if total_errors:
-        # Exit non-zero: every error above is a record that was DROPPED from the
-        # collection. Exiting 0 here made the loss silent, and because
-        # `sync-curated` writes the result over data/curated/, a single
-        # unparseable per-record file could delete a curation record outright —
-        # the next export removes its file too, and the round-trip gate then sees
-        # two sources that agree it does not exist and passes.
-        console.print(
-            f"\n[bold red]✗ {total_errors} record(s) could not be aggregated and are "
-            f"MISSING from the written collection(s).[/bold red]"
-        )
-        console.print(
-            "[red]Do not commit this output. Fix the offending file(s) and re-run.[/red]"
-        )
-        sys.exit(1)
 
     if validate:
         console.print("\n[green]Validation passed for all files[/green]")

--- a/scripts/aggregate_records.py
+++ b/scripts/aggregate_records.py
@@ -58,7 +58,7 @@ def aggregate_individual_files(
     category: str,
     validate: bool = False,
     exclude_fields: tuple[str, ...] = PER_RECORD_ONLY_FIELDS,
-) -> dict | None:
+) -> tuple[dict | None, list[str]]:
     """Aggregate individual YAML files into a collection.
 
     Args:
@@ -72,18 +72,21 @@ def aggregate_individual_files(
             does not carry it.
 
     Returns:
-        Collection dictionary with metadata and ingredients list, or None if error.
+        ``(collection, errors)``. ``collection`` is None only when the category
+        directory is absent or empty. ``errors`` lists per-file failures; a record
+        that fails to load is SKIPPED, so a non-empty list means the collection is
+        missing records and the caller MUST NOT treat it as complete.
     """
     category_dir = ingredients_dir / category
     if not category_dir.exists():
         console.print(f"[yellow]Category directory not found: {category_dir}[/yellow]")
-        return None
+        return None, []
 
     # Find all YAML files
     yaml_files = sorted(category_dir.glob("*.yaml")) + sorted(category_dir.glob("*.yml"))
     if not yaml_files:
         console.print(f"[yellow]No YAML files found in {category_dir}[/yellow]")
-        return None
+        return None, []
 
     ingredients = []
     errors = []
@@ -116,18 +119,40 @@ def aggregate_individual_files(
             errors.append(f"{yaml_file.name}: {e}")
 
     if errors:
-        console.print(f"\n[yellow]Errors in {category}:[/yellow]")
+        # Loud, and fatal in main(): each of these is a record MISSING from the
+        # collection. Silently dropping one and exiting 0 meant `sync-curated`
+        # could delete a record from data/curated/, after which the next export
+        # deletes its per-record file too and the round-trip gate — comparing two
+        # sources that now agree it does not exist — passes.
+        console.print(f"\n[red]Errors in {category} — {len(errors)} record(s) NOT aggregated:[/red]")
         for error in errors[:10]:  # Show first 10 errors
             console.print(f"  [red]✗[/red] {error}")
         if len(errors) > 10:
             console.print(f"  [dim]... and {len(errors) - 10} more errors[/dim]")
 
-    # Count mapped vs unmapped
-    mapped_count = sum(
-        1 for ing in ingredients
-        if ing.get('mapping_status') == 'MAPPED'
-    )
-    unmapped_count = len(ingredients) - mapped_count
+    # Count by status explicitly. `unmapped_count` used to be `total - mapped`,
+    # which silently relabelled every other status as UNMAPPED — REJECTED records
+    # were reported as unmapped in the header consumers read.
+    mapped_count = sum(1 for ing in ingredients if ing.get('mapping_status') == 'MAPPED')
+    unmapped_count = sum(1 for ing in ingredients if ing.get('mapping_status') == 'UNMAPPED')
+    other_count = len(ingredients) - mapped_count - unmapped_count
+    if other_count:
+        # The counts legitimately do not sum: IngredientCollection is closed and
+        # has no slot for other statuses, so say so here rather than folding them
+        # into unmapped_count and asserting something false in the file.
+        other_statuses = sorted(
+            {
+                str(ing.get('mapping_status'))
+                for ing in ingredients
+                if ing.get('mapping_status') not in ('MAPPED', 'UNMAPPED')
+            }
+        )
+        console.print(
+            f"[yellow]note:[/yellow] {category}: {other_count} record(s) are neither "
+            f"MAPPED nor UNMAPPED ({', '.join(other_statuses)}), so "
+            f"mapped_count + unmapped_count < total_count. This is accurate, not a "
+            f"miscount — the schema has no slot for these."
+        )
 
     # Create collection with metadata
     collection = {
@@ -138,7 +163,7 @@ def aggregate_individual_files(
         'ingredients': ingredients
     }
 
-    return collection
+    return collection, errors
 
 
 @click.command()
@@ -201,11 +226,12 @@ def main(ingredients_dir: str | None, output_dir: str | None, validate: bool):
         for category in categories:
             task = progress.add_task(f"Aggregating {category}...", total=None)
 
-            collection = aggregate_individual_files(
+            collection, errors = aggregate_individual_files(
                 ingredients_dir_path,
                 category,
                 validate=validate
             )
+            total_errors += len(errors)
 
             if collection is None:
                 progress.update(
@@ -235,6 +261,22 @@ def main(ingredients_dir: str | None, output_dir: str | None, validate: bool):
         output_file = output_dir_path / f"{category}_ingredients.yaml"
         if output_file.exists():
             console.print(f"    [green]✓[/green] {output_file.name}")
+
+    if total_errors:
+        # Exit non-zero: every error above is a record that was DROPPED from the
+        # collection. Exiting 0 here made the loss silent, and because
+        # `sync-curated` writes the result over data/curated/, a single
+        # unparseable per-record file could delete a curation record outright —
+        # the next export removes its file too, and the round-trip gate then sees
+        # two sources that agree it does not exist and passes.
+        console.print(
+            f"\n[bold red]✗ {total_errors} record(s) could not be aggregated and are "
+            f"MISSING from the written collection(s).[/bold red]"
+        )
+        console.print(
+            "[red]Do not commit this output. Fix the offending file(s) and re-run.[/red]"
+        )
+        sys.exit(1)
 
     if validate:
         console.print("\n[green]Validation passed for all files[/green]")

--- a/tests/test_aggregate_records.py
+++ b/tests/test_aggregate_records.py
@@ -1,0 +1,169 @@
+"""Guards for the aggregator's failure and counting behaviour (issue #172).
+
+Aggregation is load-bearing in two places that can destroy data: `just
+sync-curated` writes its output over `data/curated/`, and `just qc-roundtrip`
+compares against it. A record it silently drops therefore disappears from the
+collection, the next `just export-individual` deletes the per-record file too,
+and the round-trip gate — now comparing two sources that agree the record does
+not exist — passes. These tests pin the loud-failure behaviour that prevents it.
+"""
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "aggregate_records", ROOT / "scripts" / "aggregate_records.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _tree(tmp_path: Path, mapped: dict[str, str], unmapped: dict[str, str] | None = None) -> Path:
+    root = tmp_path / "ingredients"
+    for category, files in (("mapped", mapped), ("unmapped", unmapped or {})):
+        d = root / category
+        d.mkdir(parents=True)
+        for name, text in files.items():
+            (d / f"{name}.yaml").write_text(text)
+    return root
+
+
+def _record(identifier: str, term: str, status: str = "MAPPED") -> str:
+    return yaml.safe_dump(
+        {"identifier": identifier, "preferred_term": term, "mapping_status": status}
+    )
+
+
+# --- a dropped record must never be silent ----------------------------------
+
+
+def test_unparseable_record_is_reported_as_an_error(tmp_path):
+    agg = _load()
+    root = _tree(
+        tmp_path,
+        {"Good": _record("CHEBI:1", "Good"), "Corrupt": "identifier: CHEBI:2\nsynonyms: [unclosed\n"},
+    )
+
+    collection, errors = agg.aggregate_individual_files(root, "mapped")
+
+    assert len(errors) == 1
+    assert "Corrupt.yaml" in errors[0]
+    # The dropped record really is absent — that is why it must not be silent.
+    assert collection["total_count"] == 1
+
+
+def test_cli_exits_nonzero_when_a_record_is_dropped(tmp_path):
+    """The whole point: `sync-curated` writes over data/curated/, so a run that
+    lost a record must not report success."""
+    root = _tree(
+        tmp_path,
+        {"Good": _record("CHEBI:1", "Good"), "Corrupt": "identifier: CHEBI:2\nsynonyms: [unclosed\n"},
+    )
+    out = tmp_path / "out"
+
+    proc = subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / "aggregate_records.py"),
+         "--ingredients-dir", str(root), "--output-dir", str(out)],
+        capture_output=True, text=True, cwd=ROOT,
+    )
+
+    assert proc.returncode == 1, proc.stdout
+    assert "MISSING" in proc.stdout
+
+
+def test_cli_exits_zero_on_a_clean_tree(tmp_path):
+    root = _tree(tmp_path, {"Good": _record("CHEBI:1", "Good")})
+    out = tmp_path / "out"
+
+    proc = subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / "aggregate_records.py"),
+         "--ingredients-dir", str(root), "--output-dir", str(out)],
+        capture_output=True, text=True, cwd=ROOT,
+    )
+
+    assert proc.returncode == 0, proc.stdout
+
+
+# --- status counting must not relabel ---------------------------------------
+
+
+def test_rejected_records_are_not_counted_as_unmapped(tmp_path):
+    """`unmapped_count` used to be `total - mapped`, silently relabelling every
+    other status as UNMAPPED in a header consumers read."""
+    agg = _load()
+    root = _tree(
+        tmp_path,
+        {
+            "A": _record("CHEBI:1", "A", "MAPPED"),
+            "B": _record("CHEBI:2", "B", "REJECTED"),
+            "C": _record("CHEBI:3", "C", "REJECTED"),
+        },
+    )
+
+    collection, _ = agg.aggregate_individual_files(root, "mapped")
+
+    assert collection["total_count"] == 3
+    assert collection["mapped_count"] == 1
+    assert collection["unmapped_count"] == 0  # not 2
+
+
+def test_unmapped_records_are_counted(tmp_path):
+    agg = _load()
+    root = _tree(tmp_path, {}, {"U": _record("UNMAPPED_0001", "U", "UNMAPPED")})
+
+    collection, _ = agg.aggregate_individual_files(root, "unmapped")
+
+    assert collection["unmapped_count"] == 1
+    assert collection["mapped_count"] == 0
+
+
+# --- collection shape --------------------------------------------------------
+
+
+def test_per_record_only_fields_are_dropped(tmp_path):
+    """The collection does not carry `discussions`; aggregating must not inject it."""
+    agg = _load()
+    rec = yaml.safe_dump(
+        {
+            "identifier": "CHEBI:1",
+            "preferred_term": "A",
+            "mapping_status": "MAPPED",
+            "discussions": [{"discussion_id": "kgscan-1"}],
+        }
+    )
+    root = _tree(tmp_path, {"A": rec})
+
+    collection, _ = agg.aggregate_individual_files(root, "mapped")
+
+    assert "discussions" not in collection["ingredients"][0]
+
+
+def test_exclude_fields_tracks_the_exporter():
+    agg = _load()
+    spec = importlib.util.spec_from_file_location(
+        "export_individual_records", ROOT / "scripts" / "export_individual_records.py"
+    )
+    exp = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = exp
+    spec.loader.exec_module(exp)
+
+    assert agg.PER_RECORD_ONLY_FIELDS == tuple(exp.PER_RECORD_AUTHORED_FIELDS)
+
+
+def test_missing_category_directory_returns_no_collection(tmp_path):
+    agg = _load()
+    collection, errors = agg.aggregate_individual_files(tmp_path / "nope", "mapped")
+
+    assert collection is None
+    assert errors == []

--- a/tests/test_aggregate_records.py
+++ b/tests/test_aggregate_records.py
@@ -79,7 +79,61 @@ def test_cli_exits_nonzero_when_a_record_is_dropped(tmp_path):
     )
 
     assert proc.returncode == 1, proc.stdout
-    assert "MISSING" in proc.stdout
+    assert "could not be aggregated" in proc.stdout
+    assert "Corrupt.yaml" in proc.stdout  # names the offending file
+
+
+def test_empty_or_comment_only_file_is_an_error_not_an_empty_record(tmp_path):
+    """load_yaml returns {} for an empty document. Appending that as a record
+    loses the file's content while the collection still 'has' a record — the same
+    silent loss, wearing a different hat. Must be an error even without
+    --validate, which is how every caller runs it."""
+    agg = _load()
+    root = _tree(
+        tmp_path,
+        {"Good": _record("CHEBI:1", "Good"), "Truncated": "", "CommentOnly": "# nothing here\n"},
+    )
+
+    collection, errors = agg.aggregate_individual_files(root, "mapped")
+
+    assert len(errors) == 2
+    assert collection["total_count"] == 1
+    assert {} not in collection["ingredients"]
+
+
+def test_record_without_mapping_status_is_an_error(tmp_path):
+    """Without it the status counts silently under-report."""
+    agg = _load()
+    root = _tree(tmp_path, {"NoStatus": yaml.safe_dump({"identifier": "CHEBI:1", "preferred_term": "A"})})
+
+    _, errors = agg.aggregate_individual_files(root, "mapped")
+
+    assert len(errors) == 1
+    assert "mapping_status" in errors[0]
+
+
+def test_nothing_is_written_when_any_record_fails(tmp_path):
+    """Fail BEFORE writing: `sync-curated` points --output-dir at data/curated/,
+    so writing a short collection and then exiting 1 would still destroy the
+    record in the working tree."""
+    root = _tree(
+        tmp_path,
+        {"Good": _record("CHEBI:1", "Good"), "Corrupt": "identifier: CHEBI:2\nsynonyms: [unclosed\n"},
+    )
+    out = tmp_path / "out"
+    out.mkdir()
+    sentinel = out / "mapped_ingredients.yaml"
+    sentinel.write_text("total_count: 999\ningredients: []\n")
+
+    proc = subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / "aggregate_records.py"),
+         "--ingredients-dir", str(root), "--output-dir", str(out)],
+        capture_output=True, text=True, cwd=ROOT,
+    )
+
+    assert proc.returncode == 1
+    # The pre-existing collection must be untouched.
+    assert sentinel.read_text() == "total_count: 999\ningredients: []\n"
 
 
 def test_cli_exits_zero_on_a_clean_tree(tmp_path):


### PR DESCRIPTION
**Stacked on #167** (same file). Base is `fix/curated-perrecord-reconciliation`; retarget to `main` once #167 merges.

Closes #172.

## Why this is the most critical open issue

`aggregate_individual_files` catches a per-file load error, prints it, **skips the record**, and `main()` exits 0 unconditionally — `total_errors` was declared and never incremented, so the plumbing was intended and never wired up.

That was a latent wart until **#167 made aggregation load-bearing in two new places**. `just sync-curated` writes the aggregation over `data/curated/`, so one unparseable per-record file gives:

1. record dropped from the collection —
2. next `just export-individual` deletes its per-record file too (export clears the tree and rewrites from the collection) —
3. `just qc-roundtrip` compares two sources that now agree the record does not exist → **passes**.

The record is gone, with no error anywhere. And #167's own recipe comment — "expect a LARGE diff even when content is unchanged" — is exactly the cover such a deletion needs.

**Reproduced before fixing.** A corrupt file beside a good one:

```
Summary:
  Total ingredients aggregated: 1
    ✓ mapped_ingredients.yaml
=== AGGREGATOR EXIT CODE: 0 ===
records that survived: Good Record          # "Precious Record" silently gone
```

Now:

```
✗ 1 record(s) could not be aggregated and are MISSING from the written collection(s).
Do not commit this output. Fix the offending file(s) and re-run.
exit 1
```

## Second half: `unmapped_count` relabelled every other status

It was `total - mapped`, so a `REJECTED` record was reported as UNMAPPED in a header consumers read. Now each status is counted explicitly.

**This also corrects a mistake I made in #167.** I called the original `total_count: 1879 / mapped_count: 1877 / unmapped_count: 0` header "self-inconsistent" and recomputed it to `unmapped_count: 2`. The original was right — the counts don't sum because 2 records are `REJECTED`, and `IngredientCollection` is closed with no slot for other statuses. #167's version asserted something false. Restored to `0`, and the aggregator now prints a note naming the statuses when counts legitimately don't sum, so the next reader doesn't repeat my error:

```
note: mapped: 2 record(s) are neither MAPPED nor UNMAPPED (REJECTED), so
mapped_count + unmapped_count < total_count. This is accurate, not a miscount —
the schema has no slot for these.
```

`NEXT_TASKS.md` corrected to match.

## Tests

`tests/test_aggregate_records.py` (8): a dropped record is reported and exits 1, a clean tree exits 0, `REJECTED` is not counted as unmapped, per-record-only fields are dropped, and the exclude list tracks the exporter.

506 tests pass; `just qc` exits 0; export remains a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)