### PR TITLE
Run the gating workflows on stacked PRs too (#174)

### DIFF
--- a/.claude/commands/ground-or-propose-ingredient.md
+++ b/.claude/commands/ground-or-propose-ingredient.md
@@ -109,8 +109,11 @@ Never assert a CHEBI primary that isn't the same compound just to raise coverage
   `validate_sssom_invariants.py` Rule B1 requires. The `build-unified-mapping` skill
   regenerates the SSSOM from the collections.
 - **Reconcile + round-trip:** `python scripts/reconcile_sssom.py --apply --date YYYY-MM-DD`,
-  then `just export-individual` / `just aggregate-collections` to keep per-record files and
-  collections in sync.
+  then **`just sync-curated`** to keep per-record files and collections in sync.
+  Do NOT use `just export-individual` / `just aggregate-collections` for this:
+  export projects the collection OVER the per-record tree (reverting edits made
+  there), and aggregate-collections writes `data/collections/`, which nothing
+  reads. That pairing is what silently reverted 55 curation events (#148).
 
 ### 6. Verify + report
 `just qc` (schema + evidence + SSSOM) · `python scripts/validate_sssom_invariants.py`

--- a/.github/workflows/qc-evidence.yaml
+++ b/.github/workflows/qc-evidence.yaml
@@ -2,7 +2,10 @@ name: QC — evidence reference validation
 
 on:
   pull_request:
-    branches: [main]
+    # NO branches filter. A PR whose base is not `main` — every stacked PR —
+    # would otherwise skip this gate entirely, so the more carefully work is
+    # split into reviewable PRs the less CI it gets (#174). `push` below stays
+    # pinned to main, so this does not double-run on feature-branch pushes.
     paths:
       - "data/ingredients/**/*.yaml"
       - "references_cache/**"

--- a/.github/workflows/qc-roundtrip.yaml
+++ b/.github/workflows/qc-roundtrip.yaml
@@ -13,7 +13,10 @@ name: QC — collection/per-record round-trip
 
 on:
   pull_request:
-    branches: [main]
+    # NO branches filter. A PR whose base is not `main` — every stacked PR —
+    # would otherwise skip this gate entirely, so the more carefully work is
+    # split into reviewable PRs the less CI it gets (#174). `push` below stays
+    # pinned to main, so this does not double-run on feature-branch pushes.
     paths:
       - "data/curated/**"
       - "data/ingredients/**"

--- a/.github/workflows/qc-sssom.yaml
+++ b/.github/workflows/qc-sssom.yaml
@@ -2,7 +2,10 @@ name: QC — SSSOM invariant validation
 
 on:
   pull_request:
-    branches: [main]
+    # NO branches filter. A PR whose base is not `main` — every stacked PR —
+    # would otherwise skip this gate entirely, so the more carefully work is
+    # split into reviewable PRs the less CI it gets (#174). `push` below stays
+    # pinned to main, so this does not double-run on feature-branch pushes.
     paths:
       - "mappings/ingredient_mappings.sssom.tsv"
       - "mappings/needs_curator_review.tsv"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,6 +1,6 @@
 name: Tests (pytest)
 
-# Runs the pytest suite (310 tests, fully hermetic — OAK and HTTP are mocked, no
+# Runs the pytest suite (500+ tests, fully hermetic — OAK and HTTP are mocked, no
 # network or large ontology DBs needed) so the guard tests added across the role /
 # SSSOM / occurrence-stats work actually fail PRs on regression, instead of only
 # running locally. Complements the data/schema QC workflows (validate-strict,

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,7 +8,10 @@ name: Tests (pytest)
 
 on:
   pull_request:
-    branches: [main]
+    # NO branches filter. A PR whose base is not `main` — every stacked PR —
+    # would otherwise skip this gate entirely, so the more carefully work is
+    # split into reviewable PRs the less CI it gets (#174). `push` below stays
+    # pinned to main, so this does not double-run on feature-branch pushes.
   push:
     branches: [main]
   workflow_dispatch:

--- a/justfile
+++ b/justfile
@@ -181,15 +181,16 @@ report-label-drift:
 # LinkML cross-check (one validator process per record → too slow for CI).
 qc: validate-all validate-strict qc-evidence qc-sssom qc-roundtrip
 
-# Assert data/curated/ and data/ingredients/ still agree, so a per-record edit
-# cannot be silently reverted by the next `just export-individual` (which
-# projects the collection over the per-record tree). Aggregates into a temp dir
-# rather than data/collections/ -- comparing against that committed artifact is
-# what let this drift for months: it was last regenerated in March 2026, so the
-# check passed while 55 curation events sat unreconciled. (CI blocking.)
+# Assert data/curated/ and data/ingredients/ still describe the same records (CI blocking)
 qc-roundtrip:
     #!/usr/bin/env bash
     set -euo pipefail
+    # A per-record edit must not be silently reverted by the next
+    # `just export-individual`, which projects the collection OVER the per-record
+    # tree. Aggregates into a temp dir rather than data/collections/: comparing
+    # against that committed artifact is what let this drift for months -- it was
+    # last regenerated in March 2026, so the check kept passing while 55 curation
+    # events sat unreconciled (#148).
     tmp="$(mktemp -d)"
     trap 'rm -rf "$tmp"' EXIT
     # Aggregate diagnostics are NOT discarded: a per-record file it cannot load
@@ -200,35 +201,59 @@ qc-roundtrip:
         --ingredients-dir data/ingredients --output-dir "$tmp"
     uv run python scripts/verify_roundtrip.py \
         --original-dir data/curated --aggregated-dir "$tmp"
-    # Same byte-level assertion CI makes, so `just qc` green means CI green.
-    # Without this the recipe misses serialization drift (key order, quoting,
-    # line wrapping) that fails the workflow.
+    # The same byte-level assertion the qc-roundtrip workflow makes, so this
+    # recipe also catches serialization drift (key order, quoting, line
+    # wrapping) that verify_roundtrip cannot see.
+    #
+    # Exported into a COPY, for two reasons. (1) This is a check; it must not
+    # rewrite 2,257 working-tree files as a side effect, or a failure would
+    # already have clobbered the very per-record edits the error tells you to
+    # save. (2) CI can compare with `git status` because actions/checkout gives
+    # it a pristine tree; locally that measures divergence from HEAD, not
+    # "did export change anything" — so uncommitted per-record work would fail
+    # this check even right after `just sync-curated` made everything agree.
+    tree="$(mktemp -d)"
+    trap 'rm -rf "$tmp" "$tree"' EXIT
+    cp -R data/ingredients/. "$tree/"
     uv run python scripts/export_individual_records.py \
-        --input-dir data/curated --output-dir data/ingredients
-    if [ -n "$(git status --porcelain -- data/ingredients)" ]; then
-      echo "error: export-individual changed data/ingredients — the per-record tree" >&2
-      echo "is not a clean projection of data/curated/. Run 'just sync-curated' if the" >&2
-      echo "per-record files are the ones you meant to keep." >&2
-      git status --porcelain -- data/ingredients >&2
+        --input-dir data/curated --output-dir "$tree" >/dev/null
+    if ! diff -r -q data/ingredients "$tree"; then
+      echo "" >&2
+      echo "error: exporting data/curated does not reproduce data/ingredients." >&2
+      echo "The per-record tree is not a clean projection of the collection." >&2
+      echo "If the per-record files are the ones you meant to keep, run" >&2
+      echo "'just sync-curated' to write them back into data/curated/." >&2
+      echo "(Nothing was modified — the export above went to a scratch copy.)" >&2
       exit 1
     fi
 
-# Write the per-record tree BACK into data/curated/ — the missing half of the
-# round trip, and the remediation when `qc-roundtrip` goes red because a script
-# edited data/ingredients/ directly (apply-role-research-results does exactly
-# this). Note `aggregate-collections` is NOT this: it writes data/collections/,
-# which nothing reads, and `sync-individual` runs export FIRST, destroying the
-# per-record edits before aggregating.
-#
-# Expect a LARGE diff even when content is unchanged: the aggregator emits
-# records in filename order, which is not the collection's historical order.
-# Nothing depends on that order (the verifier sorts, the exporter iterates), but
-# review `git diff data/curated` semantically rather than by line count.
-# `discussions` is dropped on the way in -- see PER_RECORD_ONLY_FIELDS in
-# scripts/aggregate_records.py.
+# Write per-record edits BACK into data/curated/, then re-export to a fixed point
 sync-curated:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # The missing half of the round trip, and the remediation when qc-roundtrip
+    # goes red because a script edited data/ingredients/ directly
+    # (apply-role-research-results does exactly this -- issue #171).
+    #
+    # `aggregate-collections` is NOT this: it writes data/collections/, which
+    # nothing reads. `sync-individual` is not either: it runs export FIRST,
+    # destroying the per-record edits before aggregating.
+    #
+    # The re-export is not redundant. The collection does not carry
+    # `discussions`, so the exporter re-attaches it at the END of the record,
+    # swapping its position with any field edited after kgscan wrote it. Content
+    # is identical either way, but the gate compares bytes -- without the
+    # re-export a curator who edited one of the discussions-bearing records would
+    # run sync-curated, see qc-roundtrip still fail, and have nothing left to try.
+    #
+    # Expect a LARGE diff even when content is unchanged: the aggregator emits
+    # records in filename order, not the collection's historical order. Nothing
+    # depends on that order (the verifier sorts, the exporter iterates), so review
+    # `git diff data/curated` semantically rather than by line count.
     uv run python scripts/aggregate_records.py \
         --ingredients-dir data/ingredients --output-dir data/curated
+    uv run python scripts/export_individual_records.py \
+        --input-dir data/curated --output-dir data/ingredients
 
 # Render per-ingredient HTML detail pages from data/ingredients/*.yaml
 # into pages/ingredient/. Idempotent (skips fresh outputs); --force

--- a/notes/INDIVIDUAL_RECORDS.md
+++ b/notes/INDIVIDUAL_RECORDS.md
@@ -47,7 +47,9 @@ python scripts/export_individual_records.py --input-dir data/curated --output-di
 - Aggregates individual files back to collection format
 - Reverse operation of export script
 - Adds metadata: generation_date, total_count, mapped_count, unmapped_count
-- Optional validation during aggregation
+- Structural checks (non-mapping / empty document / missing `mapping_status`) are
+  ALWAYS fatal: a record it cannot load is dropped, so exiting 0 would lose it
+  silently (#172). `--validate` adds identifier / preferred_term checks on top.
 - Output: whatever `--output-dir` names. **The default, `data/collections/`, is a
   dead end** — nothing in the repo reads it (see issue #169). Writing there was
   the root cause of #148: per-record edits had no path back into `data/curated/`,
@@ -106,10 +108,17 @@ just qc-roundtrip
 
 **New commands:**
 ```makefile
-just export-individual          # Export collections to individual files
-just aggregate-collections      # Aggregate individual files to collections
+just export-individual          # Project data/curated/ ONTO the per-record tree
+just sync-curated               # Write the per-record tree BACK into data/curated/,
+                                #   then re-export so the tree is a fixed point.
+                                #   This is the one you want after editing
+                                #   data/ingredients/ directly.
+just qc-roundtrip               # Assert the two surfaces agree (blocking in CI)
 just validate-individual        # Validate individual files only
-just sync-individual            # Full workflow: export → validate → aggregate
+just aggregate-collections      # Writes data/collections/ — a dead end (#169)
+just sync-individual            # export → validate → aggregate-collections.
+                                #   NB exports FIRST, so it reverts per-record
+                                #   edits before aggregating; prefer sync-curated.
 ```
 
 **Updated commands:**

--- a/scripts/aggregate_records.py
+++ b/scripts/aggregate_records.py
@@ -6,8 +6,11 @@ combining individual ingredient YAML files back into collection format for
 reporting and backward compatibility.
 
 Usage:
-    python scripts/aggregate_records.py
-    python scripts/aggregate_records.py --ingredients-dir data/ingredients --output-dir data/collections
+    # Write the per-record tree back into the LIVE collection (`just sync-curated`).
+    python scripts/aggregate_records.py --ingredients-dir data/ingredients --output-dir data/curated
+
+    # NB the bare invocation defaults --output-dir to data/collections/, which
+    # nothing in the repo reads (issue #169).
     python scripts/aggregate_records.py --validate
 """
 


### PR DESCRIPTION
Closes #174. **Stacked on #173** (which is stacked on #167). Retarget down the stack as each merges.

## The problem

Four workflows filter their `pull_request` trigger to `branches: [main]`, so a PR whose **base** is anything else — every stacked PR — never runs them.

| workflow | `pull_request` branches | ran on #173? |
|---|---|---|
| `tests.yaml` | `[main]` | **no** |
| `qc-roundtrip.yaml` | `[main]` | **no** |
| `qc-evidence.yaml` | `[main]` | **no** |
| `qc-sssom.yaml` | `[main]` | **no** |
| `curation-history.yaml` | *(none)* | yes |
| `label-correspondence.yaml` | *(none)* | yes |
| `validate-strict.yaml` | *(none)* | yes |

The consequence is backwards: **the more carefully work is split into reviewable stacked PRs, the less CI it gets.**

#173 is the live example. It changes `scripts/aggregate_records.py` and adds `tests/test_aggregate_records.py`, but because its base is `fix/curated-perrecord-reconciliation`, neither the test suite nor the round-trip gate ran against it — including `qc-roundtrip`, *the very gate whose behaviour that PR modifies*. `gh pr checks 173` showed 4 green checks and looked healthy; the 3 that mattered most were never scheduled.

## The split was accidental, not a cost decision

If it were about cost, the expensive jobs would be the filtered ones. It's the reverse: `validate-strict` and `label-correspondence` — the latter needing `uv` plus a cached OAK ontology download — already run on every PR, while `tests.yaml` (plain pytest) was restricted to `main`.

## No double runs

Only the `pull_request` filters are removed. `push: branches: [main]` stays on all four: a PR fires `pull_request`, and a push to a non-main branch matches no `push` filter. Verified both filters' final state across all 8 workflows.

This is the `branches:` counterpart of the `paths:` problem #160/#166 addressed — a filter that silently narrows a guard until it stops guarding.

## Self-demonstrating

Stacked on #173 deliberately. This branch **contains #173's changes**, so this PR's CI run exercises them — which is the assurance #173 could not get for itself. If `pytest` and `roundtrip` appear green below, they ran against the aggregator fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)